### PR TITLE
Update from iai to iai-callgrind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,10 +538,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "iai"
-version = "0.1.1"
+name = "iai-callgrind"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
+checksum = "22275f8051874cd2f05b2aa1e0098d5cbec34df30ff92f1a1e2686a4cefed870"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e6677dc52bd798b988e62ffd6831bf7eb46e4348cb1c74c1164954ebd0e5a1"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02dd95fe4949513b45a328b5b18f527ee02e96f3428b48090aa7cf9043ab0b8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -821,6 +880,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,7 +946,7 @@ dependencies = [
  "criterion",
  "either",
  "hashbrown",
- "iai",
+ "iai-callgrind",
  "konst",
  "nom",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
-iai = "0.1.1"
+iai-callgrind = "0.14.0"
 once_cell = "1.20.2"
 pretty_assertions.workspace = true
 rasn-pkix = { path = "standards/pkix" }

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -2,15 +2,20 @@ mod common;
 
 use common::*;
 
+use iai_callgrind::{main, library_benchmark_group, library_benchmark};
+use std::hint::black_box;
+
 macro_rules! encoding_rules {
     ($($encoding: ident ($encoding_fn:ident, $decoding_fn:ident)),+ $(,)?) => {
         $(
+            #[library_benchmark]
             fn $encoding_fn() {
-                let data = iai::black_box(bench_default());
+                let data = black_box(bench_default());
 
                 rasn::$encoding::encode(&data).unwrap();
             }
 
+            #[library_benchmark]
             fn $decoding_fn() {
                 use once_cell::sync::Lazy;
 
@@ -23,7 +28,9 @@ macro_rules! encoding_rules {
 
         )+
 
-        iai::main!{$($encoding_fn, $decoding_fn),+}
+        library_benchmark_group!(name = encode; benchmarks = $($encoding_fn),+);
+        library_benchmark_group!(name = decode; benchmarks = $($decoding_fn),+);
+        main!(library_benchmark_groups = encode, decode);
     }
 }
 


### PR DESCRIPTION
This requires the iai-callgrind-runner binary to be installed (possible via cargo install), but has the advantage of working with a recent valgrind version (iai seems to be unmaintained for the past years).