### PR TITLE
fix(macro): recognize option references

### DIFF
--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -421,6 +421,9 @@ impl OptionalEnum {
                 .segments
                 .last()
                 .map_or(false, |segment| segment.ident == self.path),
+            syn::Type::Reference(syn::TypeReference { elem, .. }) => {
+                self.is_option_type(elem)
+            }
             _ => false,
         }
     }

--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -421,9 +421,7 @@ impl OptionalEnum {
                 .segments
                 .last()
                 .map_or(false, |segment| segment.ident == self.path),
-            syn::Type::Reference(syn::TypeReference { elem, .. }) => {
-                self.is_option_type(elem)
-            }
+            syn::Type::Reference(syn::TypeReference { elem, .. }) => self.is_option_type(elem),
             _ => false,
         }
     }

--- a/tests/issue217.rs
+++ b/tests/issue217.rs
@@ -9,7 +9,7 @@ enum Tx {
     Reset {
         #[rasn(tag(explicit(0)))]
         keys: Option<Vec<u32>>,
-    }
+    },
 }
 
 #[test]

--- a/tests/issue217.rs
+++ b/tests/issue217.rs
@@ -1,0 +1,20 @@
+use rasn::prelude::*;
+
+#[derive(Debug, Clone, AsnType, Encode, Decode)]
+#[rasn(choice)]
+enum Tx {
+    #[rasn(tag(explicit(0)))]
+    Test,
+    #[rasn(tag(explicit(1)))]
+    Reset {
+        #[rasn(tag(explicit(0)))]
+        keys: Option<Vec<u32>>,
+    }
+}
+
+#[test]
+fn issue_217() {
+    let tx = Tx::Reset { keys: None };
+    let encoded = rasn::der::encode(&tx).unwrap();
+    assert_eq!(encoded, vec![161, 2, 48, 0])
+}


### PR DESCRIPTION
Closes #217 

`OptionalEnum::is_option_type` did not properly process references to `Option`s. References to `Option` types are present in enum values with named fields. This PR fixes that behavior and adds a test for it.