### PR TITLE
perf: oer: format! in error messages causes allocation

### DIFF
--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -518,9 +518,9 @@ pub enum DecodeErrorKind {
     },
 
     /// Input is provided as BIT slice for nom in UPER/APER.
-    /// On BER/CER/DER it is as BYTE slice.
+    /// On BER/CER/DER/OER/COER it is a BYTE slice.
     /// Hence, `needed` field can describe either bits or bytes depending on the codec.
-    #[snafu(display("Need more BITS to continue: ({:?}).", needed))]
+    #[snafu(display("Need more data to continue: ({:?}).", needed))]
     Incomplete {
         /// Amount of bits/bytes needed.
         needed: nom::Needed,

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -11,7 +11,11 @@ use alloc::{
     vec::Vec,
 };
 
+use core::num::NonZeroUsize;
+use nom::Needed;
+
 use crate::{
+    de::{Decode, Error as _},
     oer::EncodingRules,
     types::{
         self,
@@ -20,7 +24,7 @@ use crate::{
         GeneralString, GeneralizedTime, Ia5String, IntegerType, NumericString, ObjectIdentifier,
         PrintableString, SetOf, Tag, TeletexString, UtcTime, VisibleString,
     },
-    Codec, Decode,
+    Codec,
 };
 
 use bitvec::{order::Msb0, view::BitView};
@@ -185,7 +189,6 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
     }
 
     /// Extracts data from input by length and updates the input
-    /// Since we rely on memory and `BitSlice`, we cannot handle larger data length than `0x1fff_ffff_ffff_ffff`
     /// 'length' is the length of the data in bytes (octets)
     /// Returns the data
     fn extract_data_by_length(&mut self, length: usize) -> Result<&'input [u8], DecodeError> {
@@ -193,11 +196,8 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
             return Ok(&[]);
         }
         let (data, rest) = self.input.split_at_checked(length).ok_or_else(|| {
-            DecodeError::parser_fail(
-                alloc::format!(
-                    "Unexpected end of data when parsing &[u8] with length {}",
-                    length
-                ),
+            DecodeError::incomplete(
+                Needed::Size(NonZeroUsize::new(length - self.input.len()).unwrap()),
                 self.codec(),
             )
         })?;


### PR DESCRIPTION
Use of format! in error message seemed to introduce allocation regardless whether error happened or not, and it was also in lazily evaluated context, so this is a bit odd.

Allocation does not happen if it is defined in snafu(display())

We likely need to measure impact of every error message then at some point...  

I changed the error for OER in one place since it is in critical place. 