### PR TITLE
Attempt to fix base benchmarks on CI

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main
       - run: cargo install iai-callgrind-runner@0.14.0
+      - run: sudo apt update && sudo apt install -y valgrind
       - name: Track base branch benchmarks with Bencher
         run: |
           bencher run \


### PR DESCRIPTION
This should install valgrind, which iai and iai-callgrind need to run.