### PR TITLE
Remove `backtraces` from `rasn`'s `default` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.27", default-features = false, features = ["alloc"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [features]
-default = ["macros", "backtraces"]
+default = ["macros"]
 macros = ["rasn-derive"]
 backtraces = []
 

--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -420,7 +420,9 @@ impl Config {
 #[derive(Clone, Debug)]
 pub struct OptionalEnum {
     pub path: syn::Ident,
+    #[allow(unused)]
     pub some_variant: syn::Type,
+    #[allow(unused)]
     pub none_variant: syn::Type,
 }
 


### PR DESCRIPTION
This feature can incur a significant performance penalty, and since it's more of a debugging tool, it should be disabled by default.

In my experiments, there was a ~15x perf improvement when decoding OCSP responses with this feature disabled.

Closes #246 