### PR TITLE
Add basic optimizations for allocations in OER

### DIFF
--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -601,7 +601,6 @@ impl<'input> crate::Decoder for Decoder<'input> {
         _: Tag,
         _: Constraints,
     ) -> Result<Vec<D>, Self::Error> {
-        let mut sequence_of = Vec::new();
         let length_of_quantity = self.decode_length()?;
         let coer = self.options.encoding_rules.is_coer();
         let length_bits = self.extract_data_by_length(length_of_quantity)?;
@@ -626,6 +625,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
         }
 
         let length = length_bits.load_be::<usize>();
+        let mut sequence_of: Vec<D> = Vec::with_capacity(length);
         let mut start = 1;
         let mut decoder = Self::new(self.input.0, self.options);
         while start <= length {
@@ -810,7 +810,9 @@ impl<'input> crate::Decoder for Decoder<'input> {
             .collect();
 
         let fields = {
-            let mut fields = Vec::new();
+            let mut fields = Vec::with_capacity(
+                SET::FIELDS.len() + SET::EXTENDED_FIELDS.unwrap_or_default().len(),
+            );
             let mut set_decoder = Self::new(self.input.0, self.options);
             set_decoder.extension_fields = SET::EXTENDED_FIELDS;
             set_decoder.extensions_present = extensible_present.then_some(None);

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -869,6 +869,9 @@ impl<'a> crate::Encoder for Encoder<'a> {
         // It seems that constraints here are not C/OER visible? No mention in standard...
         self.set_bit(tag, true);
         self.encode_unconstrained_integer(&value.len(), false)?;
+        self.output
+            .borrow_mut()
+            .reserve(core::mem::size_of_val(value));
         let mut encoder = Encoder::from_buffer(self.options, &self.output);
         {
             for one in value {

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -137,17 +137,8 @@ impl<'a> Encoder<'a> {
     }
 
     #[must_use]
-    pub fn output(self) -> Vec<u8> {
-        self.options
-            .set_encoding
-            .then(|| {
-                self.set_output
-                    .values()
-                    .flatten()
-                    .copied()
-                    .collect::<Vec<u8>>()
-            })
-            .unwrap_or(core::mem::take(&mut *self.output.borrow_mut()))
+    pub fn output(&self) -> Vec<u8> {
+        core::mem::take(&mut *self.output.borrow_mut())
     }
     fn collect_set(&self) {
         self.output.borrow_mut().append(
@@ -510,6 +501,9 @@ impl<'a> Encoder<'a> {
         // Must copy before move...
         let extension_fields = core::mem::take(&mut encoder.extension_fields);
         if encoder.field_bitfield.values().any(|(_, b)| *b) {
+            if encoder.options.set_encoding {
+                encoder.collect_set();
+            }
             self.output.borrow_mut().append(&mut encoder.output());
         }
         if !extensions_defined || !extensions_present {

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use bitvec::prelude::*;
+use core::cell::RefCell;
 use hashbrown::HashMap;
 use num_traits::ToPrimitive;
 
@@ -70,16 +71,92 @@ impl EncodingRules {
         matches!(self, Self::Oer)
     }
 }
-impl Default for Encoder {
+impl Default for Encoder<'_> {
     fn default() -> Self {
         Self::new(EncoderOptions::coer())
     }
 }
+
+#[derive(Debug)]
+enum Buffer<'a> {
+    Borrowed(&'a RefCell<Vec<u8>>),
+    Owned(RefCell<Vec<u8>>),
+}
+impl<'a> Buffer<'a> {
+    fn inner(&'a self) -> &'a RefCell<Vec<u8>> {
+        match self {
+            Self::Borrowed(buf) => buf,
+            Self::Owned(buf) => buf,
+        }
+    }
+    fn to_vec(self) -> Vec<u8> {
+        match self {
+            Self::Borrowed(buf) => buf.borrow().to_vec(),
+            Self::Owned(buf) => buf.into_inner(),
+        }
+    }
+    // fn clone(&self) -> Self {
+    //     match self {
+    //         Self::Borrowed(buf) => Self::Borrowed(buf),
+    //         Self::Owned(buf) => Self::Owned(buf.clone()),
+    //     }
+    // }
+    fn clear(&mut self) {
+        match self {
+            Self::Borrowed(buf) => buf.borrow_mut().clear(),
+            Self::Owned(buf) => buf.borrow_mut().clear(),
+        }
+    }
+    fn len(&self) -> usize {
+        match self {
+            Self::Borrowed(buf) => buf.borrow().len(),
+            Self::Owned(buf) => buf.borrow().len(),
+        }
+    }
+    fn into_inner(self) -> Vec<u8> {
+        match self {
+            Self::Borrowed(buf) => buf.borrow().clone(),
+            Self::Owned(buf) => buf.into_inner(),
+        }
+    }
+}
+impl Extend<u8> for Buffer<'_> {
+    fn extend<T>(&mut self, other: T)
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        match self {
+            Self::Borrowed(buf) => buf.borrow_mut().extend(other),
+            Self::Owned(buf) => buf.borrow_mut().extend(other),
+        }
+    }
+}
+impl<'a, 'b> Extend<&'b u8> for Buffer<'a> {
+    fn extend<T: IntoIterator<Item = &'b u8>>(&mut self, other: T) {
+        match self {
+            Self::Borrowed(buf) => buf.borrow_mut().extend(other),
+            Self::Owned(buf) => buf.borrow_mut().extend(other),
+        }
+    }
+}
+
+// impl<'a> PartialEq<Vec<u8>> for Buffer<'a> {
+//     fn eq(&self, other: &Vec<u8>) -> bool {
+//         *self.inner().borrow() == *other
+//     }
+// }
+
+// impl<'a> PartialEq<Buffer<'a>> for Buffer<'a> {
+//     fn eq(&self, other: &Self) -> bool {
+//         self.inner() == other.inner()
+//     }
+// }
+
 /// COER encoder. A subset of OER to provide canonical and unique encoding.
 #[derive(Debug)]
-pub struct Encoder {
+pub struct Encoder<'a> {
     options: EncoderOptions,
-    output: Vec<u8>,
+    output: Buffer<'a>,
     set_output: alloc::collections::BTreeMap<Tag, Vec<u8>>,
     // usize a.k.a. field index defines the order for Sequence
     field_bitfield: HashMap<(usize, Tag), (FieldPresence, bool)>,
@@ -104,13 +181,25 @@ pub struct Encoder {
 
 // Tags are encoded only as part of the encoding of a choice type, where the tag indicates
 // which alternative of the choice type is the chosen alternative (see 20.1).
-impl Encoder {
-    // pub fn new(options: EncoderOptions) -> Self {
+impl<'a> Encoder<'a> {
     #[must_use]
     pub fn new(options: EncoderOptions) -> Self {
         Self {
             options,
-            output: <_>::default(),
+            output: Buffer::Owned(RefCell::new(Vec::with_capacity(20))),
+            set_output: <_>::default(),
+            // field_bitfield: LinearMap::<_, _, N>::default(),
+            field_bitfield: <_>::default(),
+            current_field_index: <_>::default(),
+            extension_fields: <_>::default(),
+            is_extension_sequence: bool::default(),
+            parent_output_length: <_>::default(),
+        }
+    }
+    pub fn from_buffer(options: EncoderOptions, output: &'a RefCell<Vec<u8>>) -> Self {
+        Self {
+            options,
+            output: Buffer::Borrowed(output),
             set_output: <_>::default(),
             field_bitfield: <_>::default(),
             current_field_index: <_>::default(),
@@ -134,7 +223,7 @@ impl Encoder {
                     .copied()
                     .collect::<Vec<u8>>()
             })
-            .unwrap_or(self.output)
+            .unwrap_or(self.output.into_inner())
     }
     pub fn set_bit(&mut self, tag: Tag, bit: bool) {
         // In set encoding, field index does not matter
@@ -151,17 +240,35 @@ impl Encoder {
             self.current_field_index += 1;
         }
     }
-    fn extend(&mut self, tag: Tag, bytes: Vec<u8>) -> Result<(), EncodeError> {
-        match self.output.len().checked_add(bytes.len()) {
-            Some(_) => {
-                if self.options.set_encoding {
-                    self.set_output.insert(tag, bytes);
-                } else {
-                    self.output.extend(bytes);
-                }
-            }
-            _ => Err(EncodeError::length_exceeds_platform_size(self.codec()))?,
+    fn extend(&mut self, tag: Tag) -> Result<(), EncodeError> {
+        // if let Some(output) = self.output.as_mut() {
+        // match output.len().checked_add(bytes.len()) {
+        // Some(_) => {
+        if self.options.set_encoding {
+            self.set_output
+                .insert(tag, core::mem::take(&mut self.output.inner().borrow_mut()));
+            self.output.clear();
+        } else {
+            // output.extend(bytes);
         }
+        // }
+        // _ => Err(EncodeError::length_exceeds_platform_size(self.codec()))?,
+        // }
+        // Ok(())
+        // } else {
+        //     // Err(EncodeError::output_buffer_not_set())
+        //     Err(EncodeError::length_exceeds_platform_size(self.codec()))?
+        // }
+        // match self.output.len().checked_add(bytes.len()) {
+        //     Some(_) => {
+        //         if self.options.set_encoding {
+        //             self.set_output.insert(tag, bytes);
+        //         } else {
+        //             self.output.extend(bytes);
+        //         }
+        //     }
+        //     _ => Err(EncodeError::length_exceeds_platform_size(self.codec()))?,
+        // }
         Ok(())
     }
     /// Encode a tag as specified in ITU-T X.696 8.7
@@ -169,7 +276,7 @@ impl Encoder {
     /// Encoding of the tag is only required when encoding a choice type.
     fn encode_tag(tag: Tag) -> Vec<u8> {
         use crate::types::Class;
-        let mut bv: BitVec<u8, Msb0> = BitVec::new();
+        let mut bv: BitVec<u8, Msb0> = BitVec::with_capacity(32);
         // Encode the tag class
         match tag.class {
             Class::Universal => bv.extend(&[false, false]),
@@ -210,11 +317,7 @@ impl Encoder {
         bv.into_vec()
     }
 
-    fn encode_unconstrained_enum_index(
-        &mut self,
-        buffer: &mut Vec<u8>,
-        value: isize,
-    ) -> Result<(), EncodeError> {
+    fn encode_unconstrained_enum_index(&mut self, value: isize) -> Result<(), EncodeError> {
         let (bytes, needed) = value.to_signed_bytes_be();
         let mut length = u8::try_from(needed).map_err(|err| {
             EncodeError::integer_type_conversion_failed(
@@ -236,19 +339,19 @@ impl Encoder {
         // We must swap the first bit to show long form
         // It is always zero by default with u8 type when value being < 128
         length |= 0b_1000_0000;
-        buffer.extend(&length.to_be_bytes());
-        buffer.extend(&bytes.as_ref()[..needed]);
+        self.output.extend(&length.to_be_bytes());
+        self.output.extend(&bytes.as_ref()[..needed]);
         Ok(())
     }
     /// Encode the length of the value to output.
     /// `Length` of the data should be provided as full bytes.
     ///
     /// COER tries to use the shortest possible encoding and avoids leading zeros.
-    fn encode_length(&mut self, buffer: &mut Vec<u8>, length: usize) -> Result<(), EncodeError> {
+    fn encode_length(&mut self, length: usize) -> Result<(), EncodeError> {
         let (bytes, needed) = length.to_unsigned_bytes_be();
         if length < 128 {
             // First bit should be always zero when below 128: ITU-T X.696 8.6.4
-            buffer.extend(&bytes.as_ref()[..needed]);
+            self.output.extend(&bytes.as_ref()[..needed]);
             return Ok(());
         }
         let mut length_of_length = u8::try_from(needed).map_err(|err| {
@@ -266,26 +369,26 @@ impl Encoder {
         // We must swap the first bit to show long form
         // It is always zero by default with u8 type when value being < 128
         length_of_length |= 0b_1000_0000;
-        buffer.extend(&length_of_length.to_be_bytes());
-        buffer.extend(&bytes.as_ref()[..needed]);
+        self.output.extend(&length_of_length.to_be_bytes());
+        self.output.extend(&bytes.as_ref()[..needed]);
         Ok(())
     }
     /// Encode integer `value_to_enc` with length determinant
     /// Either as signed or unsigned, set by `signed`
     fn encode_unconstrained_integer<I: IntegerType>(
         &mut self,
-        buffer: &mut Vec<u8>,
+        // buffer: &mut Vec<u8>,
         value_to_enc: &I,
         signed: bool,
     ) -> Result<(), EncodeError> {
         if signed {
             let (bytes, needed) = value_to_enc.to_signed_bytes_be();
-            self.encode_length(buffer, needed)?;
-            buffer.extend(&bytes.as_ref()[..needed]);
+            self.encode_length(needed)?;
+            self.output.extend(&bytes.as_ref()[..needed]);
         } else {
             let (bytes, needed) = value_to_enc.to_unsigned_bytes_be();
-            self.encode_length(buffer, needed)?;
-            buffer.extend(&bytes.as_ref()[..needed]);
+            self.encode_length(needed)?;
+            self.output.extend(&bytes.as_ref()[..needed]);
         };
         Ok(())
     }
@@ -306,8 +409,6 @@ impl Encoder {
         constraints: &Constraints,
         value_to_enc: &I,
     ) -> Result<(), EncodeError> {
-        let mut buffer = Vec::with_capacity(8);
-
         if let Some(value) = constraints.value() {
             if !value.constraint.0.in_bound(value_to_enc) && value.extensible.is_none() {
                 return Err(EncodeError::value_constraint_not_satisfied(
@@ -322,21 +423,20 @@ impl Encoder {
                 |value_to_enc, sign, octets| -> Result<(), EncodeError> {
                     if let Some(octets) = octets {
                         self.encode_constrained_integer_with_padding(
-                            &mut buffer,
                             usize::from(octets),
                             value_to_enc,
                             sign,
                         )?;
                     } else {
-                        self.encode_unconstrained_integer(&mut buffer, value_to_enc, sign)?;
+                        self.encode_unconstrained_integer(value_to_enc, sign)?;
                     }
                     Ok(())
                 },
             )?;
         } else {
-            self.encode_unconstrained_integer(&mut buffer, value_to_enc, true)?;
+            self.encode_unconstrained_integer(value_to_enc, true)?;
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -344,7 +444,6 @@ impl Encoder {
     /// This means that the zero padding is possible even with COER encoding.
     fn encode_constrained_integer_with_padding<I: IntegerType>(
         &mut self,
-        buffer: &mut Vec<u8>,
         octets: usize,
         value: &I,
         signed: bool,
@@ -367,9 +466,11 @@ impl Encoder {
             Ordering::Greater => {
                 if signed && value.is_negative() {
                     // 2's complement
-                    buffer.extend(core::iter::repeat(0xff).take(octets - needed));
+                    self.output
+                        .extend(core::iter::repeat(0xff).take(octets - needed));
                 } else {
-                    buffer.extend(core::iter::repeat(0x00).take(octets - needed));
+                    self.output
+                        .extend(core::iter::repeat(0x00).take(octets - needed));
                 }
             }
             Ordering::Less => {
@@ -384,15 +485,13 @@ impl Encoder {
             // As is
             Ordering::Equal => {}
         };
-        buffer.extend(&bytes[..needed]);
+        self.output.extend(&bytes[..needed]);
         Ok(())
     }
-    fn check_fixed_size_constraint<T>(
+    fn check_fixed_size_constraint(
         &self,
-        value: T,
         length: usize,
         constraints: &Constraints,
-        mut is_fixed_fn: impl FnMut(T) -> Result<(), EncodeError>,
     ) -> Result<bool, EncodeError> {
         if let Some(size) = constraints.size() {
             if !size.constraint.contains(&length) && size.extensible.is_none() {
@@ -404,10 +503,7 @@ impl Encoder {
             }
             // Encode without length determinant
             if size.constraint.is_fixed() && size.extensible.is_none() {
-                return match is_fixed_fn(value) {
-                    Ok(()) => Ok(true),
-                    Err(err) => Err(err),
-                };
+                return Ok(true);
             }
         }
         // Prior checks before encoding with length determinant
@@ -467,8 +563,8 @@ impl Encoder {
         mut encoder: Self,
     ) -> Result<(), EncodeError> {
         self.set_bit(tag, true);
-        let mut buffer = Vec::new();
-        let mut preamble = BitString::default();
+        const WIDTH: usize = 16;
+        let mut preamble = BitString::with_capacity(WIDTH);
         // ### PREAMBLE ###
         // Section 16.2.2
         let extensions_defined = C::EXTENDED_FIELDS.is_some();
@@ -495,20 +591,20 @@ impl Encoder {
             preamble.extend(BitString::repeat(false, 8 - preamble.len() % 8));
         }
         debug_assert!(preamble.len() % 8 == 0);
-        buffer.extend(preamble.as_raw_slice());
+        self.output.extend(preamble.as_raw_slice());
         // Section 16.3 ### Encodings of the components in the extension root ###
         // Must copy before move...
         let extension_fields = core::mem::take(&mut encoder.extension_fields);
         if encoder.field_bitfield.values().any(|(_, b)| *b) {
-            buffer.extend(encoder.output());
+            self.output.extend(encoder.output());
         }
         if !extensions_defined || !extensions_present {
-            self.extend(tag, buffer)?;
+            self.extend(tag)?;
             return Ok(());
         }
         // Section 16.4 ### Extension addition presence bitmap ###
         let bitfield_length = extension_fields.len();
-        let mut extension_bitmap_buffer = BitString::new();
+        let mut extension_bitmap_buffer = BitString::with_capacity(WIDTH);
         #[allow(clippy::cast_possible_truncation)]
         let missing_bits: u8 = if bitfield_length > 0 {
             (8u8 - (bitfield_length % 8) as u8) % 8
@@ -516,28 +612,25 @@ impl Encoder {
             0
         };
         debug_assert!((bitfield_length + 8 + missing_bits as usize) % 8 == 0);
-        self.encode_length(
-            &mut buffer,
-            (8 + bitfield_length + missing_bits as usize) / 8,
-        )?;
+        self.encode_length((8 + bitfield_length + missing_bits as usize) / 8)?;
         extension_bitmap_buffer.extend(missing_bits.to_be_bytes());
         for field in &extension_fields {
             extension_bitmap_buffer.push(field.is_some());
         }
         extension_bitmap_buffer.extend(BitString::repeat(false, missing_bits as usize));
         debug_assert!(extension_bitmap_buffer.len() % 8 == 0);
-        buffer.extend(extension_bitmap_buffer.as_raw_slice());
+        self.output.extend(extension_bitmap_buffer.as_raw_slice());
         // Section 16.5 # Encodings of the components in the extension addition group, as open type
         for field in extension_fields.iter().filter_map(Option::as_ref) {
-            self.encode_length(&mut buffer, field.len())?;
-            buffer.extend_from_slice(field);
+            self.encode_length(field.len())?;
+            self.output.extend(field);
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 }
 
-impl crate::Encoder for Encoder {
+impl<'a> crate::Encoder for Encoder<'a> {
     type Ok = ();
     type Error = EncodeError;
 
@@ -555,8 +648,9 @@ impl crate::Encoder for Encoder {
     /// In Basic-OER, any non-zero octet value represents true, but we support only canonical encoding.
     fn encode_bool(&mut self, tag: Tag, value: bool) -> Result<Self::Ok, Self::Error> {
         self.set_bit(tag, true);
-        self.extend(tag, alloc::vec![if value { 0xffu8 } else { 0x00u8 }])?;
-        Ok(())
+        self.output
+            .extend(if value { &[0xffu8] } else { &[0x00u8] });
+        self.extend(tag)
     }
 
     fn encode_bit_string(
@@ -570,8 +664,8 @@ impl crate::Encoder for Encoder {
         // effective size constraint.
         // Rasn does not currently support NamedBitList
         self.set_bit(tag, true);
-        let mut buffer: Vec<u8> = Vec::new();
-        let mut bit_string_encoding = BitVec::<u8, Msb0>::new();
+        // let mut buffer: Vec<u8> = Vec::new();
+        let mut bit_string_encoding = BitVec::<u8, Msb0>::with_capacity(16);
 
         if let Some(size) = constraints.size() {
             // Constraints apply only if the lower and upper bounds
@@ -591,7 +685,7 @@ impl crate::Encoder for Encoder {
                     } else {
                         bit_string_encoding.extend(value);
                     }
-                    buffer.extend(bit_string_encoding.as_raw_slice());
+                    self.output.extend(bit_string_encoding.as_raw_slice());
                 } else {
                     return Err(EncodeError::size_constraint_not_satisfied(
                         value.len(),
@@ -599,15 +693,15 @@ impl crate::Encoder for Encoder {
                         self.codec(),
                     ));
                 }
-                self.extend(tag, buffer)?;
+                self.extend(tag)?;
                 return Ok(());
             }
         }
 
         // If the BitString is empty, length is one and initial octet is zero
         if value.is_empty() {
-            self.encode_length(&mut buffer, 1)?;
-            buffer.extend(&[0x00u8]);
+            self.encode_length(1)?;
+            self.output.extend(&[0x00u8]);
         } else {
             // TODO 22.7 X.680, NamedBitString and COER
             // if self.options.encoding_rules.is_coer()
@@ -626,10 +720,10 @@ impl crate::Encoder for Encoder {
             bit_string_encoding.extend(missing_bits.to_u8().unwrap_or(0).to_be_bytes());
             bit_string_encoding.extend(value);
             bit_string_encoding.extend(trailing);
-            self.encode_length(&mut buffer, bit_string_encoding.len() / 8)?;
-            buffer.extend(bit_string_encoding.as_raw_slice());
+            self.encode_length(bit_string_encoding.len() / 8)?;
+            self.output.extend(bit_string_encoding.as_raw_slice());
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -644,15 +738,14 @@ impl crate::Encoder for Encoder {
         // Spec allows between –2^1015 and 2^1015 – 1
         self.set_bit(tag, true);
         let number = value.discriminant();
-        let mut buffer = Vec::new();
         if 0isize <= number && number <= i8::MAX.into() {
-            self.encode_constrained_integer_with_padding(&mut buffer, 1, &number, false)?;
+            self.encode_constrained_integer_with_padding(1, &number, false)?;
         } else {
             // Value is signed here as defined in section 11.4
             // Long form but different from regular length determinant encoding
-            self.encode_unconstrained_enum_index(&mut buffer, number)?;
+            self.encode_unconstrained_enum_index(number)?;
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -664,10 +757,9 @@ impl crate::Encoder for Encoder {
         self.set_bit(tag, true);
         let mut enc = crate::ber::enc::Encoder::new(crate::ber::enc::EncoderOptions::ber());
         let octets = enc.object_identifier_as_bytes(value)?;
-        let mut buffer = Vec::new();
-        self.encode_length(&mut buffer, octets.len())?;
-        buffer.extend(&octets);
-        self.extend(tag, buffer)?;
+        self.encode_length(octets.len())?;
+        self.output.extend(&octets);
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -693,17 +785,14 @@ impl crate::Encoder for Encoder {
         value: &[u8],
     ) -> Result<Self::Ok, Self::Error> {
         self.set_bit(tag, true);
-        let mut buffer = Vec::new();
-        let fixed_size_encode = |value: &[u8]| {
-            buffer.extend(value);
-            Ok(())
-        };
-        if !self.check_fixed_size_constraint(value, value.len(), &constraints, fixed_size_encode)? {
+        if self.check_fixed_size_constraint(value.len(), &constraints)? {
+            self.output.extend(value);
+        } else {
             // Use length determinant on other cases
-            self.encode_length(&mut buffer, value.len())?;
-            buffer.extend(value);
+            self.encode_length(value.len())?;
+            self.output.extend(value);
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -857,14 +946,14 @@ impl crate::Encoder for Encoder {
     ) -> Result<Self::Ok, Self::Error> {
         // It seems that constraints here are not C/OER visible? No mention in standard...
         self.set_bit(tag, true);
-        let mut buffer = Vec::new();
-        self.encode_unconstrained_integer(&mut buffer, &value.len(), false)?;
-        for one in value {
-            let mut encoder = Self::new(self.options);
-            E::encode(one, &mut encoder)?;
-            buffer.extend(encoder.output());
+        self.encode_unconstrained_integer(&value.len(), false)?;
+        let mut encoder = Encoder::from_buffer(self.options, self.output.inner());
+        {
+            for one in value {
+                E::encode(one, &mut encoder)?;
+            }
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
 
@@ -920,19 +1009,38 @@ impl crate::Encoder for Encoder {
     ) -> Result<Self::Ok, Self::Error> {
         let mut choice_encoder = Self::new(self.options.without_set_encoding());
         let tag = encode_fn(&mut choice_encoder)?;
+
         let is_root_extension = crate::types::TagTree::tag_contains(&tag, E::VARIANTS);
         let tag_bytes: Vec<u8> = Self::encode_tag(tag);
-        let mut buffer = Vec::new();
-        buffer.extend(tag_bytes);
+        self.output.extend(tag_bytes);
         if is_root_extension {
-            buffer.extend(choice_encoder.output);
+            self.output.extend(choice_encoder.output.into_inner());
         } else {
-            self.encode_length(&mut buffer, choice_encoder.output.len())?;
-            buffer.extend(choice_encoder.output);
+            self.encode_length(choice_encoder.output.len())?;
+            self.output.extend(choice_encoder.output.into_inner());
         }
-        self.extend(tag, buffer)?;
+        self.extend(tag)?;
         Ok(())
     }
+    // fn encode_choice<'b, E: Encode + Choice>(
+    //     &mut self,
+    //     _: Constraints,
+    //     _tag: Tag,
+    //     encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+    // ) -> Result<Self::Ok, Self::Error> {
+    //     // Create a buffer for encoding the choice
+    //     let mut buffer = Vec::new();
+
+    //     // Create a new encoder that borrows the buffer
+    //     let tag = {
+    //         let mut choice_encoder = Encoder::new(self.options.without_set_encoding(), &mut buffer);
+    //         encode_fn(&mut choice_encoder)?
+    //     }; // choice_encoder is dropped here, releasing the borrow on buffer
+
+    //     // Proceed with buffer after choice_encoder is dropped
+    //     self.process_buffer::<E>(tag, buffer)
+    // }
+
     fn encode_extension_addition<E: Encode>(
         &mut self,
         tag: Tag,
@@ -941,10 +1049,11 @@ impl crate::Encoder for Encoder {
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoder = Self::new(self.options.without_set_encoding());
         encoder.current_field_index = self.current_field_index;
-        encoder.field_bitfield = <_>::from([(
+        // encoder.field_bitfield :Map::<_, _, 100>;
+        _ = encoder.field_bitfield.insert(
             (self.current_field_index, tag),
             (FieldPresence::Optional, false),
-        )]);
+        );
         E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints)?;
         if encoder
             .field_bitfield

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -81,7 +81,6 @@ impl Default for Encoder<'_> {
 #[derive(Debug)]
 pub struct Encoder<'a> {
     options: EncoderOptions,
-    // output: Buffer<'a>,
     output: alloc::borrow::Cow<'a, RefCell<Vec<u8>>>,
     set_output: alloc::collections::BTreeMap<Tag, Vec<u8>>,
     // usize a.k.a. field index defines the order for Sequence

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -1,9 +1,7 @@
-use alloc::borrow::Cow;
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use bitvec::prelude::*;
 use core::cell::RefCell;
 use hashbrown::HashMap;
-// use heapless::LinearMap;
 use num_traits::ToPrimitive;
 
 use crate::{
@@ -88,7 +86,6 @@ pub struct Encoder<'a> {
     set_output: alloc::collections::BTreeMap<Tag, Vec<u8>>,
     // usize a.k.a. field index defines the order for Sequence
     field_bitfield: HashMap<(usize, Tag), (FieldPresence, bool)>,
-    // field_bitfield: LinearMap<(usize, Tag), (FieldPresence, bool), 5>,
     current_field_index: usize,
     extension_fields: Vec<Option<Vec<u8>>>,
     is_extension_sequence: bool,
@@ -118,8 +115,6 @@ impl<'a> Encoder<'a> {
             output: Cow::Owned(RefCell::new(Vec::with_capacity(32))),
             set_output: <_>::default(),
             field_bitfield: <_>::default(),
-            // field_bitfield: LinearMap::<_, _, 5>::default(),
-            // field_bitfield: <_>::default(),
             current_field_index: <_>::default(),
             extension_fields: <_>::default(),
             is_extension_sequence: bool::default(),
@@ -180,8 +175,6 @@ impl<'a> Encoder<'a> {
             self.current_field_index += 1;
         }
     }
-    // Take data as param, same as vec.extend()
-
     fn extend(&mut self, tag: Tag) -> Result<(), EncodeError> {
         if self.options.set_encoding {
             self.set_output
@@ -957,24 +950,6 @@ impl<'a> crate::Encoder for Encoder<'a> {
         self.extend(tag)?;
         Ok(())
     }
-    // fn encode_choice<'b, E: Encode + Choice>(
-    //     &mut self,
-    //     _: Constraints,
-    //     _tag: Tag,
-    //     encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
-    // ) -> Result<Self::Ok, Self::Error> {
-    //     // Create a buffer for encoding the choice
-    //     let mut buffer = Vec::new();
-
-    //     // Create a new encoder that borrows the buffer
-    //     let tag = {
-    //         let mut choice_encoder = Encoder::new(self.options.without_set_encoding(), &mut buffer);
-    //         encode_fn(&mut choice_encoder)?
-    //     }; // choice_encoder is dropped here, releasing the borrow on buffer
-
-    //     // Proceed with buffer after choice_encoder is dropped
-    //     self.process_buffer::<E>(tag, buffer)
-    // }
 
     fn encode_extension_addition<E: Encode>(
         &mut self,

--- a/src/types/fields.rs
+++ b/src/types/fields.rs
@@ -64,6 +64,12 @@ impl Fields {
     }
 }
 
+impl Default for Fields {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl From<Cow<'static, [Field]>> for Fields {
     fn from(fields: Cow<'static, [Field]>) -> Self {
         Self::new(fields)


### PR DESCRIPTION
Lack of pre-allocations and not using existing buffers created many unnecessary allocations.

This will reduces them a bit.
I trialed several data types for output buffer, and
```rust
output: alloc::borrow::Cow<'a, RefCell<Vec<u8>>>,
```

seems to be best. I tried sharing direct reference of `Vec<u8>` and also `Bytes/BytesMut`. 
Direct reference was too difficult to add since encoder uses itself recursively. `BytesMut` was much slower. Maybe this is okay for a while.

Now the buffer is re-used when possible. e.g. no length calculation requirement afterwards.

Current improvement based on the integer test:

<img width="864" alt="image" src="https://github.com/user-attachments/assets/0437ab4c-f676-4430-8dc6-2ac9ab743bff">

