### PR TITLE
fix(derive): use `const` blocks and add generic bounds when generating an enum's `AsnType` impl

### DIFF
--- a/macros/macros_impl/src/asn_type.rs
+++ b/macros/macros_impl/src/asn_type.rs
@@ -62,7 +62,7 @@ pub fn derive_struct_impl(
                 paren_token: Some(<_>::default()),
                 modifier: syn::TraitBoundModifier::None,
                 lifetimes: None,
-                path: syn::parse_str("rasn::AsnType").unwrap(),
+                path: syn::parse_quote!(#crate_root::AsnType),
             }));
     }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -144,6 +144,13 @@ pub enum ExplicitChoice {
     ByKey,
 }
 
+#[derive(AsnType, Decode, Encode)]
+#[rasn(choice)]
+pub enum GenericEnum<T: Clone, const N: usize> {
+    FixedString(FixedOctetString<N>),
+    Sequence(Vec<T>),
+}
+
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BasicConstraints {
     #[rasn(default)]


### PR DESCRIPTION
fixes #397. this commit ensures that the `TAG_TREE` associated const uses a `const` block so it is able to access any outer generics on the enum and also bounds any type generics with `AsnType` so that impls will be met.