### PR TITLE
BER: fix decoding of extended fields in sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cast"
@@ -1034,18 +1034,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "1ac55e59090389fb9f0dd9e0f3c09615afed1d19094284d0b200441f13550793"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -1009,8 +1009,6 @@ impl<'a> FieldConfig<'a> {
                             #tag,
                             <#ty as #crate_root::AsnType>::CONSTRAINTS) #or_else #handle_extension)
                     }
-
-                    // quote!(decoder.decode_explicit_prefix(#tag) #or_else)
                 }
                 (Some(false), Some(path), true) => {
                     quote!(

--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -916,17 +916,18 @@ impl<'a> FieldConfig<'a> {
                 self.constraints.has_constraints(),
             ) {
                 (Some(true), _, _) => {
-                    let or_else = if self.is_option_type() {
-                        quote!(.ok())
+                    if self.is_option_type() {
+                        quote!(
+                            decoder.decode_optional_with_explicit_prefix(#tag)?
+                        )
                     } else if self.is_default_type() {
-                        quote!(.ok().unwrap_or_else(#default_fn))
+                        quote!(
+                            decoder.decode_optional_with_explicit_prefix(#tag)?.unwrap_or_else(#default_fn)
+                        )
                     } else {
                         // False positive
-                        #[allow(clippy::redundant_clone)]
-                        or_else.clone()
-                    };
-
-                    quote!(decoder.decode_explicit_prefix(#tag) #or_else)
+                        quote!(decoder.decode_explicit_prefix(#tag) #or_else)
+                    }
                 }
                 (Some(false), Some(path), true) => {
                     quote!(
@@ -979,13 +980,63 @@ impl<'a> FieldConfig<'a> {
 
         if self.extension_addition {
             match (
+                (self.tag.is_some() || self.container_config.automatic_tags)
+                    .then(|| self.tag.as_ref().map_or(false, |tag| tag.is_explicit())),
                 self.default.as_ref().map(|path| {
                     path.as_ref()
                         .map_or(quote!(<_>::default), |path| quote!(#path))
                 }),
                 self.constraints.has_constraints(),
             ) {
-                (Some(path), true) => {
+                (Some(true), _, constraints) => {
+                    let or_else = if self.is_option_type() {
+                        quote!(.ok())
+                    } else if self.is_default_type() {
+                        quote!(.ok().unwrap_or_else(#default_fn))
+                    } else {
+                        // False positive
+                        #[allow(clippy::redundant_clone)]
+                        or_else.clone()
+                    };
+                    if constraints {
+                        quote!(
+                            decoder.decode_extension_addition_with_explicit_tag_and_constraints(
+                                #tag,
+                                <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(#constraints),
+                                ) #or_else #handle_extension)
+                    } else {
+                        quote!(decoder.decode_extension_addition_with_explicit_tag_and_constraints(
+                            #tag,
+                            <#ty as #crate_root::AsnType>::CONSTRAINTS) #or_else #handle_extension)
+                    }
+
+                    // quote!(decoder.decode_explicit_prefix(#tag) #or_else)
+                }
+                (Some(false), Some(path), true) => {
+                    quote!(
+                        decoder.decode_extension_addition_with_default_and_tag_and_constraints(
+                            #tag,
+                            #path,
+                            <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(#constraints),
+                        ) #or_else
+                    )
+                }
+                (Some(false), None, true) => {
+                    quote!(
+                        <_>::decode_extension_addition_with_tag_and_constraints(
+                            decoder,
+                            #tag,
+                            <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(#constraints),
+                        ) #or_else #handle_extension
+                    )
+                }
+                (Some(false), Some(path), false) => {
+                    quote!(decoder.decode_extension_addition_with_default_and_tag(#tag, #path) #or_else)
+                }
+                (Some(false), None, false) => {
+                    quote!(<_>::decode_extension_addition_with_tag(decoder, #tag) #or_else #handle_extension)
+                }
+                (None, Some(path), true) => {
                     quote!(
                         decoder.decode_extension_addition_with_default_and_constraints(
                             #path,
@@ -993,21 +1044,21 @@ impl<'a> FieldConfig<'a> {
                         ) #or_else
                     )
                 }
-                (Some(path), false) => {
+                (None, Some(path), false) => {
                     quote!(
                         decoder.decode_extension_addition_with_default(
                             #path,
                         ) #or_else
                     )
                 }
-                (None, true) => {
+                (None, None, true) => {
                     quote!(
                         decoder.decode_extension_addition_with_constraints(
                             <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(#constraints),
                         ) #or_else
                     )
                 }
-                (None, false) => {
+                (None, None, false) => {
                     quote! {
                         decoder.decode_extension_addition() #or_else #handle_extension
                     }

--- a/src/aper.rs
+++ b/src/aper.rs
@@ -489,6 +489,10 @@ mod tests {
         };
 
         let encoded = rasn::aper::encode(&connect_data).expect("failed to encode");
+        assert_eq!(
+            encoded,
+            vec![0x00, 0x05, 0x00, 0x14, 0x7C, 0x00, 0x01, 0x04, 0x00, 0x01, 0x02, 0x03]
+        );
         let _: ConnectData = rasn::aper::decode(&encoded).expect("failed to decode");
     }
 }

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -383,4 +383,24 @@ mod tests {
             &[0x1f, 0x1f, 0x08, 0x32, 0x30, 0x31, 0x32, 0x31, 0x32, 0x32, 0x31]
         );
     }
+    #[test]
+    fn test_extended_sequence() {
+        use crate as rasn;
+        use rasn::prelude::*;
+        #[derive(AsnType, Debug, Clone, Encode, Decode, PartialEq)]
+        #[rasn(automatic_tags)]
+        #[non_exhaustive]
+        pub struct ExtendedInteger {
+            #[rasn(extension_addition)]
+            pub extension: Option<u64>,
+        }
+        round_trip!(
+            ber,
+            ExtendedInteger,
+            ExtendedInteger {
+                extension: Some(42)
+            },
+            &[0x30, 0x03, 0x80, 0x01, 0x2A]
+        );
+    }
 }

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -402,5 +402,19 @@ mod tests {
             },
             &[0x30, 0x03, 0x80, 0x01, 0x2A]
         );
+        #[derive(AsnType, Debug, Clone, Encode, Decode, PartialEq)]
+        #[non_exhaustive]
+        pub struct ExtendedExplicitInteger {
+            #[rasn(extension_addition)]
+            #[rasn(tag(explicit(5)))]
+            pub extension: u64,
+        }
+
+        round_trip!(
+            ber,
+            ExtendedExplicitInteger,
+            ExtendedExplicitInteger { extension: 42 },
+            &[0x30, 0x05, 0xA5, 0x03, 0x02, 0x01, 0x2A]
+        );
     }
 }

--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -652,7 +652,7 @@ impl crate::Decoder for Decoder<'_> {
             // If there are no fields, or the input is empty and we know that
             // all fields are optional or default fields, we call the default
             // initializer and skip calling the decode function at all.
-            if D::FIELDS.is_empty()
+            if D::FIELDS.is_empty() && D::EXTENDED_FIELDS.is_none()
                 || (D::FIELDS.len() == D::FIELDS.number_of_optional_and_default_fields()
                     && decoder.input.is_empty())
             {

--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -671,6 +671,14 @@ impl crate::Decoder for Decoder<'_> {
     fn decode_explicit_prefix<D: Decode>(&mut self, tag: Tag) -> Result<D> {
         self.parse_constructed_contents(tag, false, D::decode)
     }
+    fn decode_optional_with_explicit_prefix<D: Decode>(
+        &mut self,
+        tag: Tag,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_explicit_prefix(tag)
+            .map(Some)
+            .or_else(|_| Ok(None))
+    }
 
     fn decode_set<FIELDS, SET, D, F>(
         &mut self,
@@ -736,15 +744,27 @@ impl crate::Decoder for Decoder<'_> {
         D::from_tag(self, identifier.tag)
     }
 
-    fn decode_extension_addition_with_constraints<D>(
+    fn decode_extension_addition_with_explicit_tag_and_constraints<D>(
         &mut self,
+        tag: Tag,
+        _constraints: Constraints,
+    ) -> core::result::Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_explicit_prefix(tag).map(Some)
+    }
+
+    fn decode_extension_addition_with_tag_and_constraints<D>(
+        &mut self,
+        tag: Tag,
         // Constraints are irrelevant using BER
         _: Constraints,
     ) -> core::result::Result<Option<D>, Self::Error>
     where
         D: Decode,
     {
-        <Option<D>>::decode(self)
+        <Option<D>>::decode_with_tag(self, tag)
     }
 
     fn decode_extension_addition_group<D: Decode + crate::types::Constructed>(

--- a/src/ber/de/parser.rs
+++ b/src/ber/de/parser.rs
@@ -21,11 +21,7 @@ pub(crate) fn parse_value<'input>(
     })?;
 
     if let Some(tag) = tag {
-        // When decoding extended field, the implicit/explicit tag value is not carried and we will likely fail here
-        // if we assert all tag classes.
-        if tag.class != Class::Universal {
-            BerDecodeErrorKind::assert_tag(tag, identifier.tag)?;
-        }
+        BerDecodeErrorKind::assert_tag(tag, identifier.tag)?;
     }
 
     let (input, contents) = parse_contents(config, identifier, input)

--- a/src/ber/de/parser.rs
+++ b/src/ber/de/parser.rs
@@ -21,7 +21,11 @@ pub(crate) fn parse_value<'input>(
     })?;
 
     if let Some(tag) = tag {
-        BerDecodeErrorKind::assert_tag(tag, identifier.tag)?;
+        // When decoding extended field, the implicit/explicit tag value is not carried and we will likely fail here
+        // if we assert all tag classes.
+        if tag.class != Class::Universal {
+            BerDecodeErrorKind::assert_tag(tag, identifier.tag)?;
+        }
     }
 
     let (input, contents) = parse_contents(config, identifier, input)

--- a/src/coer.rs
+++ b/src/coer.rs
@@ -1296,6 +1296,26 @@ mod tests {
             },
             &[0b10000000, 0x01, 0x01, 0x03, 0x01, 0x02, 0x03]
         );
+
+        #[derive(AsnType, Decode, Encode, Clone, Debug, PartialEq, Eq)]
+        pub struct SequenceOptionalsExplicit {
+            #[rasn(tag(explicit(0)))]
+            pub it: Integer,
+            #[rasn(tag(explicit(1)))]
+            pub is: Option<OctetString>,
+            #[rasn(tag(explicit(2)))]
+            pub late: Option<Integer>,
+        }
+        round_trip!(
+            coer,
+            SequenceOptionalsExplicit,
+            SequenceOptionalsExplicit {
+                it: 42.into(),
+                is: None,
+                late: None
+            },
+            &[0, 1, 42]
+        );
         #[derive(AsnType, Decode, Encode, Clone, Debug, PartialEq, Eq)]
         #[non_exhaustive]
         pub struct SequenceDuplicatesExtended {

--- a/src/de.rs
+++ b/src/de.rs
@@ -297,8 +297,6 @@ pub trait Decoder: Sized {
     where
         D: Decode;
 
-    /// Decode an optional extension addition with explicit tag in a `SEQUENCE` or `SET`.
-
     /// Decode an extension addition value with tag in a `SEQUENCE` or `SET`.
     fn decode_extension_addition_with_tag<D>(&mut self, tag: Tag) -> Result<Option<D>, Self::Error>
     where

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -293,6 +293,12 @@ impl crate::Decoder for Decoder {
                 )
             })
     }
+    fn decode_optional_with_explicit_prefix<D: Decode>(
+        &mut self,
+        _: Tag,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
 
     fn decode_explicit_prefix<D: crate::Decode>(&mut self, _t: Tag) -> Result<D, Self::Error> {
         D::decode(self)
@@ -395,8 +401,20 @@ impl crate::Decoder for Decoder {
         self.decode_optional()
     }
 
-    fn decode_extension_addition_with_constraints<D>(
+    fn decode_extension_addition_with_explicit_tag_and_constraints<D>(
         &mut self,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> core::result::Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_extension_addition_with_tag_and_constraints::<D>(tag, constraints)
+    }
+
+    fn decode_extension_addition_with_tag_and_constraints<D>(
+        &mut self,
+        _: Tag,
         _: Constraints,
     ) -> Result<Option<D>, Self::Error>
     where

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -771,9 +771,20 @@ impl crate::Decoder for Decoder<'_> {
     ) -> Result<BmpString, Self::Error> {
         self.parse_known_multiplier_string(&constraints)
     }
+    fn decode_optional_with_explicit_prefix<D: Decode>(
+        &mut self,
+        tag: Tag,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional_with_tag(tag)
+    }
 
-    fn decode_explicit_prefix<D: Decode>(&mut self, _tag: Tag) -> Result<D, Self::Error> {
-        D::decode(self)
+    fn decode_explicit_prefix<D: Decode>(&mut self, tag: Tag) -> Result<D, Self::Error> {
+        // Whether we have a choice here
+        if D::TAG == Tag::EOC {
+            D::decode(self)
+        } else {
+            D::decode_with_tag(self, tag)
+        }
     }
 
     fn decode_utc_time(&mut self, tag: Tag) -> Result<UtcTime, Self::Error> {
@@ -938,9 +949,20 @@ impl crate::Decoder for Decoder<'_> {
             Ok(None)
         }
     }
-
-    fn decode_extension_addition_with_constraints<D>(
+    fn decode_extension_addition_with_explicit_tag_and_constraints<D>(
         &mut self,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_extension_addition_with_tag_and_constraints::<D>(tag, constraints)
+    }
+
+    fn decode_extension_addition_with_tag_and_constraints<D>(
+        &mut self,
+        _tag: Tag,
         constraints: Constraints,
     ) -> Result<Option<D>, Self::Error>
     where

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -872,12 +872,9 @@ impl crate::Encoder for Encoder<'_> {
         tag: Tag,
         value: &V,
     ) -> Result<Self::Ok, Self::Error> {
-        if let Some((_, true)) = self.field_bitfield.get(&(self.current_field_index, tag)) {
-            value.encode(self)
-        } else if !self
-            .field_bitfield
-            .contains_key(&(self.current_field_index, tag))
-        {
+        // Whether we have a choice type being encoded
+        if V::TAG == Tag::EOC {
+            self.set_bit(tag, true);
             value.encode(self)
         } else {
             self.set_bit(tag, true);

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -880,9 +880,20 @@ impl crate::Decoder for Decoder<'_> {
 
         Ok(value)
     }
+    fn decode_optional_with_explicit_prefix<D: Decode>(
+        &mut self,
+        tag: Tag,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional_with_tag(tag)
+    }
 
-    fn decode_explicit_prefix<D: Decode>(&mut self, _: Tag) -> Result<D> {
-        D::decode(self)
+    fn decode_explicit_prefix<D: Decode>(&mut self, tag: Tag) -> Result<D> {
+        // Whether we have a choice here
+        if D::TAG == Tag::EOC {
+            D::decode(self)
+        } else {
+            D::decode_with_tag(self, tag)
+        }
     }
 
     fn decode_set<FIELDS, SET, D, F>(
@@ -1066,8 +1077,20 @@ impl crate::Decoder for Decoder<'_> {
         D::decode(&mut decoder).map(Some)
     }
 
-    fn decode_extension_addition_with_constraints<D>(
+    fn decode_extension_addition_with_explicit_tag_and_constraints<D>(
         &mut self,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> core::result::Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_extension_addition_with_tag_and_constraints::<D>(tag, constraints)
+    }
+
+    fn decode_extension_addition_with_tag_and_constraints<D>(
+        &mut self,
+        _: Tag,
         constraints: Constraints,
     ) -> core::result::Result<Option<D>, Self::Error>
     where

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1082,14 +1082,8 @@ impl crate::Encoder for Encoder {
         tag: Tag,
         value: &V,
     ) -> Result<Self::Ok, Self::Error> {
-        if let Some((_, true)) = self.field_bitfield.get(&(self.current_field_index, tag)) {
-            value.encode(self)
-        } else if !self
-            .field_bitfield
-            .contains_key(&(self.current_field_index, tag))
-        {
-            // There is no bitfield if none of the parent objects is struct/set
-            // But we still need to handle nested choices explicitly
+        if V::TAG == Tag::EOC {
+            self.set_bit(tag, true)?;
             value.encode(self)
         } else {
             self.set_bit(tag, true)?;


### PR DESCRIPTION
BER currently does not handle the decoding of extended fields correctly.

* If there are no root components in sequence, field decoding is skipped
* Value of the explicit/implict tag is not carried (macros are not generating it for `decode_extension_addition` and function does not have the parameter), so assert of tag value will fail later in 

https://github.com/librasn/rasn/blob/d1208daf6f818226c185ce0d3fb51a23c3708081/src/ber/de/parser.rs#L23-L25

I am not sure if it is possible to fix without major changes or complete removal of the assert, so I just changed assert to apply for non-universal tags.

Maybe cargo.lock update fixes the main as well?