### PR TITLE
Fix most issues related to dependency update, except hashbrown version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
 name = "rasn-cms"
 version = "0.20.2"
 dependencies = [
+ "pretty_assertions",
  "rasn",
  "rasn-pkix",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,18 +396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "foldhash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,13 +430,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
+ "ahash",
  "allocator-api2",
- "equivalent",
- "foldhash",
 ]
 
 [[package]]
@@ -1213,6 +1212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,3 +1429,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ bitvec.workspace = true
 bytes = { version = "1.7.2", default-features = false }
 chrono.workspace = true
 either = { version = "1.13.0", default-features = false }
-# hashbrown = "0.14.5"
-hashbrown = "0.15"
+hashbrown = "0.14.5"
 konst = { version = "0.3.9", default-features = false }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 nom-bitvec = { package = "bitvec-nom2", version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,8 @@ bitvec.workspace = true
 bytes = { version = "1.7.2", default-features = false }
 chrono.workspace = true
 either = { version = "1.13.0", default-features = false }
-hashbrown = "0.15.0"
+# hashbrown = "0.14.5"
+hashbrown = "0.15"
 konst = { version = "0.3.9", default-features = false }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 nom-bitvec = { package = "bitvec-nom2", version = "0.2.1" }
@@ -82,7 +83,9 @@ once_cell = { version = "1.20.2", default-features = false, features = [
 ] }
 rasn-compiler = { version = "0.5.3", optional = true }
 rasn-derive = { version = "0.20", path = "macros", optional = true }
-snafu = { version = "0.8.5", default-features = false, features = ["rust_1_81"] }
+snafu = { version = "0.8.5", default-features = false, features = [
+    "rust_1_81",
+] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/types/constructed.rs
+++ b/src/types/constructed.rs
@@ -214,7 +214,7 @@ mod tests {
 
         assert_eq!(set_a, set_b);
         assert_ne!(set_a, set_c);
-        let hasher = hashbrown::DefaultHashBuilder::default();
+        let hasher = hashbrown::hash_map::DefaultHashBuilder::default();
         let hashed_a = hasher.hash_one(&set_a);
         let hashed_c = hasher.hash_one(set_c);
         assert_ne!(hashed_a, hashed_c);

--- a/standards/cbr/src/lib.rs
+++ b/standards/cbr/src/lib.rs
@@ -5,13 +5,13 @@ extern crate alloc;
 
 use rasn::prelude::*;
 
-pub const PAL_ZONE: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 2]);
-pub const PAL_FREQUENCY: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 3]);
-pub const CBSD_FCCID: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 4]);
-pub const CBSD_SERIAL: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 5]);
-pub const SAS_FRN: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 6]);
-pub const CPIR: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 7]);
-pub const TEST: &'static Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 8]);
+pub const PAL_ZONE: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 2]);
+pub const PAL_FREQUENCY: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 3]);
+pub const CBSD_FCCID: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 4]);
+pub const CBSD_SERIAL: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 5]);
+pub const SAS_FRN: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 6]);
+pub const CPIR: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 7]);
+pub const TEST: &Oid = Oid::const_new(&[1, 3, 6, 1, 4, 1, 46609, 1, 8]);
 
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
 #[rasn(delegate)]

--- a/standards/cms/Cargo.toml
+++ b/standards/cms/Cargo.toml
@@ -13,3 +13,6 @@ path = "../.."
 [dependencies.rasn-pkix]
 version = "0.20"
 path = "../pkix"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/standards/cms/tests/test_cms.rs
