### PR TITLE
fix: split iai and criterion benches, use correct adapters

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: bencherdev/bencher@main
       - run: cargo install iai-callgrind-runner@0.14.0
       - run: sudo apt update && sudo apt install -y valgrind
-      - name: Track base branch benchmarks with Bencher
+      - name: Track base branch IAI benchmarks with Bencher
         run: |
           bencher run \
           --project rasn \
@@ -26,6 +26,23 @@ jobs:
           --threshold-upper-boundary 0.99 \
           --thresholds-reset \
           --err \
-          --adapter json \
+          --adapter rust_iai_callgrind \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          cargo bench --bench iai
+
+      - name: Track base branch criterion benchmarks with Bencher
+        run: |
+          bencher run \
+          --project rasn \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch main \
+          --testbed ubuntu-latest \
+          --threshold-measure latency \
+          --threshold-test t_test \
+          --threshold-max-sample-size 64 \
+          --threshold-upper-boundary 0.99 \
+          --thresholds-reset \
+          --err \
+          --adapter rust_criterion \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           cargo bench

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ test = true
 name = "iai"
 path = "benches/iai.rs"
 harness = false
+bench = false
 
 [[bench]]
 name = "criterion_integer"


### PR DESCRIPTION
One attempt more to see if benches work. After there is some historical data, we can change this to apply all PRs?