### PR TITLE
bench: run x509 benches only on x86_64 or aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ iai = "0.1.1"
 once_cell = "1.20.2"
 pretty_assertions.workspace = true
 rasn-pkix = { path = "standards/pkix" }
+
+# Assume that we need these dependencies only when benching manually on specific targets
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dev-dependencies]
 rustls-webpki = "0.102.8"
 x509-cert = "0.2.5"
 x509-certificate = "0.23.1"

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -19,9 +19,10 @@ fn rasn(c: &mut Criterion) {
         }}
     }
 
-    bench_encoding_rules!(ber, der, cer, uper);
+    bench_encoding_rules!(ber, der, cer, uper, oer);
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn x509(c: &mut Criterion) {
     let data: &[u8] = include_bytes!("../standards/pkix/tests/data/letsencrypt-x3.crt");
     let mut group = c.benchmark_group("X.509");
@@ -29,7 +30,13 @@ fn x509(c: &mut Criterion) {
         b.iter(|| black_box(rasn::der::decode::<rasn_pkix::Certificate>(data).unwrap()))
     });
     group.bench_function("x509-parser", |b| {
-        b.iter(|| black_box(<x509_parser::certificate::X509Certificate as x509_parser::prelude::FromDer<x509_parser::error::X509Error>>::from_der(data)))
+        b.iter(|| {
+            black_box(
+                <x509_parser::certificate::X509Certificate as x509_parser::prelude::FromDer<
+                    x509_parser::error::X509Error,
+                >>::from_der(data),
+            )
+        })
     });
     group.bench_function("x509-cert", |b| {
         b.iter(|| black_box(<x509_cert::Certificate as x509_cert::der::Decode>::from_der(data)))
@@ -40,5 +47,9 @@ fn x509(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 criterion_group!(codec, x509, rasn);
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+criterion_group!(codec, rasn);
 criterion_main!(codec);


### PR DESCRIPTION
Maybe it is okay to assume that x509 benches are only needed on `aarch64` and `x86_64`.