### PR TITLE
Reroll back to BTreeMap

### DIFF
--- a/src/coer.rs
+++ b/src/coer.rs
@@ -990,6 +990,44 @@ mod tests {
             },
             &[0x80, 0xff, 0x02, 0x07, 0x80, 0x01, 0xff]
         );
+        #[derive(AsnType, Debug, Decode, Encode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[rasn(automatic_tags)]
+        #[non_exhaustive]
+        pub struct ExtendedOptional {
+            pub value: Integer,
+            pub integer1: Option<Integer>,
+            pub octet1: Option<OctetString>,
+            pub integer2: Option<Integer>,
+            pub octet2: Option<OctetString>,
+            pub integer3: Option<Integer>,
+            pub octet3: Option<OctetString>,
+            #[rasn(extension_addition)]
+            pub integer4: Option<Integer>,
+            #[rasn(extension_addition)]
+            pub octet4: Option<OctetString>,
+            #[rasn(extension_addition)]
+            pub integer5: Option<Integer>,
+            #[rasn(extension_addition)]
+            pub octet5: Option<OctetString>,
+        }
+        round_trip!(
+            coer,
+            ExtendedOptional,
+            ExtendedOptional {
+                value: 1.into(),
+                integer1: Some(1_230_066_625_199_609_624u64.into()),
+                octet1: None,
+                integer2: None,
+                octet2: None,
+                integer3: Some(1.into()),
+                octet3: None,
+                integer4: None,
+                octet4: None,
+                integer5: None,
+                octet5: None
+            },
+            &[68, 1, 1, 8, 17, 18, 19, 20, 21, 22, 23, 24, 1, 1]
+        );
     }
     #[test]
     fn test_sequence_of() {

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -1,9 +1,9 @@
 //! Encoding Rust structures into Octet Encoding Rules data.
 
+use alloc::collections::BTreeMap;
 use alloc::{borrow::Cow, vec::Vec};
 use bitvec::prelude::*;
 use core::cell::RefCell;
-use hashbrown::HashMap;
 use num_traits::ToPrimitive;
 
 use crate::{
@@ -66,7 +66,7 @@ pub struct Encoder<'a> {
     output: alloc::borrow::Cow<'a, RefCell<Vec<u8>>>,
     set_output: alloc::collections::BTreeMap<Tag, Vec<u8>>,
     // usize a.k.a. field index defines the order for Sequence
-    field_bitfield: HashMap<(usize, Tag), (FieldPresence, bool)>,
+    field_bitfield: BTreeMap<(usize, Tag), (FieldPresence, bool)>,
     current_field_index: usize,
     extension_fields: Vec<Option<Vec<u8>>>,
     is_extension_sequence: bool,

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1,7 +1,7 @@
 //! Encoding Rust structures into Packed Encoding Rules data.
 
+use alloc::collections::BTreeMap;
 use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
-use hashbrown::HashMap;
 
 use bitvec::prelude::*;
 
@@ -73,7 +73,7 @@ pub struct Encoder {
     output: BitString,
     set_output: alloc::collections::BTreeMap<Tag, BitString>,
     // usize a.k.a. field index defines the order for Sequence
-    field_bitfield: HashMap<(usize, Tag), (FieldPresence, bool)>,
+    field_bitfield: BTreeMap<(usize, Tag), (FieldPresence, bool)>,
     current_field_index: usize,
     extension_fields: Vec<Option<Vec<u8>>>,
     is_extension_sequence: bool,


### PR DESCRIPTION
Workaround until "final proper" solution for sequence/set field presence tracking is identified.