### PR TITLE
Use `OR` operator in Cargo.toml `license` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["fuzzing"]
 
 [workspace.package]
 edition = "2021"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 version = "0.18.0"
 repository = "https://github.com/librasn/rasn.git"
 

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["Erin Power <xampprocky@gmail.com>"]
 edition = "2018"
 description = "Something someday."
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [workspace]


### PR DESCRIPTION
The use of `/` is deprecated, per the Cargo reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields