### PR TITLE
perf: don't heap allocate a BigInt for every integer that is decoded

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -19,6 +19,16 @@ pub struct Bench {
     n: Utf8String,
     o: UtcTime,
     p: GeneralizedTime,
+    q: u8,
+    r: u16,
+    s: u32,
+    t: u64,
+    u: usize,
+    v: i8,
+    w: i16,
+    x: i32,
+    y: i64,
+    z: isize,
 }
 
 #[derive(AsnType, Decode, Encode)]
@@ -58,5 +68,15 @@ pub fn bench_default() -> Bench {
             .unwrap()
             .with_ymd_and_hms(2018, 6, 13, 11, 1, 58)
             .unwrap(),
+        q: u8::MAX / 2,
+        r: u16::MAX / 2,
+        s: u32::MAX / 2,
+        t: u64::MAX / 2,
+        u: usize::MAX / 2,
+        v: i8::MIN / 2,
+        w: i16::MIN / 2,
+        x: i32::MIN / 2,
+        y: i64::MIN / 2,
+        z: isize::MIN / 2,
     }
 }

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -143,7 +143,7 @@ pub struct DecodeError {
 impl core::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "Error Kind: {}", self.kind)?;
-        writeln!(f, "Codec: {}", self.kind)?;
+        writeln!(f, "Codec: {}", self.codec)?;
         #[cfg(feature = "backtraces")]
         write!(f, "\nBacktrace:\n{}", self.backtrace)?;
         Ok(())
@@ -297,6 +297,10 @@ impl DecodeError {
     #[must_use]
     pub fn unexpected_extra_data(length: usize, codec: Codec) -> Self {
         Self::from_kind(DecodeErrorKind::UnexpectedExtraData { length }, codec)
+    }
+    #[must_use]
+    pub fn unexpected_empty_input(codec: Codec) -> Self {
+        Self::from_kind(DecodeErrorKind::UnexpectedEmptyInput, codec)
     }
 
     pub fn assert_length(
@@ -758,6 +762,7 @@ impl crate::de::Error for DecodeError {
         Self::from_kind(DecodeErrorKind::UnknownField { index, tag }, codec)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,11 +154,11 @@ mod tests {
                         &match crate::$codec::decode::<T>(
                             &match crate::$codec::encode(value).map_err(|error| error.to_string()) {
                                 Ok(value) => value,
-                                Err(error) => panic!("{}", error),
+                                Err(error) => panic!("error encoding: {}", error),
                             }
                         ) {
                             Ok(value) => value,
-                            Err(error) => panic!("{}", error),
+                            Err(error) => panic!("error decoding: {}", error),
                         }
                     );
                 )+
@@ -251,14 +251,7 @@ mod tests {
                 tag: Tag,
                 constraints: Constraints,
             ) -> Result<Self, D::Error> {
-                use crate::de::Error;
-                use core::convert::TryFrom;
-
-                let integer = decoder.decode_integer(tag, constraints)?;
-
-                Ok(Self(
-                    <_>::try_from(integer).map_err(|e| D::Error::custom(e, decoder.codec()))?,
-                ))
+                Ok(Self(decoder.decode_integer::<i32>(tag, constraints)?))
             }
         }
 


### PR DESCRIPTION
there's some outstanding concerns around behavior, though all of the tests do pass. mainly, with the `wrapping_add` in the PER `parse_integer` method, and with the `as` casts in the integer type `IntegerType` trait impls as well, but it _seems_ to be working assuming the tests cover enough ground. current preliminary benchmarks seem promising (after modifying the `common.rs` file in `main` to include integer benchmarking), though maybe not quite as significant as I had hoped, but I can perform more performance analysis at some point in the future that specifically looks at the integer decoding alone.

my laptop info for this benchmark run:
```
OS: Arch Linux x86_64
Host: Laptop 13 (AMD Ryzen 7040Series) A7
Kernel: 6.9.3-arch1-1
CPU: AMD Ryzen 7 7840U w/ Radeon 780M Graphics (16) @ 5.1
Memory: 16050MiB / 27868MiB
```

before
```
ber/decode              time:   [1.5740 µs 1.5848 µs 1.5964 µs]
                        change: [-0.2673% +1.2938% +2.9768%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

der/decode              time:   [1.5334 µs 1.5440 µs 1.5550 µs]
                        change: [-2.8790% -0.8514% +0.6799%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

cer/decode              time:   [6.2658 µs 6.2982 µs 6.3305 µs]
                        change: [-0.4698% +0.6365% +2.0601%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

uper/decode             time:   [5.0579 µs 5.0919 µs 5.1279 µs]
                        change: [-2.4254% -0.8317% +0.6502%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

after
```
ber/decode              time:   [1.3727 µs 1.3816 µs 1.3915 µs]
                        change: [-15.479% -14.106% -12.900%] (p = 0.00 < 0.05)
                        Performance has improved.

der/decode              time:   [1.3505 µs 1.3587 µs 1.3676 µs]
                        change: [-12.842% -11.670% -10.479%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

cer/decode              time:   [5.6029 µs 5.6373 µs 5.6722 µs]
                        change: [-11.062% -9.8772% -8.7710%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

uper/decode             time:   [4.6751 µs 4.7029 µs 4.7329 µs]
                        change: [-8.7410% -7.6456% -6.5511%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```