### PR TITLE
CI: Run Clippy for all targets

### DIFF
--- a/ci/clippy.bash
+++ b/ci/clippy.bash
@@ -5,8 +5,8 @@ set -e
 source ci/common.bash
 
 # $1 {path} = Path to cross/cargo executable
-CROSS=$1
+CROSS="$1"
 
-required_arg $CROSS 'CROSS'
+required_arg "$CROSS" 'CROSS'
 
-$CROSS clippy --all -- -D warnings
+"$CROSS" clippy --all-targets -- -D warnings

--- a/src/coer.rs
+++ b/src/coer.rs
@@ -707,8 +707,8 @@ mod tests {
     }
     #[test]
     fn test_utf8_string() {
-        round_trip!(coer, Utf8String, "".try_into().unwrap(), &[0x00]);
-        round_trip!(coer, Utf8String, "2".try_into().unwrap(), &[0x01, 0x32]);
+        round_trip!(coer, Utf8String, "".into(), &[0x00]);
+        round_trip!(coer, Utf8String, "2".into(), &[0x01, 0x32]);
         round_trip!(
             coer,
             Utf8String,
@@ -722,7 +722,7 @@ mod tests {
         round_trip!(
             coer,
             Utf8String,
-            "ÄÖÄÖÄÖÄÖ12e4Ä".try_into().unwrap(),
+            "ÄÖÄÖÄÖÄÖ12e4Ä".into(),
             &[
                 0x16, 0xc3, 0x84, 0xc3, 0x96, 0xc3, 0x84, 0xc3, 0x96, 0xc3, 0x84, 0xc3, 0x96, 0xc3,
                 0x84, 0xc3, 0x96, 0x31, 0x32, 0x65, 0x34, 0xc3, 0x84
@@ -732,7 +732,7 @@ mod tests {
             coer,
             Utf8String,
             Constraints::new(&[Constraint::Size(Size::new(Bounded::Single(3)).into())]),
-            "foo".try_into().unwrap(),
+            "foo".into(),
             &[0x66, 0x6f, 0x6f]
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,10 @@ mod tests {
             $(
                 #[test]
                 fn $integer() {
-                    let min = <$integer>::min_value();
-                    let max = <$integer>::max_value();
-                    let half_max = <$integer>::max_value() / 2;
-                    let half_min = <$integer>::min_value() / 2;
+                    let min = <$integer>::MIN;
+                    let max = <$integer>::MAX;
+                    let half_max = <$integer>::MAX / 2;
+                    let half_min = <$integer>::MIN / 2;
 
                     round_trip(&min);
                     round_trip(&half_min);

--- a/tests/issue222.rs
+++ b/tests/issue222.rs
@@ -5,7 +5,7 @@ fn issue222() {
     let arr: &[u32] = &[1, 2, 3];
     let oid = ObjectIdentifier::new(arr).unwrap();
     if &oid != arr {
-        assert!(false);
+        unreachable!();
     }
     println!("done");
 }


### PR DESCRIPTION
Maybe it is not bad thing if we run Clippy for all targets.
This also applies suggested fixes for tests.