### PR TITLE
Add basic support for REAL using f32/f64 with JER/OER rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ chrono = { version = "0.4.38", default-features = false, features = ["alloc"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [features]
+default = ["f32", "f64"]
 std = []
+f32 = []
+f64 = []
 backtraces = ["std", "snafu/backtrace"]
 compiler = ["rasn-compiler"]
 

--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -410,6 +410,14 @@ impl<'input> crate::Decoder for Decoder<'input> {
         }
     }
 
+    fn decode_real<R: types::RealType>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+    ) -> Result<R, Self::Error> {
+        Err(DecodeError::real_not_supported(self.codec()))
+    }
+
     fn decode_octet_string<'b, T: From<&'b [u8]> + From<Vec<u8>>>(
         &'b mut self,
         tag: Tag,

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -395,6 +395,15 @@ impl crate::Encoder<'_> for Encoder {
         Ok(())
     }
 
+    fn encode_real<R: types::RealType>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+        _: &R,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(EncodeError::real_not_supported(self.codec()))
+    }
+
     fn encode_null(&mut self, tag: Tag) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[]);
         Ok(())

--- a/src/de.rs
+++ b/src/de.rs
@@ -93,6 +93,14 @@ pub trait Decoder<const RCL: usize = 0, const ECL: usize = 0>: Sized {
         tag: Tag,
         constraints: Constraints,
     ) -> Result<I, Self::Error>;
+
+    /// Decode a `REAL` identified by `tag` from the available input.
+    fn decode_real<R: types::RealType>(
+        &mut self,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> Result<R, Self::Error>;
+
     /// Decode `NULL` identified by `tag` from the available input.
     fn decode_null(&mut self, tag: Tag) -> Result<(), Self::Error>;
     /// Decode a `OBJECT IDENTIFIER` identified by `tag` from the available input.
@@ -531,6 +539,28 @@ impl Decode for types::Integer {
         constraints: Constraints,
     ) -> Result<Self, D::Error> {
         decoder.decode_integer::<types::Integer>(tag, constraints)
+    }
+}
+
+#[cfg(feature = "f32")]
+impl Decode for f32 {
+    fn decode_with_tag_and_constraints<D: Decoder>(
+        decoder: &mut D,
+        tag: Tag,
+        _: Constraints,
+    ) -> Result<Self, D::Error> {
+        decoder.decode_real::<f32>(tag, Constraints::default())
+    }
+}
+
+#[cfg(feature = "f64")]
+impl Decode for f64 {
+    fn decode_with_tag_and_constraints<D: Decoder>(
+        decoder: &mut D,
+        tag: Tag,
+        _: Constraints,
+    ) -> Result<Self, D::Error> {
+        decoder.decode_real::<f64>(tag, Constraints::default())
     }
 }
 

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -2,6 +2,8 @@
 
 use crate::types::{self, AsnType, Constraints, Enumerated, IntegerType, SetOf, Tag};
 
+use crate::types::RealType;
+
 use num_bigint::BigInt;
 pub use rasn_derive::Encode;
 
