### PR TITLE
docs: fix accidental double backtick in `Integer` docs

### DIFF
--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_traits::{identities::Zero, Signed, ToBytes, ToPrimitive};
 use num_traits::{CheckedAdd, CheckedSub};
 
-/// `Integer`` enum is variable-sized non-constrained integer type which uses `isize` for lower values to optimize performance.
+/// `Integer` enum is variable-sized non-constrained integer type which uses [`isize`] for lower values to optimize performance.
 #[derive(Debug, Clone, Ord, PartialOrd)]
 #[allow(missing_docs)]
 pub enum Integer {


### PR DESCRIPTION
noticed the broken formatting while browsing the docs, this also adds a doc link to `isize` for convenience.