### PR TITLE
OER: decode error when unused preamble bits are not zero

### DIFF
--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -695,6 +695,8 @@ pub enum OerDecodeErrorKind {
         /// The amount of invalid bits.
         msg: alloc::string::String,
     },
+    #[snafu(display("Invalid preamble: {msg}"))]
+    InvalidPreamble { msg: alloc::string::String },
 }
 
 impl OerDecodeErrorKind {
@@ -718,6 +720,10 @@ impl OerDecodeErrorKind {
     #[must_use]
     pub fn invalid_bit_string(msg: alloc::string::String) -> DecodeError {
         CodecDecodeError::Oer(Self::InvalidOerBitString { msg }).into()
+    }
+    #[must_use]
+    pub fn invalid_preamble(msg: alloc::string::String) -> DecodeError {
+        CodecDecodeError::Oer(Self::InvalidPreamble { msg }).into()
     }
 }
 

--- a/src/oer.rs
+++ b/src/oer.rs
@@ -120,4 +120,28 @@ mod tests {
         decode_error!(coer, Test, &[0b1000_0001, 0x01]);
         decode_ok!(oer, Test, &[0b1000_0001, 0x01], Test::A);
     }
+    #[test]
+    fn test_seq_preamble_unused_bits() {
+        use crate as rasn;
+        #[derive(AsnType, Decode, Encode, Clone, Debug, PartialEq, Eq)]
+        #[rasn(automatic_tags)]
+        pub struct SequenceOptionals {
+            pub it: Integer,
+            pub is: Option<OctetString>,
+            pub late: Option<Integer>,
+        }
+        let data = [0x10, 0x01, 0x2A];
+        decode_error!(coer, SequenceOptionals, &data);
+        let data = [0x0, 0x01, 0x2A];
+        round_trip!(
+            oer,
+            SequenceOptionals,
+            SequenceOptionals {
+                it: 42.into(),
+                is: None,
+                late: None
+            },
+            &data
+        );
+    }
 }


### PR DESCRIPTION
Adds an error if unused bits on preamble are not zero.