@@ -115,6 +117,14 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &I,
+    ) -> Result<Self::Ok, Self::Error>;
+
+    /// Encode a `REAL` value.
+    fn encode_real<R: RealType>(
+        &mut self,
+        tag: Tag,
+        constraints: Constraints,
+        value: &R,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `NULL` value.
@@ -573,6 +583,30 @@ impl Encode for types::Integer {
         constraints: Constraints,
     ) -> Result<(), E::Error> {
         encoder.encode_integer(tag, constraints, self).map(drop)
+    }
+}
+
+#[cfg(feature = "f32")]
+impl Encode for f32 {
+    fn encode_with_tag_and_constraints<'b, E: Encoder<'b>>(
+        &self,
+        encoder: &mut E,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> Result<(), E::Error> {
+        encoder.encode_real(tag, constraints, self).map(drop)
+    }
+}
+
+#[cfg(feature = "f64")]
+impl Encode for f64 {
+    fn encode_with_tag_and_constraints<'b, E: Encoder<'b>>(
+        &self,
+        encoder: &mut E,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> Result<(), E::Error> {
+        encoder.encode_real(tag, constraints, self).map(drop)
     }
 }
 

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -276,6 +276,12 @@ impl DecodeError {
         DecodeError::from_kind(DecodeErrorKind::Parser { msg }, codec)
     }
 
+    /// Creates a wrapper around using `REAL` with unsupported codecs.
+    #[must_use]
+    pub fn real_not_supported(codec: Codec) -> Self {
+        DecodeError::from_kind(DecodeErrorKind::RealNotSupported, codec)
+    }
+
     /// Creates a wrapper around a missing required extension error from a given codec.
     #[must_use]
     pub fn required_extension_not_present(tag: Tag, codec: Codec) -> Self {
@@ -552,6 +558,14 @@ pub enum DecodeErrorKind {
         /// The reason the conversion failed.
         msg: alloc::string::String,
     },
+
+    /// Real conversion failure.
+    #[snafu(display("Invalid real encoding"))]
+    InvalidRealEncoding,
+
+    /// Decoder doesn't support REAL
+    #[snafu(display("Decoder doesn't support REAL types"))]
+    RealNotSupported,
 
     /// BitString contains an invalid amount of unused bits.
     #[snafu(display("BitString contains an invalid amount of unused bits: {}", bits))]

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -212,6 +212,12 @@ impl EncodeError {
         Self::from_kind(EncodeErrorKind::VariantNotInChoice, codec)
     }
 
+    /// Returns an encode error when the encoder doesn't support `REAL` type.
+    #[must_use]
+    pub fn real_not_supported(codec: crate::Codec) -> Self {
+        Self::from_kind(EncodeErrorKind::RealNotSuppored, codec)
+    }
+
     /// A helper function to construct an `EncodeError` from the given `kind` and `codec`.
     #[must_use]
     pub fn from_kind(kind: EncodeErrorKind, codec: crate::Codec) -> Self {
@@ -328,6 +334,10 @@ pub enum EncodeErrorKind {
     /// Error when the selected variant is not found in the choice.
     #[snafu(display("Selected Variant not found from Choice"))]
     VariantNotInChoice,
+
+    /// Error when we try to encode a `REAL` type with an unspported codec.
+    #[snafu(display("Encoder doesn't support `REAL` type"))]
+    RealNotSuppored,
 }
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for BER.
 #[derive(Snafu, Debug)]
@@ -392,6 +402,9 @@ pub enum JerEncodeErrorKind {
         /// value failed to encode
         value: BigInt,
     },
+    /// Error to be thrown when encoding real values that exceed the supported range
+    #[snafu(display("Exceeds supported real value range"))]
+    ExceedsSupportedRealRange,
     /// Error to be thrown when some character from the input data is not valid UTF-8
     #[snafu(display("Invalid character: {:?}", error))]
     InvalidCharacter {

--- a/src/jer.rs
+++ b/src/jer.rs
@@ -26,14 +26,20 @@ mod tests {
     macro_rules! round_trip_jer {
         ($typ:ty, $value:expr, $expected:expr) => {{
             let value: $typ = $value;
+            pretty_assertions::assert_eq!(value, round_trip_value!($typ, $value, $expected));
+        }};
+    }
+
+    macro_rules! round_trip_value {
+        ($typ:ty, $value:expr, $expected:expr) => {{
+            let value: $typ = $value;
             let expected: &'static str = $expected;
             let actual_encoding = crate::jer::encode(&value).unwrap();
 
             pretty_assertions::assert_eq!(expected, &*actual_encoding);
 
             let decoded_value: $typ = crate::jer::decode(&actual_encoding).unwrap();
-
-            pretty_assertions::assert_eq!(value, decoded_value);
+            decoded_value
         }};
     }
 
@@ -185,6 +191,36 @@ mod tests {
         round_trip_jer!(Integer, 1.into(), "1");
         round_trip_jer!(Integer, (-1235352).into(), "-1235352");
         round_trip_jer!(ConstrainedInt, ConstrainedInt(1.into()), "1");
+    }
+
+    #[test]
+    #[cfg(feature = "f32")]
+    fn real_f32() {
+        round_trip_jer!(f32, 0.0, "0.0");
+        round_trip_jer!(f32, -0.0, "\"-0\"");
+
+        round_trip_jer!(f32, f32::INFINITY, "\"INF\"");
+        round_trip_jer!(f32, f32::NEG_INFINITY, "\"-INF\"");
+
+        assert!(round_trip_value!(f32, f32::NAN, "\"NAN\"").is_nan());
+
+        round_trip_jer!(f32, 1.0, "1.0");
+        round_trip_jer!(f32, -1.0, "-1.0");
+    }
+
+    #[test]
+    #[cfg(feature = "f64")]
+    fn real_f64() {
+        round_trip_jer!(f64, 0.0, "0.0");
+        round_trip_jer!(f64, -0.0, "\"-0\"");
+
+        round_trip_jer!(f64, f64::INFINITY, "\"INF\"");
+        round_trip_jer!(f64, f64::NEG_INFINITY, "\"-INF\"");
+
+        assert!(round_trip_value!(f64, f64::NAN, "\"NAN\"").is_nan());
+
+        round_trip_jer!(f64, 1.0, "1.0");
+        round_trip_jer!(f64, -1.0, "-1.0");
     }
 
     #[test]

--- a/src/oer.rs
+++ b/src/oer.rs
@@ -129,6 +129,7 @@ mod tests {
             decode_ok!(oer, bool, &bytes, true);
         }
     }
+
     #[test]
     fn test_length_determinant() {
         // short with leading zeros
@@ -143,6 +144,31 @@ mod tests {
             &[0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x41, 0x41]
         );
     }
+
+    #[test]
+    #[cfg(feature = "f32")]
+    fn real_f32() {
+        round_trip!(oer, f32, 1.0, &[0x3f, 0x80, 0x00, 0x00]);
+        round_trip!(oer, f32, -1.0, &[0xbf, 0x80, 0x00, 0x00]);
+    }
+
+    #[test]
+    #[cfg(feature = "f64")]
+    fn real_f64() {
+        round_trip!(
+            oer,
+            f64,
+            1.0,
+            &[0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        );
+        round_trip!(
+            oer,
+            f64,
+            -1.0,
+            &[0xbf, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        );
+    }
+
     #[test]
     fn test_sequence_of() {
         #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
@@ -160,6 +186,7 @@ mod tests {
         let data: [u8; 108] = [30; 108];
         decode_error!(oer, TestA, &data);
     }
+
     #[test]
     fn test_enumerated() {
         // short with leading zeros
@@ -191,6 +218,7 @@ mod tests {
         decode_error!(coer, Test, &[0b1000_0001, 0x01]);
         decode_ok!(oer, Test, &[0b1000_0001, 0x01], Test::A);
     }
+
     #[test]
     fn test_seq_preamble_unused_bits() {
         use crate as rasn;
@@ -215,6 +243,7 @@ mod tests {
             &data
         );
     }
+
     #[test]
     fn test_explicit_with_optional() {
         #[derive(AsnType, Decode, Encode, Clone, Debug, PartialEq, Eq)]

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -554,6 +554,16 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
         self.decode_integer_with_constraints::<I>(&constraints)
     }
 
+    fn decode_real<R: crate::types::RealType>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+    ) -> Result<R, Self::Error> {
+        let octets = self.extract_data_by_length(R::BYTE_WIDTH)?;
+        R::try_from_ieee754_bytes(octets)
+            .map_err(|_| DecodeError::from_kind(DecodeErrorKind::InvalidRealEncoding, self.codec()))
+    }
+
     /// Null contains no data, so we just skip
     fn decode_null(&mut self, _: Tag) -> Result<(), Self::Error> {
         Ok(())

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -8,8 +8,8 @@ use crate::{
     oer::EncodingRules,
     types::{
         Any, BitStr, BmpString, Choice, Constraints, Constructed, Date, Enumerated, GeneralString,
-        GeneralizedTime, Ia5String, IntegerType, NumericString, PrintableString, SetOf, Tag,
-        TeletexString, UtcTime, VisibleString,
+        GeneralizedTime, Ia5String, IntegerType, NumericString, PrintableString, RealType, SetOf,
+        Tag, TeletexString, UtcTime, VisibleString,
     },
     Codec, Encode,
 };
@@ -748,6 +748,19 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         value: &I,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_integer_with_constraints(tag, &constraints, value)
+    }
+
+    fn encode_real<R: RealType>(
+        &mut self,
+        tag: Tag,
+        _constraints: Constraints,
+        value: &R,
+    ) -> Result<Self::Ok, Self::Error> {
+        let (bytes, len) = value.to_ieee754_bytes();
+        self.output.extend_from_slice(&bytes.as_ref()[..len]);
+        self.extend(tag)?;
+
+        Ok(())
     }
 
     fn encode_null(&mut self, _tag: Tag) -> Result<Self::Ok, Self::Error> {

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -688,6 +688,14 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
         self.parse_integer::<I>(constraints)
     }
 
+    fn decode_real<R: types::RealType>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+    ) -> Result<R, Self::Error> {
+        Err(DecodeError::real_not_supported(self.codec()))
+    }
+
     fn decode_octet_string<'b, T: From<&'b [u8]> + From<Vec<u8>>>(
         &'b mut self,
         _: Tag,

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -893,6 +893,15 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Ok(())
     }
 
+    fn encode_real<R: types::RealType>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+        _: &R,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::real_not_supported(self.codec()))
+    }
+
     fn encode_null(&mut self, _tag: Tag) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,9 @@ pub(crate) mod constructed;
 pub(crate) mod date;
 pub(crate) mod integer;
 pub(crate) mod oid;
+
+pub(crate) mod real;
+
 pub(crate) mod strings;
 
 use crate::macros::{constraints, size_constraint, value_constraint};
@@ -41,6 +44,8 @@ pub use {
     },
     rasn_derive::AsnType,
 };
+
+pub use self::real::RealType;
 
 ///  The `UniversalString` type.
 pub type UniversalString = Implicit<tag::UNIVERSAL_STRING, Utf8String>;
@@ -319,4 +324,14 @@ impl<T> AsnType for &'_ [T] {
 impl AsnType for Any {
     const TAG: Tag = Tag::EOC;
     const TAG_TREE: TagTree = TagTree::Choice(&[]);
+}
+
+#[cfg(feature = "f32")]
+impl AsnType for f32 {
+    const TAG: Tag = Tag::REAL;
+}
+
+#[cfg(feature = "f64")]
+impl AsnType for f64 {
+    const TAG: Tag = Tag::REAL;
 }

--- a/src/types/real.rs
+++ b/src/types/real.rs
@@ -1,0 +1,81 @@
+use num_traits::float::FloatCore;
+
+/// Represents a real type in Rust that can be decoded or encoded into any
+/// ASN.1 codec.
+pub trait RealType: Sized + core::fmt::Debug + core::fmt::Display {
+    /// The byte level width of the floating point type.
+    const BYTE_WIDTH: usize;
+
+    /// Returns the IEEE 754 encoded bytes of the real type, byte count defined in `usize`
+    fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize);
+
+    /// Attempts to decode the IEEE 754 encoded bytes into `Self`
+    fn try_from_ieee754_bytes(bytes: &[u8]) -> Result<Self, TryFromRealError>;
+
+    /// Attempts to convert a generic floating point type into `Self`
+    fn try_from_float(value: impl FloatCore) -> Option<Self>;
+
+    /// Attempts to convert `Self` into a generic floating point type
+    fn try_to_float(&self) -> Option<impl FloatCore>;
+}
+
+#[cfg(feature = "f64")]
+impl RealType for f64 {
+    const BYTE_WIDTH: usize = core::mem::size_of::<Self>();
+
+    #[inline]
+    fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize) {
+        let bytes = self.to_be_bytes();
+        (bytes, bytes.len())
+    }
+
+    #[inline]
+    fn try_from_ieee754_bytes(bytes: &[u8]) -> Result<Self, TryFromRealError> {
+        let bytes = bytes
+            .try_into()
+            .map_err(|_| TryFromRealError::InvalidEncoding)?;
+
+        Ok(f64::from_be_bytes(bytes))
+    }
+
+    fn try_from_float(value: impl FloatCore) -> Option<Self> {
+        value.to_f64()
+    }
+
+    fn try_to_float(&self) -> Option<impl FloatCore> {
+        Some(*self)
+    }
+}
+
+#[cfg(feature = "f32")]
+impl RealType for f32 {
+    const BYTE_WIDTH: usize = core::mem::size_of::<Self>();
+
+    #[inline]
+    fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize) {
+        let bytes = self.to_be_bytes();
+        (bytes, bytes.len())
+    }
+
+    #[inline]
+    fn try_from_ieee754_bytes(bytes: &[u8]) -> Result<Self, TryFromRealError> {
+        let bytes = bytes
+            .try_into()
+            .map_err(|_| TryFromRealError::InvalidEncoding)?;
+
+        Ok(f32::from_be_bytes(bytes))
+    }
+
+    fn try_from_float(value: impl FloatCore) -> Option<Self> {
+        value.to_f32()
+    }
+
+    fn try_to_float(&self) -> Option<impl FloatCore> {
+        Some(*self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TryFromRealError {
+    InvalidEncoding,
+}


### PR DESCRIPTION
I think this is a compliant implementation of REAL, as long as you're fine with being constrained to 32/64-bit floats.

From what I can gather this is the first type that isn't supported for every codec so I added a generic error for the unsupported codecs. Unfortunately this means that you won't get an error until runtime.

I added f32/f64 feature flags so you don't have to use any of it if you don't want it.

Neither my rust nor my asn.1 is something to brag about, so if you want it done in another way just let me know.