### PR TITLE
OER: remove nom usage, improve errors

### DIFF
--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -339,7 +339,7 @@ impl Config {
     }
 
     pub fn has_explicit_tag(&self) -> bool {
-        self.tag.as_ref().map_or(false, |tag| tag.is_explicit())
+        self.tag.as_ref().is_some_and(|tag| tag.is_explicit())
     }
 
     pub fn tag_for_struct(&self, fields: &syn::Fields) -> proc_macro2::TokenStream {
@@ -369,7 +369,7 @@ pub(crate) fn is_option_type(ty: &syn::Type) -> bool {
             .path
             .segments
             .last()
-            .map_or(false, |segment| segment.ident == "Option"),
+            .is_some_and(|segment| segment.ident == "Option"),
         syn::Type::Reference(syn::TypeReference { elem, .. }) => is_option_type(elem),
         _ => false,
     }
@@ -496,7 +496,7 @@ impl<'config> VariantConfig<'config> {
     }
 
     pub fn has_explicit_tag(&self) -> bool {
-        self.tag.as_ref().map_or(false, |tag| tag.is_explicit())
+        self.tag.as_ref().is_some_and(|tag| tag.is_explicit())
     }
 
     pub fn decode(&self, name: &syn::Ident, context: usize) -> proc_macro2::TokenStream {
@@ -806,7 +806,7 @@ impl<'a> FieldConfig<'a> {
         };
 
         let encode = if self.tag.is_some() || self.container_config.automatic_tags {
-            if self.tag.as_ref().map_or(false, |tag| tag.is_explicit()) {
+            if self.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
                 // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
                 quote!(encoder.encode_explicit_prefix(#tag, &self.#field)?;)
             } else if self.extension_addition {
@@ -964,7 +964,7 @@ impl<'a> FieldConfig<'a> {
         } else {
             match (
                 (self.tag.is_some() || self.container_config.automatic_tags)
-                    .then(|| self.tag.as_ref().map_or(false, |tag| tag.is_explicit())),
+                    .then(|| self.tag.as_ref().is_some_and(|tag| tag.is_explicit())),
                 self.default.as_ref().map(|path| {
                     path.as_ref()
                         .map_or(quote!(<_>::default), |path| quote!(#path))
@@ -1041,7 +1041,7 @@ impl<'a> FieldConfig<'a> {
         if self.extension_addition {
             match (
                 (self.tag.is_some() || self.container_config.automatic_tags)
-                    .then(|| self.tag.as_ref().map_or(false, |tag| tag.is_explicit())),
+                    .then(|| self.tag.as_ref().is_some_and(|tag| tag.is_explicit())),
                 self.default.as_ref().map(|path| {
                     path.as_ref()
                         .map_or(quote!(<_>::default), |path| quote!(#path))

--- a/macros/macros_impl/src/decode.rs
+++ b/macros/macros_impl/src/decode.rs
@@ -262,7 +262,7 @@ pub fn derive_struct_impl(
     };
 
     let decode_impl =
-        if !config.delegate && config.tag.as_ref().map_or(false, |tag| tag.is_explicit()) {
+        if !config.delegate && config.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
             let tag = config.tag_for_struct(&container.fields);
             map_from_inner_type(
                 tag,

--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -91,7 +91,7 @@ pub fn derive_struct_impl(
             }).map(drop)
         };
 
-        if config.tag.as_ref().map_or(false, |tag| tag.is_explicit()) {
+        if config.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
             map_to_inner_type(
                 config.tag.clone().unwrap(),
                 &name,

--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -203,7 +203,7 @@ impl<'input> Decoder<'input> {
             && string
                 .chars()
                 .nth(len - 5)
-                .map_or(false, |c| c == '+' || c == '-')
+                .is_some_and(|c| c == '+' || c == '-')
         {
             let naive = parse_without_timezone(&string[..len - 5])?;
             let sign = match string.chars().nth(len - 5) {

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -98,10 +98,7 @@ impl crate::Encoder<'_> for Encoder {
                 acc.push_str(&alloc::format!("{bit:02X?}"));
                 acc
             });
-        let json_value = if constraints
-            .size()
-            .map_or(false, |s| s.constraint.is_fixed())
-        {
+        let json_value = if constraints.size().is_some_and(|s| s.constraint.is_fixed()) {
             Value::String(bytes)
         } else {
             let mut value_map = ValueMap::new();

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -561,7 +561,7 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
             total_length += length;
             if constraints
                 .permitted_alphabet()
-                .map_or(false, |alphabet| alphabet.constraint.len() == 1)
+                .is_some_and(|alphabet| alphabet.constraint.len() == 1)
             {
                 return Ok(input);
             }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -233,7 +233,7 @@ impl<const RCL: usize, const ECL: usize> Encoder<RCL, ECL> {
         let string_length = value.len();
 
         let is_extended_value = self.encode_extensible_bit(constraints, &mut buffer, || {
-            constraints.size().map_or(false, |size_constraint| {
+            constraints.size().is_some_and(|size_constraint| {
                 size_constraint.extensible.is_some()
                     && size_constraint.constraint.contains(&string_length)
             })
@@ -598,7 +598,7 @@ impl<const RCL: usize, const ECL: usize> Encoder<RCL, ECL> {
     ) -> Result<()> {
         let octet_string_length = value.len();
         let extensible_is_present = self.encode_extensible_bit(&constraints, buffer, || {
-            constraints.size().map_or(false, |size_constraint| {
+            constraints.size().is_some_and(|size_constraint| {
                 size_constraint.extensible.is_some()
                     && size_constraint.constraint.contains(&octet_string_length)
             })
@@ -640,7 +640,7 @@ impl<const RCL: usize, const ECL: usize> Encoder<RCL, ECL> {
         buffer: &mut BitString,
     ) -> Result<()> {
         let is_extended_value = self.encode_extensible_bit(&constraints, buffer, || {
-            constraints.value().map_or(false, |value_range| {
+            constraints.value().is_some_and(|value_range| {
                 value_range.extensible.is_some() && value_range.constraint.in_bound(value)
             })
         });
@@ -801,7 +801,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         let mut buffer = BitString::default();
         let bit_string_length = value.len();
         let extensible_is_present = self.encode_extensible_bit(&constraints, &mut buffer, || {
-            constraints.size().map_or(false, |size_constraint| {
+            constraints.size().is_some_and(|size_constraint| {
                 size_constraint.extensible.is_some()
                     && size_constraint.constraint.contains(&bit_string_length)
             })
@@ -814,7 +814,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
             })?;
         } else if size.and_then(|size| size.constraint.range()) == Some(0) {
             // NO-OP
-        } else if size.map_or(false, |size| {
+        } else if size.is_some_and(|size| {
             size.constraint.range() == Some(1) && size.constraint.as_start() <= Some(&16)
         }) {
             // ITU-T X.691 (02/2021) §16: Bitstrings constrained to a fixed length less than or equal to 16 bits
@@ -1017,7 +1017,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         let options = self.options;
 
         self.encode_extensible_bit(&constraints, &mut buffer, || {
-            constraints.size().map_or(false, |size_constraint| {
+            constraints.size().is_some_and(|size_constraint| {
                 size_constraint.extensible.is_some()
                     && size_constraint.constraint.contains(&values.len())
             })

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,7 +129,7 @@ pub trait Enumerated: Sized + 'static + PartialEq + Copy + core::fmt::Debug {
 
     /// Whether `self` is a variant contained in `Self::EXTENDED_VARIANTS`.
     fn is_extended_variant(&self) -> bool {
-        Self::EXTENDED_VARIANTS.map_or(false, |array| array.iter().any(|variant| variant == self))
+        Self::EXTENDED_VARIANTS.is_some_and(|array| array.iter().any(|variant| variant == self))
     }
 
     /// Returns the enumeration for the variant, if it's an extended variant

--- a/standards/cdt/src/lib.rs
+++ b/standards/cdt/src/lib.rs
@@ -11,7 +11,6 @@ pub struct AlgorithmIdShortForm(pub Integer);
 
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
 #[rasn(delegate)]
-
 pub struct CompressedContent(pub OctetString);
 
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]

--- a/standards/mib/src/lib.rs
+++ b/standards/mib/src/lib.rs
@@ -190,7 +190,6 @@ pub mod system {
 /// The Interfaces Group
 ///
 /// Implementation of the Interfaces group is mandatory for all systems.
-
 pub mod interfaces {
     use super::*;
 


### PR DESCRIPTION
OER decoding has simplified a bit and we can actually just remove `nom` usage completely.
This improves error messages slightly as well at the same time, and move some historical constants. 