### PR TITLE
Encoder: call correct method for Default and Optional types when value is None

### DIFF
--- a/src/enc.rs
+++ b/src/enc.rs
@@ -236,7 +236,7 @@ pub trait Encoder {
         if value != &E::default() {
             self.encode_some_with_tag(tag, value)
         } else {
-            self.encode_none::<E>()
+            self.encode_none_with_tag(tag)
         }
     }
 
@@ -405,7 +405,7 @@ impl<E: Encode> Encode for Option<E> {
     fn encode_with_tag<EN: Encoder>(&self, encoder: &mut EN, tag: Tag) -> Result<(), EN::Error> {
         match self {
             Some(value) => encoder.encode_some_with_tag(tag, value),
-            None => encoder.encode_none::<E>(),
+            None => encoder.encode_none_with_tag(tag),
         }
         .map(drop)
     }
@@ -419,7 +419,7 @@ impl<E: Encode> Encode for Option<E> {
             Some(value) => {
                 encoder.encode_some_with_tag_and_constraints(Self::TAG, constraints, value)
             }
-            None => encoder.encode_none::<E>(),
+            None => encoder.encode_none_with_tag(Self::TAG),
         }
         .map(drop)
     }
@@ -433,7 +433,7 @@ impl<E: Encode> Encode for Option<E> {
         match self {
             Some(value) => encoder.encode_some_with_tag_and_constraints(tag, constraints, value),
 
-            None => encoder.encode_none::<E>(),
+            None => encoder.encode_none_with_tag(tag),
         }
         .map(drop)
     }


### PR DESCRIPTION
The algorithm introduced in 413a39a relies on the value's tag and an index incremented each time a value is processed. 
In sequences with mixed required and optional values, optional values were not set present in the preamble, causing decoding issues, because of calling `encode_none()` instead of `encode_none_with_tag()` in relevant cases.
This pull request fix this, by calling the correct encoding method for Default/Optional types when the value is None. 