### PR TITLE
fix(der): sort SET OF items

### DIFF
--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -7,11 +7,13 @@ use chrono::Timelike;
 
 use super::Identifier;
 use crate::{
-    bits::octet_string_ascending, types::{
+    bits::octet_string_ascending,
+    types::{
         self,
         oid::{MAX_OID_FIRST_OCTET, MAX_OID_SECOND_OCTET},
         Constraints, Enumerated, Tag,
-    }, Codec, Encode
+    },
+    Codec, Encode,
 };
 
 pub use crate::error::{BerEncodeErrorKind, EncodeError, EncodeErrorKind};
@@ -552,11 +554,14 @@ impl crate::Encoder for Encoder {
         values: &types::SetOf<E>,
         _constraints: Constraints,
     ) -> Result<Self::Ok, Self::Error> {
-        let mut encoded_values = values.iter().map(|val| {
-            let mut sequence_encoder = Self::new(self.config);
-            val.encode(&mut sequence_encoder).map(|_| sequence_encoder.output)
-        })
-        .collect::<Result<Vec<Vec<u8>>, _>>()?;
+        let mut encoded_values = values
+            .iter()
+            .map(|val| {
+                let mut sequence_encoder = Self::new(self.config);
+                val.encode(&mut sequence_encoder)
+                    .map(|_| sequence_encoder.output)
+            })
+            .collect::<Result<Vec<Vec<u8>>, _>>()?;
 
         // The encodings of the component values of a set-of value shall appear in ascending order,
         // the encodings being compared as octet strings [...]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,9 +1,42 @@
 //! Module for different bit modification functions which are used in the library.
 
+use core::cmp::Ordering;
+
 use alloc::vec::Vec;
 
 pub(crate) fn range_from_len(bit_length: u32) -> i128 {
     2i128.pow(bit_length) - 1
+}
+
+/// The canonical encoding of SET OF values in DER requires
+/// the encoded elements to be sorted in ascending order.
+/// When DER-encoding a SET OF, its elements are encoded one by one.
+/// The encoded elements are then compared as octet strings
+/// (shorter strings are zero-padded at their backs).
+/// The function is to be used as a compare function for `alloc::slice::sort_by`.
+/// 
+/// ***From ISO/IEC 8825-1:2021***
+/// 
+/// *11.6 Set of components*
+/// 
+/// *The encodings of the component values of a set-of value shall appear in ascending order,*
+/// *the encodings being compared as octet strings with the shorter components being padded*
+/// *at their trailing end with 0-octets.*
+pub(crate) fn octet_string_ascending(a: &Vec<u8>, b: &Vec<u8>) -> Ordering {
+    let min_length = b.len().min(a.len());
+    for i in 0..min_length {
+        match a[i].cmp(&b[i]) {
+            Ordering::Equal => continue,
+            o => return o,
+        }
+    }
+    if b.len() > a.len() {
+        return Ordering::Less
+    } else if a.len() > b.len() {
+        return Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
 }
 
 // Workaround for https://github.com/ferrilab/bitvec/issues/228

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -14,11 +14,11 @@ pub(crate) fn range_from_len(bit_length: u32) -> i128 {
 /// The encoded elements are then compared as octet strings
 /// (shorter strings are zero-padded at their backs).
 /// The function is to be used as a compare function for `alloc::slice::sort_by`.
-/// 
+///
 /// ***From ISO/IEC 8825-1:2021***
-/// 
+///
 /// *11.6 Set of components*
-/// 
+///
 /// *The encodings of the component values of a set-of value shall appear in ascending order,*
 /// *the encodings being compared as octet strings with the shorter components being padded*
 /// *at their trailing end with 0-octets.*
@@ -31,9 +31,9 @@ pub(crate) fn octet_string_ascending(a: &Vec<u8>, b: &Vec<u8>) -> Ordering {
         }
     }
     if b.len() > a.len() {
-        return Ordering::Less
+        return Ordering::Less;
     } else if a.len() > b.len() {
-        return Ordering::Greater
+        return Ordering::Greater;
     } else {
         Ordering::Equal
     }

--- a/tests/issue218.rs
+++ b/tests/issue218.rs
@@ -1,0 +1,12 @@
+#[test]
+fn issue_218() {
+    // https://github.com/librasn/rasn/issues/218
+    let mut set_of = rasn::types::SetOf::new();
+    set_of.insert(String::from("c"));
+    set_of.insert(String::from("ab"));
+    let encoding = rasn::der::encode(&set_of).unwrap();
+    //                                    c          a   b
+    //                                    |          |   |
+    //                                    v          v   v
+    assert_eq!(&encoding, &[49, 7, 12, 1, 99, 12, 2, 97, 98]);
+}


### PR DESCRIPTION
Closes #218

SET OF items need to be encoded in ascending order, comparing the encoded values as octet strings. This PR adds the corresponding sorting logic and a test to assure proper sorting.