### PR TITLE
fix: remove `Default` bound from `[T; N]`'s `Decode` impl

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -641,7 +641,7 @@ impl<T: Decode + Eq + core::hash::Hash> Decode for SetOf<T> {
     }
 }
 
-impl<T: Decode + Default, const N: usize> Decode for [T; N] {
+impl<T: Decode, const N: usize> Decode for [T; N] {
     fn decode_with_tag_and_constraints<D: Decoder>(
         decoder: &mut D,
         tag: Tag,


### PR DESCRIPTION
this seems like an accidental holdover from an earlier iteration of the impl or something since there's no need for `T: Default` with the current implementation