### PR TITLE
Manually fix the incompatible versions (a result of v0.13.0 release) and some clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ num-traits = { version = "0.2.16", default-features = false }
 snafu = { version = "0.7.5", default-features = false, features = ["backtraces"] }
 bytes = { version = "1.4.0", default-features = false }
 bitvec.workspace = true
-rasn-derive = { version = "0.12", path = "macros", optional = true }
+rasn-derive = { version = "0.13", path = "macros", optional = true }
 chrono.workspace = true
 konst = { version = "0.3.5", default-features = false }
 nom-bitvec = { package = "bitvec-nom2", version = "0.2.0" }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,6 @@
 //! Generic ASN.1 decoding framework.
 
 use alloc::{boxed::Box, string::ToString, vec::Vec};
-use core::convert::TryInto;
 
 use crate::error::DecodeError;
 use crate::types::{self, AsnType, Constraints, Enumerated, Tag};

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -444,6 +444,8 @@ impl Decoder {
     }
 
     fn object_identifier_from_value(value: JsonValue) -> Result<ObjectIdentifier, DecodeError> {
+        // For performance reasons, sometimes it is better to use lazy one
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         Ok(value
             .as_str()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1026,7 +1026,7 @@ impl crate::Encoder for Encoder {
     ) -> Result<Self::Ok, Self::Error> {
         if let Some((_, true)) = self.field_bitfield.get(&tag) {
             value.encode(self)
-        } else if self.field_bitfield.get(&tag).is_none() {
+        } else if !self.field_bitfield.contains_key(&tag) {
             // There is no bitfield if none of the parent objects is struct/set
             // But we still need to handle nested choices explicitly
             value.encode(self)

--- a/standards/cap/Cargo.toml
+++ b/standards/cap/Cargo.toml
@@ -9,4 +9,4 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }

--- a/standards/cms/Cargo.toml
+++ b/standards/cms/Cargo.toml
@@ -7,9 +7,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies.rasn]
-version = "0.12.6"
+version = "0.13"
 path = "../.."
 
 [dependencies.rasn-pkix]
-version = "0.12.6"
+version = "0.13"
 path = "../pkix"

--- a/standards/cms/src/authenticode.rs
+++ b/standards/cms/src/authenticode.rs
@@ -28,6 +28,8 @@ pub const SPC_TIME_STAMP_REQUEST_OBJID: &Oid = Oid::ISO_IDENTIFIED_ORGANISATION_
 pub const SPC_RFC3161_OBJID: &Oid =
     Oid::ISO_IDENTIFIED_ORGANISATION_DOD_INTERNET_PRIVATE_ENTERPRISES_MICROSOFT_SPC_RFC3161_OBJID;
 
+#[allow(clippy::declare_interior_mutable_const)]
+// Mutable const warning comes from external crate `bytes` FIXME
 pub const SPC_CLASS_UUID: OctetString = OctetString::from_static(&[
     0xa6, 0xb5, 0x86, 0xd5, 0xb4, 0xa1, 0x24, 0x66, 0xae, 0x05, 0xa2, 0x17, 0xda, 0x8e, 0x60, 0xd6,
 ]);

--- a/standards/kerberos/Cargo.toml
+++ b/standards/kerberos/Cargo.toml
@@ -14,8 +14,8 @@ features = ["otp"]
 otp = ["rasn-pkix"]
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
-rasn-pkix = { path = "../pkix", version = "0.12.6", optional = true }
+rasn = { path = "../..", version = "0.13" }
+rasn-pkix = { path = "../pkix", version = "0.13", optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/standards/ldap/Cargo.toml
+++ b/standards/ldap/Cargo.toml
@@ -9,4 +9,4 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }

--- a/standards/mib/Cargo.toml
+++ b/standards/mib/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smi = { path = "../smi", package = "rasn-smi", version = "0.12.6" }
-rasn = { path = "../..", version = "0.12.6" }
+smi = { path = "../smi", package = "rasn-smi", version = "0.13" }
+rasn = { path = "../..", version = "0.13" }

--- a/standards/ocsp/Cargo.toml
+++ b/standards/ocsp/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
-rasn-pkix = { path = "../pkix", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }
+rasn-pkix = { path = "../pkix", version = "0.13" }

--- a/standards/pkix/Cargo.toml
+++ b/standards/pkix/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/standards/smi/Cargo.toml
+++ b/standards/smi/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }
 chrono.workspace = true

--- a/standards/smi/src/object_type.rs
+++ b/standards/smi/src/object_type.rs
@@ -1,5 +1,3 @@
-use core::convert::TryInto;
-
 /// A managed Management Information Base (MIB) object.
 pub trait ObjectType
 where

--- a/standards/smi/src/v1.rs
+++ b/standards/smi/src/v1.rs
@@ -1,7 +1,5 @@
 //! Version 1 (RFC 1155)
 
-use core::convert::TryInto;
-
 use rasn::{
     error::EncodeError,
     types::{Constraints, FixedOctetString, Integer, ObjectIdentifier, OctetString, Oid},

--- a/standards/smi/src/v2.rs
+++ b/standards/smi/src/v2.rs
@@ -1,12 +1,8 @@
 //! Version 2 (RFC 2578)
 
 use alloc::string::ToString;
-use core::convert::TryInto;
 
-use rasn::{
-    prelude::*,
-    types::{Integer, ObjectIdentifier, OctetString, Oid, Utf8String},
-};
+use rasn::prelude::*;
 
 use crate::v1::InvalidVariant;
 

--- a/standards/smime/Cargo.toml
+++ b/standards/smime/Cargo.toml
@@ -9,6 +9,6 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rasn = { path = "../..", version = "0.12.6" }
-rasn-cms = { path = "../cms", version = "0.12.6" }
-rasn-pkix = { path = "../pkix", version = "0.12.6" }
+rasn = { path = "../..", version = "0.13" }
+rasn-cms = { path = "../cms", version = "0.13" }
+rasn-pkix = { path = "../pkix", version = "0.13" }

--- a/standards/snmp/Cargo.toml
+++ b/standards/snmp/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smi = { path = "../smi", package = "rasn-smi", version = "0.12.6" }
-rasn = { path = "../..", version = "0.12.6" }
+smi = { path = "../smi", package = "rasn-smi", version = "0.13" }
+rasn = { path = "../..", version = "0.13" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/standards/snmp/src/v3.rs
+++ b/standards/snmp/src/v3.rs
@@ -12,10 +12,7 @@
 
 use alloc::boxed::Box;
 
-use rasn::{
-    prelude::*,
-    types::{Integer, OctetString},
-};
+use rasn::prelude::*;
 
 pub use crate::v2::{
     GetBulkRequest, GetNextRequest, GetRequest, InformRequest, Pdus, Response, SetRequest, Trap,


### PR DESCRIPTION
Updated the dependency versions.