### PR TITLE
Remove `to_vec` and `to_left_padded_vec` as unnecessary and reduce allocations

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -35,46 +35,6 @@ pub(crate) fn octet_string_ascending(a: &Vec<u8>, b: &Vec<u8>) -> Ordering {
     a.len().cmp(&b.len())
 }
 
-// Workaround for https://github.com/ferrilab/bitvec/issues/228
-pub(crate) fn to_vec(slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>) -> Vec<u8> {
-    use bitvec::prelude::*;
-    let mut vec = Vec::new();
-
-    for slice in slice.chunks(8) {
-        if slice.len() != 8 {
-            // pad unaligned BitSlices
-            let mut owned = slice.to_bitvec();
-            for _ in 0..(8 - slice.len()) {
-                owned.push(false);
-            }
-            vec.push(owned.load_be());
-        } else {
-            vec.push(slice.load_be());
-        }
-    }
-
-    vec
-}
-
-pub(crate) fn to_left_padded_vec(
-    slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>,
-) -> Vec<u8> {
-    use bitvec::prelude::*;
-
-    let mut vec = Vec::new();
-
-    let missing_bits = 8 - slice.len() % 8;
-    if missing_bits == 8 {
-        to_vec(slice)
-    } else {
-        let mut padding = bitvec::bitvec![u8, bitvec::prelude::Msb0; 0; missing_bits];
-        padding.append(&mut slice.to_bitvec());
-        for s in padding.chunks(8) {
-            vec.push(s.load_be());
-        }
-        vec
-    }
-}
 pub fn integer_to_bytes(value: &crate::prelude::Integer, signed: bool) -> Option<Vec<u8>> {
     if signed {
         Some(value.to_signed_bytes_be())

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -3,7 +3,6 @@
 use jzon::{object::Object, JsonValue};
 
 use crate::{
-    bits::to_vec,
     enc::Error,
     error::{EncodeError, JerEncodeErrorKind},
     types::{fields::Fields, variants},
@@ -81,7 +80,10 @@ impl crate::Encoder for Encoder {
         constraints: crate::types::Constraints,
         value: &crate::types::BitStr,
     ) -> Result<Self::Ok, Self::Error> {
-        let bytes = to_vec(value)
+        let mut bitvec = value.to_bitvec();
+        bitvec.force_align();
+        let bytes = bitvec
+            .into_vec()
             .iter()
             .fold(alloc::string::String::new(), |mut acc, bit| {
                 acc.push_str(&alloc::format!("{bit:02X?}"));

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -75,7 +75,7 @@ impl Default for Encoder {
         Self::new(EncoderOptions::coer())
     }
 }
-/// COER encoder. A subset of OER to provide canonical and unique encoding.  
+/// COER encoder. A subset of OER to provide canonical and unique encoding.
 #[derive(Debug)]
 pub struct Encoder {
     options: EncoderOptions,
@@ -510,7 +510,7 @@ impl Encoder {
             preamble.extend(BitString::repeat(false, 8 - preamble.len() % 8));
         }
         debug_assert!(preamble.len() % 8 == 0);
-        buffer.extend(crate::bits::to_vec(&preamble));
+        buffer.extend(preamble.as_raw_slice());
         // Section 16.3 ### Encodings of the components in the extension root ###
         // Must copy before move...
         let extension_fields = core::mem::take(&mut encoder.extension_fields);
@@ -541,7 +541,7 @@ impl Encoder {
         }
         extension_bitmap_buffer.extend(BitString::repeat(false, missing_bits as usize));
         debug_assert!(extension_bitmap_buffer.len() % 8 == 0);
-        buffer.extend(crate::bits::to_vec(&extension_bitmap_buffer));
+        buffer.extend(extension_bitmap_buffer.as_raw_slice());
         // Section 16.5 # Encodings of the components in the extension addition group, as open type
         for field in extension_fields.iter().filter_map(Option::as_ref) {
             self.encode_length(&mut buffer, field.len())?;
@@ -606,7 +606,7 @@ impl crate::Encoder for Encoder {
                     } else {
                         bit_string_encoding.extend(value);
                     }
-                    buffer.extend(crate::bits::to_vec(&bit_string_encoding));
+                    buffer.extend(bit_string_encoding.as_raw_slice());
                 } else {
                     return Err(EncodeError::size_constraint_not_satisfied(
                         value.len(),
@@ -642,7 +642,7 @@ impl crate::Encoder for Encoder {
             bit_string_encoding.extend(value);
             bit_string_encoding.extend(trailing);
             self.encode_length(&mut buffer, bit_string_encoding.len() / 8)?;
-            buffer.extend(crate::bits::to_vec(&bit_string_encoding));
+            buffer.extend(bit_string_encoding.as_raw_slice());
         }
         self.extend(tag, buffer)?;
         Ok(())

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -120,7 +120,7 @@ impl Encoder {
     pub fn output(self) -> Vec<u8> {
         let mut output = self.bitstring_output();
         Self::force_pad_to_alignment(&mut output);
-        crate::bits::to_vec(&output)
+        output.as_raw_slice().to_vec()
     }
 
     pub fn bitstring_output(self) -> BitString {

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -162,8 +162,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             padding.extend_from_bitslice(ch);
             index_string.extend(padding);
         }
-
-        crate::bits::to_vec(&index_string)
+        index_string.as_raw_slice().to_vec()
     }
 
     fn octet_aligned_char_width(&self) -> usize {
@@ -192,7 +191,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             octet_string
                 .extend_from_bitslice(&ch.view_bits::<Msb0>()[(u32::BITS as usize - width)..]);
         }
-        crate::bits::to_vec(&octet_string)
+        octet_string.as_raw_slice().to_vec()
     }
 
     fn character_width() -> u32 {


### PR DESCRIPTION
I wanted to understand what is wrong with `bitslice.to_bitvec().into_vec()` call combination, because our custom functions add some overhead.

It might actually work as intended, see my comment [here.](https://github.com/ferrilab/bitvec/issues/228#issuecomment-2305929792)

For example, the original problem
```rust
assert_eq!(bitvec::bits![u8, Msb0; 1, 1, 0, 0, 0, 1, 1, 1, 0, 1][2..].to_bitvec().into_vec(), vec![29]);
```

This results to correct `BitVec` but the internal memory layout is not unified as result of slicing. Slicing here combines a set of references internally to construct the intended BitSlice (e.g. two first bits are omitted from the first byte). When we use `to_bitvec()`, this  internal layout is carried on, and internal byte alignment is the same, and `into_vec` result might be unexpected.  

To get the expected, unified memory layout, we need to call `.force_align()` to unify it after `to_bitvec()` call.

Then `.into_vec` will result into "expected" byte array, as `.into_vec` is based on memory presentation.

This seems to be noted on documentation, so maybe it is expected behavior. 

If we use the above correctly, we can drop all custom functions and extra allocations.   