### PR TITLE
COER: Fix invalid handling of zero padding on length of length

### DIFF
--- a/src/oer.rs
+++ b/src/oer.rs
@@ -83,6 +83,11 @@ mod tests {
         // Long form when not needed
         decode_error!(coer, Integer, &[0b1000_0001, 0x01, 0x01]);
         decode_ok!(oer, Integer, &[0b1000_0001, 0x01, 0x01], 1.into());
+        decode_error!(
+            coer,
+            OctetString,
+            &[0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x41, 0x41]
+        );
     }
     #[test]
     fn test_enumerated() {

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -193,7 +193,7 @@ impl<'input> Decoder<'input> {
                             self.codec(),
                         ));
                     }
-                    if self.options.encoding_rules.is_coer() && input.leading_zeros() > 8 {
+                    if self.options.encoding_rules.is_coer() && data.leading_zeros() > 8 {
                         return Err(CoerDecodeErrorKind::NotValidCanonicalEncoding {
                             msg: "Length value should not have leading zeroes in COER".to_string(),
                         }


### PR DESCRIPTION
Validation was previously done based on the wrong variable. 