### PR TITLE
perf(ber): don't allocate `2 + N` `BigInt`s when parsing OIDs

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -116,15 +116,15 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 /// ##### Shared Attributes
 /// These attributes are available on containers, variants, and fields.
 /// - *`tag([class], number)`* — override the default tag with the one
-/// specified with this attribute. E.g. `#[rasn(tag(context, 0))]`, you can also
-/// wrapp `[class], number` in `explicit` to mark it as a explicit tag
-/// (e.g.  `#[rasn(tag(explicit(0)))]`.)
+///   specified with this attribute. E.g. `#[rasn(tag(context, 0))]`, you can also
+///   wrapp `[class], number` in `explicit` to mark it as a explicit tag
+///   (e.g.  `#[rasn(tag(explicit(0)))]`.)
 ///
 /// ##### Container Attributes
 /// - `crate_root` The path to the `rasn` library to use in the macro.
 /// - `enumerated/choice` Use either `#[rasn(choice)]` or `#[rasn(enumerated)]`
 /// - `delegate` Only available for newtype wrappers (e.g. `struct Delegate(T)`);
-/// uses the inner `T` type for implementing the trait.
+///   uses the inner `T` type for implementing the trait.
 #[proc_macro_derive(AsnType, attributes(rasn))]
 pub fn asn_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Parse the input tokens into a syntax tree


### PR DESCRIPTION
the `BigInt`s that are used to parse OIDs are downcasted to `u32`s later on in the code anyway, so now that we have fixed-sized integer parsing that doesn't roundtrip through `BigInt`s, we can just attempt to deserialize them as `u32`s instead of allocating a bunch. this bought me a ~(-72%) benchmark win on parsing an SNMP packet since every varbind value has an associated OID, and got the parse time below `netsnmp`'s PDU decode for my microbenchmark :)