### PR TITLE
Hide `jer` behind feature (implying `std`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 default = ["macros"]
 macros = ["rasn-derive"]
 backtraces = []
+std = []
+jer = ["std", "jzon"]
 
 [[bench]]
 name = "criterion"
@@ -58,7 +60,7 @@ arrayvec = { version = "0.7.4", default-features = false }
 either = { version = "1.9.0", default-features = false }
 once_cell = { version = "1.18.0", default-features = false, features = ["race", "alloc"] }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
-jzon = "0.12.5"
+jzon = { version = "0.12.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -16,6 +16,7 @@ pub enum Codec {
     /// X.691 — Packed Encoding Rules (Unaligned)
     Uper,
     /// [JSON Encoding Rules](https://obj-sys.com/docs/JSONEncodingRules.pdf)
+    #[cfg(feature = "jer")]
     Jer,
     /// X.696 — Octet Encoding Rules
     Oer,
@@ -31,6 +32,7 @@ impl core::fmt::Display for Codec {
             Self::Cer => write!(f, "CER"),
             Self::Der => write!(f, "DER"),
             Self::Uper => write!(f, "UPER"),
+            #[cfg(feature = "jer")]
             Self::Jer => write!(f, "JER"),
             Self::Oer => write!(f, "OER"),
             Self::Coer => write!(f, "COER"),
@@ -54,6 +56,7 @@ impl Codec {
             Self::Cer => crate::cer::encode(value),
             Self::Der => crate::der::encode(value),
             Self::Uper => crate::uper::encode(value),
+            #[cfg(feature = "jer")]
             Self::Jer => crate::jer::encode(value).map(alloc::string::String::into_bytes),
             Self::Oer => crate::oer::encode(value),
             Self::Coer => crate::coer::encode(value),
@@ -77,6 +80,7 @@ impl Codec {
             Self::Uper => crate::uper::decode(input),
             Self::Oer => crate::oer::decode(input),
             Self::Coer => crate::coer::decode(input),
+            #[cfg(feature = "jer")]
             Self::Jer => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
                 |e| {
                     Err(crate::error::DecodeError::from_kind(
@@ -97,6 +101,7 @@ impl Codec {
     /// # Errors
     /// - If the value fails to be encoded, or if trying to encode using
     ///   binary-based encoding rules, returns `EncodeError` struct.
+    #[cfg(feature = "jer")]
     pub fn encode_to_string<T: Encode>(
         self,
         value: &T,
@@ -118,6 +123,7 @@ impl Codec {
     /// # Errors
     /// - If `D` cannot be decoded from `input`, or if trying to decode using
     ///   binary-based encoding rules, returns `DecodeError` struct.
+    #[cfg(feature = "jer")]
     pub fn decode_from_str<D: Decode>(&self, input: &str) -> Result<D, crate::error::DecodeError> {
         match self {
             Self::Jer => crate::jer::decode(input),

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -1,8 +1,10 @@
+#[cfg(feature = "jer")]
 use core::num::ParseIntError;
 
 use super::strings::PermittedAlphabetError;
 use alloc::{boxed::Box, string::ToString};
 
+#[cfg(feature = "jer")]
 use jzon::JsonValue;
 use snafu::Snafu;
 #[cfg(feature = "backtraces")]
@@ -21,6 +23,7 @@ pub enum CodecDecodeError {
     Der(DerDecodeErrorKind),
     Uper(UperDecodeErrorKind),
     Aper(AperDecodeErrorKind),
+    #[cfg(feature = "jer")]
     Jer(JerDecodeErrorKind),
     Oer(OerDecodeErrorKind),
     Coer(CoerDecodeErrorKind),
@@ -42,6 +45,7 @@ impl_from!(Cer, CerDecodeErrorKind);
 impl_from!(Der, DerDecodeErrorKind);
 impl_from!(Uper, UperDecodeErrorKind);
 impl_from!(Aper, AperDecodeErrorKind);
+#[cfg(feature = "jer")]
 impl_from!(Jer, JerDecodeErrorKind);
 impl_from!(Oer, OerDecodeErrorKind);
 impl_from!(Coer, CoerDecodeErrorKind);
@@ -345,6 +349,7 @@ impl DecodeError {
             CodecDecodeError::Der(_) => crate::Codec::Der,
             CodecDecodeError::Uper(_) => crate::Codec::Uper,
             CodecDecodeError::Aper(_) => crate::Codec::Aper,
+            #[cfg(feature = "jer")]
             CodecDecodeError::Jer(_) => crate::Codec::Jer,
             CodecDecodeError::Oer(_) => crate::Codec::Oer,
             CodecDecodeError::Coer(_) => crate::Codec::Coer,
@@ -630,16 +635,20 @@ pub enum JerDecodeErrorKind {
         needed: &'static str,
         found: alloc::string::String,
     },
+    #[cfg(feature = "jer")]
     #[snafu(display("Found invalid byte in bit string. {parse_int_err}"))]
     InvalidJerBitstring { parse_int_err: ParseIntError },
+    #[cfg(feature = "jer")]
     #[snafu(display("Found invalid character in octet string."))]
     InvalidJerOctetString {},
+    #[cfg(feature = "jer")]
     #[snafu(display("Failed to construct OID from value {value}",))]
     InvalidOIDString { value: JsonValue },
     #[snafu(display("Found invalid enumerated discriminant {discriminant}",))]
     InvalidEnumDiscriminant { discriminant: alloc::string::String },
 }
 
+#[cfg(feature = "jer")]
 impl JerDecodeErrorKind {
     pub fn eoi() -> CodecDecodeError {
         CodecDecodeError::Jer(JerDecodeErrorKind::EndOfInput {})

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -15,6 +15,7 @@ pub enum CodecEncodeError {
     Der(DerEncodeErrorKind),
     Uper(UperEncodeErrorKind),
     Aper(AperEncodeErrorKind),
+    #[cfg(feature = "jer")]
     Jer(JerEncodeErrorKind),
     Coer(CoerEncodeErrorKind),
 }
@@ -34,6 +35,7 @@ impl_from!(Cer, CerEncodeErrorKind);
 impl_from!(Der, DerEncodeErrorKind);
 impl_from!(Uper, UperEncodeErrorKind);
 impl_from!(Aper, AperEncodeErrorKind);
+#[cfg(feature = "jer")]
 impl_from!(Jer, JerEncodeErrorKind);
 impl_from!(Coer, CoerEncodeErrorKind);
 
@@ -206,6 +208,7 @@ impl EncodeError {
             CodecEncodeError::Der(_) => crate::Codec::Der,
             CodecEncodeError::Uper(_) => crate::Codec::Uper,
             CodecEncodeError::Aper(_) => crate::Codec::Aper,
+            #[cfg(feature = "jer")]
             CodecEncodeError::Jer(_) => crate::Codec::Jer,
             CodecEncodeError::Coer(_) => crate::Codec::Coer,
         };
@@ -300,6 +303,7 @@ pub enum CerEncodeErrorKind {}
 pub enum DerEncodeErrorKind {}
 
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for UPER.
+#[cfg(feature = "jer")]
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -21,6 +21,6 @@ pub use decode::{
     JerDecodeErrorKind, OerDecodeErrorKind,
 };
 pub use encode::EncodeErrorKind;
-pub use encode::{
-    BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError, JerEncodeErrorKind,
-};
+#[cfg(feature = "jer")]
+pub use encode::JerEncodeErrorKind;
+pub use encode::{BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ pub mod cer;
 pub mod coer;
 pub mod der;
 pub mod error;
+#[cfg(feature = "jer")]
 pub mod jer;
 mod num;
 pub mod oer;


### PR DESCRIPTION
Quick attempt to hide JER implementation that is based on `jzon`, which requires `std` - see https://github.com/librasn/rasn/issues/262.