### PR TITLE
Disallow structs without fields for a `set`

### DIFF
--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -1223,7 +1223,8 @@ impl StringValue {
             let string = if content.peek(syn::LitStr) {
                 content.parse::<syn::LitStr>()?.value()
             } else if content.peek(syn::Ident) {
-                panic!("StringValue2: {:?}", content);
+                let path: syn::Path = content.parse()?;
+                path.require_ident()?.to_string()
             } else {
                 panic!("StringValue Unsupported meta item: {:?}", content);
             };

--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -43,6 +43,9 @@ pub fn derive_struct_impl(
             }
         }
     } else if config.set {
+        if container.fields.is_empty() {
+            panic!("`struct`s without any fields are not currently supported as `set`s.")
+        }
         let field_names = container.fields.iter().map(|field| field.ident.clone());
         let field_names2 = field_names.clone();
         let required_field_names = container


### PR DESCRIPTION
Also fix an oversight from the syn2 migration that wasn't caught in the testcases.