### PR TITLE
fix(types): stack overflow in ObjectIdentifier PartialEq

### DIFF
--- a/src/types/oid.rs
+++ b/src/types/oid.rs
@@ -225,7 +225,7 @@ impl PartialEq<ObjectIdentifier> for &Oid {
 
 impl PartialEq<[u32]> for ObjectIdentifier {
     fn eq(&self, rhs: &[u32]) -> bool {
-        self == rhs
+        self.0 == rhs
     }
 }
 

--- a/tests/issue222.rs
+++ b/tests/issue222.rs
@@ -1,0 +1,11 @@
+use rasn::types::ObjectIdentifier;
+
+#[test]
+fn issue222() {
+    let arr: &[u32] = &[1, 2, 3];
+    let oid = ObjectIdentifier::new(arr).unwrap();
+    if &oid != arr {
+        assert!(false);
+    }
+    println!("done");
+}


### PR DESCRIPTION
The implementation of PartialEq<[u32]> for ObjectIdentifier did not compare the inner Cow<[u32]> but 'self' with the other [u32]. This triggered an infinite ping pong between Deref::deref and PartialEq::eq.

Closes #222 