### PR TITLE
Remove dependency on rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,6 @@ dependencies = [
  "once_cell",
  "oorandom",
  "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -330,31 +329,6 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -1070,26 +1044,6 @@ dependencies = [
  "pretty_assertions",
  "rasn",
  "rasn-smi",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ snafu = { version = "0.8.5", default-features = false, features = [
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support"] }
 iai-callgrind = "0.14.0"
 once_cell = "1.20.2"
 pretty_assertions.workspace = true


### PR DESCRIPTION
Fixes #359

As discussed in that issue, removes rayon from the dependencies, making the crate a little more lightweight to install.