### PR TITLE
OER: no more BitSlice for general parsing

### DIFF
--- a/src/coer.rs
+++ b/src/coer.rs
@@ -9,10 +9,7 @@ use crate::types::Constraints;
 /// # Errors
 /// Returns `DecodeError` if `input` is not valid COER encoding specific to the expected type.
 pub fn decode<T: crate::Decode>(input: &[u8]) -> Result<T, DecodeError> {
-    T::decode(&mut Decoder::<0, 0>::new(
-        crate::types::BitStr::from_slice(input),
-        de::DecoderOptions::coer(),
-    ))
+    T::decode(&mut Decoder::<0, 0>::new(input, de::DecoderOptions::coer()))
 }
 /// Attempts to encode `value` of type `T` to COER.
 ///
@@ -33,10 +30,7 @@ pub fn decode_with_constraints<T: crate::Decode>(
     input: &[u8],
 ) -> Result<T, DecodeError> {
     T::decode_with_constraints(
-        &mut Decoder::<0, 0>::new(
-            crate::types::BitStr::from_slice(input),
-            de::DecoderOptions::coer(),
-        ),
+        &mut Decoder::<0, 0>::new(input, de::DecoderOptions::coer()),
         constraints,
     )
 }

--- a/src/oer.rs
+++ b/src/oer.rs
@@ -13,10 +13,7 @@ use crate::types::Constraints;
 /// # Errors
 /// Returns `DecodeError` if `input` is not valid OER encoding specific to the expected type.
 pub fn decode<T: crate::Decode>(input: &[u8]) -> Result<T, DecodeError> {
-    T::decode(&mut Decoder::<0, 0>::new(
-        crate::types::BitStr::from_slice(input),
-        de::DecoderOptions::oer(),
-    ))
+    T::decode(&mut Decoder::<0, 0>::new(input, de::DecoderOptions::oer()))
 }
 /// Attempts to encode `value` of type `T` to OER.
 ///
@@ -38,10 +35,7 @@ pub fn decode_with_constraints<T: crate::Decode>(
     input: &[u8],
 ) -> Result<T, DecodeError> {
     T::decode_with_constraints(
-        &mut Decoder::<0, 0>::new(
-            crate::types::BitStr::from_slice(input),
-            de::DecoderOptions::oer(),
-        ),
+        &mut Decoder::<0, 0>::new(input, de::DecoderOptions::oer()),
         constraints,
     )
 }


### PR DESCRIPTION
Apparetly using `nom_bitvec` for parsing the input in OER was significantly slower, at least on my usage.

This changes OER to parse `&[u8]` in general.

<img width="767" alt="image" src="https://github.com/user-attachments/assets/c619ea02-4262-4a7e-b481-af123899413f">
