### PR TITLE
Fix error name regression introduced in a75b26b

### DIFF
--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -973,7 +973,8 @@ impl<'a> FieldConfig<'a> {
         let tag = self.tag(context);
         let constraints = self.constraints.const_expr(crate_root);
         let handle_extension = if self.is_not_option_or_default_type() {
-            quote!(.ok_or_else(|| #crate_root::de::Error::field_error(#ident, crate::error::DecodeError::extension_present_but_not_required(#tag, decoder.codec()), decoder.codec()))?)
+            quote!(.ok_or_else(|| {
+                #crate_root::de::Error::field_error(#ident, #crate_root::error::DecodeError::required_extension_not_present(#tag, decoder.codec()), decoder.codec())})?)
         } else if self.is_default_type() {
             quote!(.unwrap_or_else(#default_fn))
         } else {

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -109,7 +109,7 @@ impl From<CodecDecodeError> for DecodeError {
 ///                             Needed::Size(n) => {
 ///                                 let missing_bytes = n.get() / 7;
 ///                                 missing_bytes
-///                                
+///
 ///                             }
 ///                             _ => {
 ///                                 #[cfg(feature = "backtraces")]
@@ -255,13 +255,7 @@ impl DecodeError {
     pub fn required_extension_not_present(tag: Tag, codec: Codec) -> Self {
         Self::from_kind(DecodeErrorKind::RequiredExtensionNotPresent { tag }, codec)
     }
-    #[must_use]
-    pub fn extension_present_but_not_required(tag: crate::types::Tag, codec: Codec) -> Self {
-        Self::from_kind(
-            DecodeErrorKind::ExtensionPresentButNotRequired { tag },
-            codec,
-        )
-    }
+
     #[must_use]
     pub fn enumeration_index_not_found(index: usize, extended_list: bool, codec: Codec) -> Self {
         Self::from_kind(
@@ -511,8 +505,8 @@ pub enum DecodeErrorKind {
     },
     #[snafu(display("Extension with class `{}` and tag `{}` required, but not present", tag.class, tag.value))]
     RequiredExtensionNotPresent { tag: crate::types::Tag },
-    #[snafu(display("Extension {} present but but not required", tag.class))]
-    ExtensionPresentButNotRequired { tag: crate::types::Tag },
+    #[snafu(display("Extension {} required but not present", tag.class))]
+    ExtensionRequiredButNotPresent { tag: crate::types::Tag },
     #[snafu(display("Error in Parser: {}", msg))]
     Parser {
         /// The error's message.


### PR DESCRIPTION
This is fix for a regression introduced in a75b26b, where `extension required but not present` was changed to `extension_present_but_not_required`, which is not the same meaning.

This fix proposes `required_extension_not_present` name to switch back and enforce the error meaning.

