### PR TITLE
OER: correctly encode null in option in extensions

### DIFF
--- a/src/coer.rs
+++ b/src/coer.rs
@@ -1222,4 +1222,24 @@ mod tests {
             &[0x80, 0x01, 0x02, 0x03]
         );
     }
+    #[test]
+    fn test_null_in_option() {
+        #[derive(AsnType, Debug, Encode, Decode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[rasn(automatic_tags)]
+        #[non_exhaustive]
+        pub struct Omitted {
+            pub a: Option<OctetString>,
+            #[rasn(extension_addition)]
+            pub omitted: Option<()>,
+        }
+        round_trip!(
+            coer,
+            Omitted,
+            Omitted {
+                a: Some(OctetString::from_static(&[0x00, 0x01, 0x02])),
+                omitted: Some(())
+            },
+            &[192, 3, 0, 1, 2, 2, 7, 128, 0]
+        );
+    }
 }


### PR DESCRIPTION
A bit corner case, but fixes encoding of null value in optional extended type. 

I hope that I understood the use of `()` correctly.

The test should represent

```asn
Omitted ::= SEQUENCE { 
  a OctetString OPTIONAL,
  ...,
  omitted     NULL OPTIONAL
}
```