### PR TITLE
Pass constraints correctly when encoding optional type

### DIFF
--- a/src/coer.rs
+++ b/src/coer.rs
@@ -1196,4 +1196,30 @@ mod tests {
             &[0x00]
         );
     }
+    #[test]
+    fn test_constrained_option() {
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[rasn(delegate, size("3"))]
+        pub struct HashedId3(pub OctetString);
+
+        #[derive(AsnType, Debug, Decode, Encode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[rasn(automatic_tags)]
+        pub struct ConstrainedOptions {
+            pub a: Option<HashedId3>,
+        }
+        round_trip!(
+            coer,
+            ConstrainedOptions,
+            ConstrainedOptions { a: None },
+            &[0x00]
+        );
+        round_trip!(
+            coer,
+            ConstrainedOptions,
+            ConstrainedOptions {
+                a: Some(HashedId3(OctetString::from_static(&[0x01, 0x02, 0x03])))
+            },
+            &[0x80, 0x01, 0x02, 0x03]
+        );
+    }
 }

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -249,7 +249,7 @@ pub trait Encoder {
         tag: Tag,
         value: &E,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_some_with_tag_and_constraints(tag, <_>::default(), value)
+        self.encode_some_with_tag_and_constraints(tag, E::CONSTRAINTS, value)
     }
 
     /// Encode the present value of an optional field.


### PR DESCRIPTION
Constraints where not correctly passed in general when encoding optional type. 

