### PR TITLE
OER: Add `decode_with_remainder` for decoding stream

### DIFF
--- a/src/oer.rs
+++ b/src/oer.rs
@@ -15,6 +15,16 @@ use crate::types::Constraints;
 pub fn decode<T: crate::Decode>(input: &[u8]) -> Result<T, DecodeError> {
     T::decode(&mut Decoder::<0, 0>::new(input, de::DecoderOptions::oer()))
 }
+
+/// Attempts to decode `T` from `input` using OER. Returns both `T` and reference to the remainder of the input.
+///
+/// # Errors
+/// Returns `DecodeError` if `input` is not valid OER encoding specific to the expected type.
+pub fn decode_with_remainder<T: crate::Decode>(input: &[u8]) -> Result<(T, &[u8]), DecodeError> {
+    let decoder = &mut Decoder::<0, 0>::new(input, de::DecoderOptions::oer());
+    let decoded = T::decode(decoder)?;
+    Ok((decoded, decoder.remaining()))
+}
 /// Attempts to encode `value` of type `T` to OER.
 ///
 /// # Errors

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -85,6 +85,11 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
     fn codec(&self) -> Codec {
         self.options.current_codec()
     }
+    /// Returns reference to the remaining input data that has not been parsed.
+    #[must_use]
+    pub fn remaining(&self) -> &'input [u8] {
+        self.input
+    }
 
     fn parse_one_byte(&mut self) -> Result<u8, DecodeError> {
         let (first, rest) = self.input.split_first().ok_or_else(|| {


### PR DESCRIPTION
Currently decoding a stream is a bit cumbersome. Since we pass slices as reference, we don't consume the data. 

Maybe we can have a high level `decode_with_remainder` function that returns the type and reference to the remaining slice. Similar approach should work for other codecs too. 