### PR TITLE
docs: ObjectIdentifier::new: first arc may be 2

### DIFF
--- a/src/types/oid.rs
+++ b/src/types/oid.rs
@@ -177,7 +177,7 @@ impl ObjectIdentifier {
     /// Creates a new object identifier from `vec`.
     ///
     /// Returns `None` if `vec` contains less than two components or the first
-    /// component is greater than 1.
+    /// component is greater than 2.
     pub fn new(arcs: impl Into<alloc::borrow::Cow<'static, [u32]>>) -> Option<Self> {
         let arcs = arcs.into();
         is_valid_oid(&arcs).then_some(Self(arcs))


### PR DESCRIPTION
The first arc is limited to the values 0, 1 and 2, but the doc comment for ObjectIdentifier::new states that an OID is invalid if the first component is greater than 1. (All other instances of such a statement, found mostly around the Oid type, correctly mention 2 as the minimum.)