### PR TITLE
Constraint utilities, constraint const default, more const functions

### DIFF
--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -859,7 +859,7 @@ impl<'a> FieldConfig<'a> {
                 let constraints = self
                     .constraints
                     .const_expr(&self.container_config.crate_root)
-                    .unwrap_or_else(|| quote!(<_>::default()));
+                    .unwrap_or_else(|| quote!(#crate_root::types::Constraints::default()));
                 quote!(
                     encoder.encode_extension_addition(
                         #tag,
@@ -873,7 +873,7 @@ impl<'a> FieldConfig<'a> {
                 let constraints = self
                     .constraints
                     .const_expr(&self.container_config.crate_root)
-                    .unwrap_or_else(|| quote!(<_>::default()));
+                    .unwrap_or_else(|| quote!(#crate_root::types::Constraints::default()));
                 match (self.constraints.has_constraints(), self.default.is_some()) {
                     (true, true) => {
                         quote!(
@@ -905,7 +905,7 @@ impl<'a> FieldConfig<'a> {
             let constraints = self
                 .constraints
                 .const_expr(&self.container_config.crate_root)
-                .unwrap_or_else(|| quote!(<_>::default()));
+                .unwrap_or_else(|| quote!(#crate_root::types::Constraints::default()));
             quote!(
                 encoder.encode_extension_addition(
                     #tag,

--- a/src/aper.rs
+++ b/src/aper.rs
@@ -38,6 +38,7 @@ pub fn encode_with_constraints<T: crate::Encode>(
 #[cfg(test)]
 mod tests {
     use crate::{
+        macros::*,
         prelude::*,
         types::{constraints::*, *},
     };
@@ -384,52 +385,50 @@ mod tests {
         // round_trip!(aper, F, F { a: true, b: "123".try_into().unwrap() }, &[0x80, 0x31, 0x32, 0x33]);
         // round_trip!(aper, G, G { a: true, b: "1".try_into().unwrap() }, &[0xcc, 0x40]);
         // round_trip!(aper, H, H { a: true, b: "1".try_into().unwrap() }, &[0xa0, 0x31]);
-        round_trip_with_constraints!(
-            aper,
-            VisibleString,
-            Constraints::new(&[
-                Constraint::PermittedAlphabet(
-                    PermittedAlphabet::new(&[
-                        b'a' as u32,
-                        b'b' as u32,
-                        b'c' as u32,
-                        b'd' as u32,
-                        b'e' as u32,
-                        b'f' as u32,
-                        b'g' as u32,
-                        b'h' as u32,
-                        b'i' as u32,
-                        b'j' as u32,
-                        b'k' as u32,
-                        b'l' as u32,
-                        b'm' as u32,
-                        b'n' as u32,
-                        b'o' as u32,
-                        b'p' as u32,
-                        b'q' as u32,
-                        b'r' as u32,
-                        b's' as u32,
-                        b't' as u32,
-                        b'u' as u32,
-                        b'v' as u32,
-                        b'w' as u32,
-                        b'x' as u32,
-                        b'y' as u32,
-                        b'z' as u32,
-                    ])
-                    .into()
-                ),
-                Constraint::Size(Size::new(Bounded::new(1, 255)).into())
+        const PERMITTED_CONSTRAINT: Constraints = constraints!(
+            permitted_alphabet_constraint!(&[
+                b'a' as u32,
+                b'b' as u32,
+                b'c' as u32,
+                b'd' as u32,
+                b'e' as u32,
+                b'f' as u32,
+                b'g' as u32,
+                b'h' as u32,
+                b'i' as u32,
+                b'j' as u32,
+                b'k' as u32,
+                b'l' as u32,
+                b'm' as u32,
+                b'n' as u32,
+                b'o' as u32,
+                b'p' as u32,
+                b'q' as u32,
+                b'r' as u32,
+                b's' as u32,
+                b't' as u32,
+                b'u' as u32,
+                b'v' as u32,
+                b'w' as u32,
+                b'x' as u32,
+                b'y' as u32,
+                b'z' as u32,
             ]),
-            VisibleString::try_from("hej").unwrap(),
-            &[0x02, 0x68, 0x65, 0x6a]
+            size_constraint!(1, 255)
         );
         round_trip_with_constraints!(
             aper,
             VisibleString,
-            Constraints::new(&[Constraint::PermittedAlphabet(
-                PermittedAlphabet::new(&[b'a' as u32,]).into()
-            ),]),
+            PERMITTED_CONSTRAINT,
+            VisibleString::try_from("hej").unwrap(),
+            &[0x02, 0x68, 0x65, 0x6a]
+        );
+        const PERMITTED_CONSTRAINT_2: Constraints =
+            constraints!(permitted_alphabet_constraint!(&[b'a' as u32]));
+        round_trip_with_constraints!(
+            aper,
+            VisibleString,
+            PERMITTED_CONSTRAINT_2,
             VisibleString::try_from("a").unwrap(),
             &[0x01]
         );

--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -376,7 +376,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
     }
 
     fn decode_enumerated<E: Enumerated>(&mut self, tag: Tag) -> Result<E> {
-        let discriminant = self.decode_integer::<isize>(tag, <_>::default())?;
+        let discriminant = self.decode_integer::<isize>(tag, Constraints::default())?;
 
         E::from_discriminant(discriminant)
             .ok_or_else(|| DecodeError::discriminant_value_not_found(discriminant, self.codec()))
@@ -575,7 +575,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
     }
 
     fn decode_generalized_time(&mut self, tag: Tag) -> Result<types::GeneralizedTime> {
-        let string = self.decode_utf8_string(tag, <_>::default())?;
+        let string = self.decode_utf8_string(tag, Constraints::default())?;
         if self.config.encoding_rules.is_ber() {
             Self::parse_any_generalized_time_string(string)
         } else {
@@ -585,7 +585,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
 
     fn decode_utc_time(&mut self, tag: Tag) -> Result<types::UtcTime> {
         // Reference https://obj-sys.com/asn1tutorial/node15.html
-        let string = self.decode_utf8_string(tag, <_>::default())?;
+        let string = self.decode_utf8_string(tag, Constraints::default())?;
         if self.config.encoding_rules.is_ber() {
             Self::parse_any_utc_time_string(string)
         } else {
@@ -594,7 +594,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
     }
 
     fn decode_date(&mut self, tag: Tag) -> core::result::Result<types::Date, Self::Error> {
-        let string = self.decode_utf8_string(tag, <_>::default())?;
+        let string = self.decode_utf8_string(tag, Constraints::default())?;
         Self::parse_date_string(&string)
     }
 

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -377,7 +377,7 @@ impl crate::Encoder for Encoder {
         value: &E,
     ) -> Result<Self::Ok, Self::Error> {
         let value = E::discriminant(value);
-        self.encode_integer(tag, <_>::default(), &value)
+        self.encode_integer(tag, Constraints::default(), &value)
     }
 
     fn encode_integer<I: IntegerType>(

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -8,7 +8,7 @@ type ValueMap = Map<alloc::string::String, Value>;
 
 use crate::{
     error::{EncodeError, JerEncodeErrorKind},
-    types::{fields::Fields, variants, IntegerType, Tag},
+    types::{fields::Fields, variants, Constraints, IntegerType, Tag},
 };
 
 pub struct Encoder {
@@ -66,7 +66,7 @@ impl crate::Encoder for Encoder {
     type Error = EncodeError;
 
     fn encode_any(&mut self, t: Tag, value: &crate::types::Any) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(t, <_>::default(), &value.contents)
+        self.encode_octet_string(t, Constraints::default(), &value.contents)
     }
 
     fn encode_bool(&mut self, _: Tag, value: bool) -> Result<Self::Ok, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,14 @@ mod num;
 mod per;
 pub mod types;
 
+// Helper macros
+// Macros are in root anyway, but make them available in a separate module
+pub mod macros {
+    pub use crate::{
+        constraints, permitted_alphabet_constraint, size_constraint, value_constraint,
+    };
+}
+
 // Data Formats
 
 pub mod aper;
@@ -229,9 +237,7 @@ mod tests {
         impl crate::AsnType for CustomInt {
             const TAG: Tag = Tag::INTEGER;
             const CONSTRAINTS: Constraints<'static> =
-                Constraints::new(&[Constraint::Value(constraints::Extensible::new(
-                    constraints::Value::new(constraints::Bounded::start_from(127)),
-                ))]);
+                crate::macros::constraints!(crate::macros::value_constraint!(start: 127));
         }
 
         impl crate::Encode for CustomInt {

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -961,7 +961,8 @@ mod tests {
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::types::constraints::{Bounded, Constraint, Constraints, Extensible, Size, Value};
+    use crate::macros::{constraints, value_constraint};
+    use crate::types::constraints::Constraints;
     use bitvec::prelude::BitSlice;
     use num_bigint::BigInt;
 
@@ -1078,33 +1079,33 @@ mod tests {
     }
     #[test]
     fn test_integer_decode_with_constraints() {
-        let range_bound = Bounded::<i128>::Range {
-            start: 0.into(),
-            end: 255.into(),
-        };
-        let value_range = &[Constraint::Value(Extensible::new(Value::new(range_bound)))];
-        let consts = Constraints::new(value_range);
+        const CONSTRAINT_1: Constraints = constraints!(value_constraint!(0, 255));
         let data = BitString::from_slice(&[0x01u8]);
         let mut decoder = Decoder::new(&data, DecoderOptions::oer());
-        let decoded_int: i32 = decoder.decode_integer_with_constraints(&consts).unwrap();
+        let decoded_int: i32 = decoder
+            .decode_integer_with_constraints(&CONSTRAINT_1)
+            .unwrap();
         assert_eq!(decoded_int, 1);
 
         let data = BitString::from_slice(&[0xffu8]);
         let mut decoder = Decoder::new(&data, DecoderOptions::oer());
-        let decoded_int: i64 = decoder.decode_integer_with_constraints(&consts).unwrap();
+        let decoded_int: i64 = decoder
+            .decode_integer_with_constraints(&CONSTRAINT_1)
+            .unwrap();
         assert_eq!(decoded_int, 255);
 
         let data = BitString::from_slice(&[0xffu8, 0xff]);
         let mut decoder = Decoder::new(&data, DecoderOptions::oer());
-        let decoded_int: BigInt = decoder.decode_integer_with_constraints(&consts).unwrap();
+        let decoded_int: BigInt = decoder
+            .decode_integer_with_constraints(&CONSTRAINT_1)
+            .unwrap();
         assert_eq!(decoded_int, 255.into());
 
         let data = BitString::from_slice(&[0x02u8, 0xff, 0x01]);
         let mut decoder = Decoder::new(&data, DecoderOptions::oer());
+        const CONSTRAINT_2: Constraints = Constraints::default();
         let decoded_int: BigInt = decoder
-            .decode_integer_with_constraints(&Constraints::new(&[Constraint::Size(
-                Size::new(Bounded::None).into(),
-            )]))
+            .decode_integer_with_constraints(&CONSTRAINT_2)
             .unwrap();
         assert_eq!(decoded_int, BigInt::from(-255));
     }

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -987,8 +987,8 @@ mod tests {
     use num_bigint::BigInt;
 
     use super::*;
+    use crate::macros::{constraints, value_constraint};
     use crate::prelude::{AsnType, Decode, Encode};
-    use crate::types::constraints::{Bounded, Constraint, Extensible, Value};
 
     #[test]
     fn test_encode_bool() {
@@ -1005,20 +1005,15 @@ mod tests {
     }
     #[test]
     fn test_encode_integer_manual_setup() {
-        let range_bound = Bounded::<i128>::Range {
-            start: 0.into(),
-            end: 255.into(),
-        };
-        let value_range = &[Constraint::Value(Extensible::new(Value::new(range_bound)))];
-        let consts = Constraints::new(value_range);
+        const CONSTRAINT_1: Constraints = constraints!(value_constraint!(0, 255));
         let mut encoder = Encoder::default();
-        let result = encoder.encode_integer_with_constraints(Tag::INTEGER, &consts, &244);
+        let result = encoder.encode_integer_with_constraints(Tag::INTEGER, &CONSTRAINT_1, &244);
         assert!(result.is_ok());
         let v = vec![244u8];
         assert_eq!(encoder.output, v);
         encoder.output.clear();
         let value = BigInt::from(256);
-        let result = encoder.encode_integer_with_constraints(Tag::INTEGER, &consts, &value);
+        let result = encoder.encode_integer_with_constraints(Tag::INTEGER, &CONSTRAINT_1, &value);
         assert!(result.is_err());
     }
     #[test]

--- a/src/per.rs
+++ b/src/per.rs
@@ -1,6 +1,7 @@
 pub mod de;
 pub mod enc;
 
+use crate::macros::{constraints, value_constraint};
 use crate::types::Constraints;
 
 pub use self::{de::Decoder, enc::Encoder};
@@ -9,6 +10,8 @@ const SIXTEEN_K: u16 = 16384;
 const THIRTY_TWO_K: u16 = 32768;
 const FOURTY_EIGHT_K: u16 = 49152;
 const SIXTY_FOUR_K: u32 = 65536;
+const SMALL_UNSIGNED_CONSTRAINT: Constraints = constraints!(value_constraint!(0, 63));
+const LARGE_UNSIGNED_CONSTRAINT: Constraints = constraints!(value_constraint!(start: 0));
 
 /// Attempts to decode `T` from `input` using PER.
 pub(crate) fn decode<T: crate::Decode>(

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -398,6 +398,7 @@ pub trait IntegerType:
 {
     const WIDTH: u32;
     const BYTE_WIDTH: usize = Self::WIDTH as usize / 8;
+    const ZERO: Self;
     /// `Self` as an unsigned type with the same width.
     type UnsignedPair: IntegerType;
     /// `Self` as a signed type with one type size larger to prevent truncation, in case `Self` is unsigned. (e.g. u8 -> i16)
@@ -466,6 +467,7 @@ macro_rules! integer_type_impl {
     ((signed $t1:ty, $t2:ty), $($ts:tt)*) => {
         impl IntegerType for $t1 {
             const WIDTH: u32 = <$t1>::BITS;
+            const ZERO: $t1 = 0 as $t1;
             type UnsignedPair = $t2;
             type SignedPair = $t1;
 
@@ -565,6 +567,7 @@ macro_rules! integer_type_impl {
 
         impl IntegerType for $t1 {
             const WIDTH: u32 = <$t1>::BITS;
+            const ZERO: $t1 = 0 as $t1;
             type UnsignedPair = $t1;
             type SignedPair = $t2;
 
@@ -676,6 +679,7 @@ integer_type_impl!(
 
 impl IntegerType for BigInt {
     const WIDTH: u32 = u32::MAX;
+    const ZERO: BigInt = BigInt::ZERO;
     type UnsignedPair = Self;
     type SignedPair = Self;
 
@@ -755,6 +759,7 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for IntegerBytesRef<T> {
 
 impl IntegerType for Integer {
     const WIDTH: u32 = u32::MAX;
+    const ZERO: Integer = Integer::ZERO;
     type UnsignedPair = Self;
     type SignedPair = Self;
 

--- a/src/uper.rs
+++ b/src/uper.rs
@@ -39,9 +39,11 @@ pub fn encode_with_constraints<T: crate::Encode>(
 #[cfg(test)]
 mod tests {
     use crate::{
+        macros::{constraints, permitted_alphabet_constraint, size_constraint},
         prelude::*,
         types::{constraints::*, *},
     };
+
     #[test]
     fn bool() {
         round_trip!(uper, bool, true, &[0x80]);
@@ -96,42 +98,36 @@ mod tests {
             " 0123456789".try_into().unwrap(),
             &[0x0b, 0x01, 0x23, 0x45, 0x67, 0x89, 0xa0]
         );
+        const CONSTRAINT_1: Constraints = constraints!(size_constraint!(5));
         round_trip_with_constraints!(
             uper,
             NumericString,
-            Constraints::new(&[Constraint::Size(Size::new(Bounded::Single(5)).into())]),
+            CONSTRAINT_1,
             "1 9 5".try_into().unwrap(),
             &[0x20, 0xa0, 0x60]
         );
 
+        const CONSTRAINT_2: Constraints = constraints!(size_constraint!(19, 134));
         round_trip_with_constraints!(
             uper,
             NumericString,
-            Constraints::new(&[Constraint::Size(
-                Size::new(Bounded::Range {
-                    start: 19.into(),
-                    end: 134.into()
-                })
-                .into()
-            )]),
+            CONSTRAINT_2,
             "0123456789 9876543210".try_into().unwrap(),
             &[0x04, 0x24, 0x68, 0xac, 0xf1, 0x34, 0x15, 0x30, 0xec, 0xa8, 0x64, 0x20]
         );
+        const CONSTRAINT_3: Constraints = constraints!(permitted_alphabet_constraint!(&[
+            b'0' as u32,
+            b'1' as u32,
+            b'2' as u32,
+            b'3' as u32,
+            b'4' as u32,
+            b'5' as u32
+        ]));
 
         round_trip_with_constraints!(
             uper,
             NumericString,
-            Constraints::new(&[Constraint::PermittedAlphabet(
-                PermittedAlphabet::new(&[
-                    b'0' as u32,
-                    b'1' as u32,
-                    b'2' as u32,
-                    b'3' as u32,
-                    b'4' as u32,
-                    b'5' as u32
-                ])
-                .into()
-            )]),
+            CONSTRAINT_3,
             "5".try_into().unwrap(),
             &[0x01, 0xa0]
         );
@@ -139,27 +135,22 @@ mod tests {
 
     #[test]
     fn visible_string() {
+        const CONSTRAINT_1: Constraints = constraints!(size_constraint!(19, 133));
         round_trip_with_constraints!(
             uper,
             VisibleString,
-            Constraints::new(&[Constraint::Size(
-                Size::new(Bounded::Range {
-                    start: 19.into(),
-                    end: 133.into()
-                })
-                .into()
-            )]),
+            CONSTRAINT_1,
             "HejHoppHappHippAbcde".try_into().unwrap(),
             &[
                 0x03, 0x23, 0x2e, 0xa9, 0x1b, 0xf8, 0x70, 0x91, 0x87, 0x87, 0x09, 0x1a, 0x78, 0x70,
                 0x83, 0x8b, 0x1e, 0x4c, 0xa0
             ]
         );
-
+        const CONSTRAINT_2: Constraints = constraints!(size_constraint!(5));
         round_trip_with_constraints!(
             uper,
             VisibleString,
-            Constraints::new(&[Constraint::Size(Size::new(Bounded::Single(5)).into())]),
+            CONSTRAINT_2,
             "Hejaa".try_into().unwrap(),
             &[0x91, 0x97, 0x56, 0x1c, 0x20]
         );
@@ -181,56 +172,41 @@ mod tests {
 
             array
         };
-
+        const CONSTRAINT_3: Constraints = constraints!(
+            size_constraint!(1, 255),
+            permitted_alphabet_constraint!(ALPHABET)
+        );
         round_trip_with_constraints!(
             uper,
             VisibleString,
-            Constraints::new(&[
-                Constraint::Size(
-                    Size::new(Bounded::Range {
-                        start: 1.into(),
-                        end: 255.into()
-                    })
-                    .into()
-                ),
-                Constraint::PermittedAlphabet(PermittedAlphabet::new(ALPHABET).into()),
-            ]),
+            CONSTRAINT_3,
             "hej".try_into().unwrap(),
             &[0x02, 0x39, 0x12]
         );
     }
     #[test]
     fn printable_string() {
+        const CONSTRAINT_1: Constraints = constraints!(size_constraint!(16));
         round_trip_with_constraints!(
             uper,
             PrintableString,
-            Constraints::new(&[Constraint::Size(Size::new(Bounded::Single(16)).into())]),
+            CONSTRAINT_1,
             PrintableString::from_bytes("0123456789abcdef".as_bytes()).unwrap(),
             &[0x60, 0xc5, 0x93, 0x36, 0x8d, 0x5b, 0x37, 0x70, 0xe7, 0x0e, 0x2c, 0x79, 0x32, 0xe6]
         );
+        const CONSTRAINT_2: Constraints = constraints!(size_constraint!(0, 31));
         round_trip_with_constraints!(
             uper,
             PrintableString,
-            Constraints::new(&[Constraint::Size(
-                Size::new(Bounded::Range {
-                    start: 0.into(),
-                    end: 31.into()
-                })
-                .into()
-            )]),
+            CONSTRAINT_2,
             "".try_into().unwrap(),
             &[0x00]
         );
+        const CONSTRAINT_3: Constraints = constraints!(size_constraint!(0, 31));
         round_trip_with_constraints!(
             uper,
             PrintableString,
-            Constraints::new(&[Constraint::Size(
-                Size::new(Bounded::Range {
-                    start: 0.into(),
-                    end: 31.into()
-                })
-                .into()
-            )]),
+            CONSTRAINT_3,
             "2".try_into().unwrap(),
             &[0x0b, 0x20]
         );

--- a/standards/kerberos/tests/issue111.rs
+++ b/standards/kerberos/tests/issue111.rs
@@ -1,8 +1,9 @@
 use rasn::{
     ber,
-    types::{Class, Tag},
+    types::{Class, Constraints, Tag},
     Decoder, Encoder,
 };
+
 use rasn_kerberos::KerberosFlags;
 
 #[test]
@@ -10,7 +11,7 @@ fn kerberos_flags_dec() {
     let input = b"\x03\x05\x00\x40\x81\x00\x00";
     let mut decoder = ber::de::Decoder::new(input, ber::de::DecoderOptions::ber());
     let output = decoder
-        .decode_bit_string(Tag::new(Class::Universal, 3), <_>::default())
+        .decode_bit_string(Tag::new(Class::Universal, 3), Constraints::default())
         .unwrap();
     let expected = KerberosFlags::from_vec([0x40, 0x81, 0x00, 0x00].to_vec());
     assert_eq!(output, expected)
@@ -21,7 +22,11 @@ fn kerberos_flags_enc() {
     let bitstring = KerberosFlags::from_vec([0x40, 0x81, 0x00, 0x00].to_vec());
     let mut encoder = ber::enc::Encoder::new(ber::enc::EncoderOptions::ber());
     encoder
-        .encode_bit_string(Tag::new(Class::Universal, 3), <_>::default(), &bitstring)
+        .encode_bit_string(
+            Tag::new(Class::Universal, 3),
+            Constraints::default(),
+            &bitstring,
+        )
         .unwrap();
     assert_eq!(
         encoder.output(),

--- a/standards/pkix/tests/digicert.rs
+++ b/standards/pkix/tests/digicert.rs
@@ -24,7 +24,7 @@ fn extensions() {
 
         encoder.encode_sequence::<Sequence, _>(Tag::SEQUENCE, |encoder| {
             encoder.encode_bool(Tag::BOOL, true)?;
-            encoder.encode_integer::<u32>(Tag::INTEGER, <_>::default(), &0u32)?;
+            encoder.encode_integer::<u32>(Tag::INTEGER, Constraints::default(), &0u32)?;
             Ok(())
         })?;
 

--- a/standards/smi/src/v2.rs
+++ b/standards/smi/src/v2.rs
@@ -2,6 +2,7 @@
 
 use alloc::string::ToString;
 
+use rasn::macros::*;
 use rasn::prelude::*;
 
 use crate::v1::InvalidVariant;
@@ -76,10 +77,11 @@ impl Encode for ExtUtcTime {
         tag: Tag,
         _: Constraints,
     ) -> Result<(), EN::Error> {
+        const CONSTRAINT_1: constraints::Constraints = constraints!(value_constraint!(13));
         encoder
             .encode_octet_string(
                 tag,
-                <_>::from(&[constraints::Size::new(constraints::Bounded::single_value(13)).into()]),
+                CONSTRAINT_1,
                 self.0.format(FULL_DATE_FORMAT).to_string().as_bytes(),
             )
             .map(drop)


### PR DESCRIPTION
Smaller update based on #318 which might be useful anyway already.

* Add ZERO associated constant for `IntegerType`
* Change Constraints::default() to be const
* Change some other constraint-related functions to be constant
* Add `VARIANCE_CONSTRAINT` for choice type - variance can be calculated in compile time
* Add macros to generate constant constraints, like

```rust
const CONSTRAINTS: Constraints = constraints!(value_constraint!(0, 100), size_constraint!(0, 100));
```