### PR TITLE
fix(jer): ENUMERATED values as strings

### DIFF
--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -571,7 +571,7 @@ pub enum JerDecodeErrorKind {
     #[snafu(display("Failed to construct OID from value {value}",))]
     InvalidOIDString { value: JsonValue },
     #[snafu(display("Found invalid enumerated discriminant {discriminant}",))]
-    InvalidEnumDiscriminant { discriminant: isize },
+    InvalidEnumDiscriminant { discriminant: alloc::string::String },
 }
 
 impl JerDecodeErrorKind {

--- a/src/jer.rs
+++ b/src/jer.rs
@@ -231,11 +231,11 @@ mod tests {
 
     #[test]
     fn enumerated() {
-        round_trip_jer!(SimpleEnum, SimpleEnum::Test1, "5");
-        round_trip_jer!(SimpleEnum, SimpleEnum::Test2, "2");
-        round_trip_jer!(ExtEnum, ExtEnum::Test1, "5");
-        round_trip_jer!(ExtEnum, ExtEnum::Test2, "2");
-        round_trip_jer!(ExtEnum, ExtEnum::Test3, "-1");
+        round_trip_jer!(SimpleEnum, SimpleEnum::Test1, "\"Test1\"");
+        round_trip_jer!(SimpleEnum, SimpleEnum::Test2, "\"Test2\"");
+        round_trip_jer!(ExtEnum, ExtEnum::Test1, "\"Test1\"");
+        round_trip_jer!(ExtEnum, ExtEnum::Test2, "\"Test2\"");
+        round_trip_jer!(ExtEnum, ExtEnum::Test3, "\"Test3\"");
     }
 
     #[test]

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -414,10 +414,11 @@ impl Decoder {
                 needed: "enumerated item as string",
                 found: alloc::format!("{value}"),
             })?;
-        Ok(E::from_identifier(identifier)
-            .ok_or_else(|| JerDecodeErrorKind::InvalidEnumDiscriminant {
-                discriminant: alloc::format!("{identifier}"),
-            })?)
+        Ok(E::from_identifier(identifier).ok_or_else(|| {
+            JerDecodeErrorKind::InvalidEnumDiscriminant {
+                discriminant: alloc::string::String::from(identifier),
+            }
+        })?)
     }
 
     fn integer_from_value(value: JsonValue) -> Result<Integer, DecodeError> {

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -408,18 +408,15 @@ impl Decoder {
     }
 
     fn enumerated_from_value<E: Enumerated>(value: JsonValue) -> Result<E, DecodeError> {
-        let discriminant = value
-            .as_i64()
+        let identifier = value
+            .as_str()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
-                needed: "enumerable index",
+                needed: "enumerated item as string",
                 found: alloc::format!("{value}"),
-            })?
-            .try_into()
-            .ok();
-        Ok(discriminant
-            .and_then(|i| E::from_discriminant(i))
+            })?;
+        Ok(E::from_identifier(identifier)
             .ok_or_else(|| JerDecodeErrorKind::InvalidEnumDiscriminant {
-                discriminant: discriminant.unwrap_or(isize::MIN),
+                discriminant: alloc::format!("{identifier}"),
             })?)
     }
 

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -93,9 +93,9 @@ impl crate::Encoder for Encoder {
         _: crate::Tag,
         value: &E,
     ) -> Result<Self::Ok, Self::Error> {
-        self.update_root_or_constructed(JsonValue::String(
-            alloc::string::String::from(value.identifier())
-        ))
+        self.update_root_or_constructed(JsonValue::String(alloc::string::String::from(
+            value.identifier(),
+        )))
     }
 
     fn encode_object_identifier(

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -93,7 +93,9 @@ impl crate::Encoder for Encoder {
         _: crate::Tag,
         value: &E,
     ) -> Result<Self::Ok, Self::Error> {
-        self.update_root_or_constructed(JsonValue::Number(value.discriminant().into()))
+        self.update_root_or_constructed(JsonValue::String(
+            alloc::string::String::from(value.identifier())
+        ))
     }
 
     fn encode_object_identifier(

--- a/src/types.rs
+++ b/src/types.rs
@@ -201,6 +201,39 @@ pub trait Enumerated: Sized + 'static + PartialEq + Copy + core::fmt::Debug {
     fn from_extended_enumeration_index(index: usize) -> Option<Self> {
         Self::EXTENDED_VARIANTS.and_then(|array| array.get(index).copied())
     }
+
+    /// Returns the variant identifier
+    fn identifier(&self) -> &'static str {
+        let index = if self.is_extended_variant() {
+            Self::EXTENDED_VARIANTS
+                .unwrap()
+                .iter()
+                .position(|lhs| lhs == self)
+                .unwrap() + Self::VARIANTS.len()
+        } else {
+            Self::VARIANTS
+                .iter()
+                .position(|lhs| lhs == self)
+                .expect("Variant not defined in Enumerated::VARIANTS")
+        };
+        Self::IDENTIFIERS[index]
+    }
+
+    /// Returns a variant, if the provided identifier matches any variant.
+    fn from_identifier(identifier: &str) -> Option<Self> {
+        Self::IDENTIFIERS
+            .iter()
+            .enumerate()
+            .find(|id| id.1.eq(&identifier)).and_then(|(i, _)| {
+            if i < Self::VARIANTS.len() {
+                Self::VARIANTS.get(i).copied()
+            } else {
+                Self::EXTENDED_VARIANTS.and_then(|array| 
+                    array.get(i - Self::VARIANTS.len()).copied()
+                )
+            }
+        })
+    }
 }
 
 /// A integer which has encoded constraint range between `START` and `END`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -209,7 +209,8 @@ pub trait Enumerated: Sized + 'static + PartialEq + Copy + core::fmt::Debug {
                 .unwrap()
                 .iter()
                 .position(|lhs| lhs == self)
-                .unwrap() + Self::VARIANTS.len()
+                .unwrap()
+                + Self::VARIANTS.len()
         } else {
             Self::VARIANTS
                 .iter()
@@ -224,15 +225,15 @@ pub trait Enumerated: Sized + 'static + PartialEq + Copy + core::fmt::Debug {
         Self::IDENTIFIERS
             .iter()
             .enumerate()
-            .find(|id| id.1.eq(&identifier)).and_then(|(i, _)| {
-            if i < Self::VARIANTS.len() {
-                Self::VARIANTS.get(i).copied()
-            } else {
-                Self::EXTENDED_VARIANTS.and_then(|array| 
-                    array.get(i - Self::VARIANTS.len()).copied()
-                )
-            }
-        })
+            .find(|id| id.1.eq(&identifier))
+            .and_then(|(i, _)| {
+                if i < Self::VARIANTS.len() {
+                    Self::VARIANTS.get(i).copied()
+                } else {
+                    Self::EXTENDED_VARIANTS
+                        .and_then(|array| array.get(i - Self::VARIANTS.len()).copied())
+                }
+            })
     }
 }
 


### PR DESCRIPTION
Hey there!

The JER standard (X.697 22. 2021) mandates that JER-encoded ENUMERATED values must be JSON strings instead of integers.

First PR here, so let me know if it can be improved in any way, thanks!