### PR TITLE
Add two custom profiles for benching lto and debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,16 @@ std = []
 backtraces = ["std", "snafu/backtraces"]
 jer = ["std", "jzon"]
 
+[profile.bench-lto]
+inherits = "bench"
+opt-level = 3
+codegen-units = 1
+lto = "fat"
+
+[profile.bench-debug]
+inherits = "dev"
+opt-level = 1
+
 [[bench]]
 name = "criterion"
 path = "benches/criterion.rs"


### PR DESCRIPTION
With some basic release build optimizations, we can get around 10-20% performance increase.
Maybe it is okay by default?

E.g. that integer bench:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/8a77fd93-4da0-487b-8931-09d6ccfc7914">