+++ b/standards/cms/tests/test_cms.rs
@@ -1,3 +1,4 @@
+use pretty_assertions::assert_eq;
 use rasn::der::{decode, encode};
 
 use rasn_cms::authenticode::{
@@ -15,7 +16,7 @@ fn test_cms_signed() {
     let info = decode::<ContentInfo>(SIGNED_DATA).unwrap();
     assert_eq!(CONTENT_SIGNED_DATA, info.content_type);
     let data = decode::<SignedData>(info.content.as_bytes()).unwrap();
-    println!("{:#?}", data);
+    // println!("{:#?}", data);
 
     assert_eq!(CONTENT_DATA, data.encap_content_info.content_type);
 

--- a/standards/cms/tests/test_cms.rs
+++ b/standards/cms/tests/test_cms.rs
@@ -16,7 +16,6 @@ fn test_cms_signed() {
     let info = decode::<ContentInfo>(SIGNED_DATA).unwrap();
     assert_eq!(CONTENT_SIGNED_DATA, info.content_type);
     let data = decode::<SignedData>(info.content.as_bytes()).unwrap();
-    // println!("{:#?}", data);
 
     assert_eq!(CONTENT_DATA, data.encap_content_info.content_type);
 
@@ -30,7 +29,6 @@ fn test_cms_encrypted() {
     let info = decode::<ContentInfo>(ENCRYPTED_DATA).unwrap();
     assert_eq!(CONTENT_ENVELOPED_DATA, info.content_type);
     let data = decode::<EnvelopedData>(info.content.as_bytes()).unwrap();
-    println!("{:#?}", data);
 
     assert_eq!(CONTENT_DATA, data.encrypted_content_info.content_type);
 

--- a/standards/pkix/src/est.rs
+++ b/standards/pkix/src/est.rs
@@ -36,6 +36,7 @@ pub struct Attribute {
 
 #[cfg(test)]
 mod tests {
+    use base64::prelude::{Engine as _, BASE64_STANDARD};
     use pretty_assertions::assert_eq;
 
     use alloc::{borrow::Cow, string::ToString, vec};
@@ -163,7 +164,7 @@ mod tests {
 
         let data_bin = rasn::der::encode(&data).unwrap();
         let txt = "MEEGCSqGSIb3DQEJBzASBgcqhkjOPQIBMQcGBSuBBAAiMBYGCSqGSIb3DQEJDjEJBgcrBgEBAQEWBggqhkjOPQQDAw==";
-        let bin = base64::decode(txt).unwrap();
+        let bin = BASE64_STANDARD.decode(txt).unwrap();
         assert_eq!(data_bin, bin);
         let decoded_data = rasn::der::decode::<CsrAttrs>(&bin);
         assert!(decoded_data.is_ok());
@@ -238,7 +239,7 @@ mod tests {
 
         let data_bin = rasn::der::encode(&data).unwrap();
         let txt = "MHwGBysGAQEBARYwIgYDiDcBMRsTGVBhcnNlIFNFVCBhcyAyLjk5OS4xIGRhdGEGCSqGSIb3DQEJBzAsBgOINwIxJQYDiDcDBgOINwQTGVBhcnNlIFNFVCBhcyAyLjk5OS4yIGRhdGEGCSskAwMCCAEBCwYJYIZIAWUDBAIC";
-        let bin = base64::decode(txt).unwrap();
+        let bin = BASE64_STANDARD.decode(txt).unwrap();
         assert_eq!(bin, data_bin);
         let decoded_data = rasn::der::decode::<CsrAttrs>(&bin);
         assert!(decoded_data.is_ok());

--- a/standards/pkix/tests/digicert.rs
+++ b/standards/pkix/tests/digicert.rs
@@ -7,9 +7,9 @@ use rasn_pkix::*;
 fn it_works() {
     let contents = pem::parse(include_bytes!("data/DigiCertAssuredIDTLSCA.crt.pem")).unwrap();
 
-    let cert: rasn_pkix::Certificate = rasn::der::decode(&contents.contents).unwrap();
+    let cert: rasn_pkix::Certificate = rasn::der::decode(contents.contents()).unwrap();
 
-    assert_eq!(contents.contents, rasn::der::encode(&cert).unwrap());
+    assert_eq!(contents.contents(), rasn::der::encode(&cert).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Fixes most of the issues related to dependency updates.
Could it be possible to do large changes in branch so that main does not end up into bad state?

`hashbrown` dependency update seems to break encoding of `BitString` type in BER for some standard tests, I don't know why yet. Should we downgrade that for now?

E.g. `cargo test -p rasn-cms --test test_cms test_cms_signed 1> error.log`

shows failures on `BitString` types only.

[error.log](https://github.com/user-attachments/files/17460949/error.log)



