### PR TITLE
Hide `snafu` backtraces behind `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 [features]
 default = ["macros"]
 macros = ["rasn-derive"]
-backtraces = []
+std = []
+backtraces = ["std", "snafu/backtraces"]
 
 [[bench]]
 name = "criterion"
@@ -47,7 +48,7 @@ harness = false
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
-snafu = { version = "0.7.5", default-features = false, features = ["backtraces"] }
+snafu = { version = "0.7.5", default-features = false, features = [] }
 bytes = { version = "1.4.0", default-features = false }
 bitvec.workspace = true
 rasn-derive = { version = "0.15", path = "macros", optional = true }


### PR DESCRIPTION
One step toward `no_std` compatibility - see https://github.com/librasn/rasn/issues/262#issuecomment-2167887631.