### PR TITLE
Feat/xml encoding rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,15 +956,16 @@ dependencies = [
 
 [[package]]
 name = "rasn-compiler"
-version = "0.5.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68212f28a56793c190cf8795d0b9b87ed1f574110e29e11ea7d80a337c01a4de"
+checksum = "13c9c9e62462bc21d4eb088f301493553c6888ba5494d5f874d2d7aabb7f7d22"
 dependencies = [
  "chrono",
  "nom",
  "num",
  "proc-macro2",
  "quote",
+ "regex",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "x509-cert",
  "x509-certificate",
  "x509-parser",
+ "xml-no-std",
 ]
 
 [[package]]
@@ -1629,6 +1630,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "xml-no-std"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4f451c779ea0b57e28c106c0fdafe9290038c97d26364aeb87617d2b78f698"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ once_cell = { version = "1.20.2", default-features = false, features = [
     "race",
     "alloc",
 ] }
-rasn-compiler = { version = "0.5.3", optional = true }
+rasn-compiler = { version = "0.7", optional = true }
 rasn-derive = { version = "0.24", path = "macros" }
 snafu = { version = "0.8.5", default-features = false, features = [
     "rust_1_81",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ snafu = { version = "0.8.5", default-features = false, features = [
     "rust_1_81",
 ] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
+xml-no-std = "0.8.19"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ Next is the `Decode` and `Encode` traits. These are mirrors of each other and bo
 ```rust
 # use rasn::{AsnType, types::{Constructed, fields::{Field, Fields}}};
 # struct Person { name: Utf8String, age: Integer }
-# impl AsnType for Person { const TAG: Tag = Tag::SEQUENCE; }
+# impl AsnType for Person {
+#    const TAG: Tag = Tag::SEQUENCE;
+#    const IDENTIFIER: Identifier = Identifier(Some("Person"));
+# }
 # impl Constructed<2, 0> for Person {
 #     const FIELDS: Fields<2> = Fields::from_static([
 #          Field::new_required(0, Utf8String::TAG, Utf8String::TAG_TREE, "age"),
@@ -123,7 +126,7 @@ impl Decode for Person {
 }
 
 impl Encode for Person {
-    fn encode_with_tag_and_constraints<'encoder, E: Encoder<'encoder>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints, identifier: Option<&'static str>) -> Result<(), E::Error> {
+    fn encode_with_tag_and_constraints<'encoder, E: Encoder<'encoder>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints, identifier: Identifier) -> Result<(), E::Error> {
         // Accepts a closure that encodes the contents of the sequence.
         encoder.encode_sequence::<2, 0, Self, _>(tag, |encoder| {
             self.age.encode(encoder)?;

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ impl Decode for Person {
 }
 
 impl Encode for Person {
-    fn encode_with_tag_and_constraints<'encoder, E: Encoder<'encoder>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints) -> Result<(), E::Error> {
+    fn encode_with_tag_and_constraints<'encoder, E: Encoder<'encoder>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints, identifier: Option<&'static str>) -> Result<(), E::Error> {
         // Accepts a closure that encodes the contents of the sequence.
         encoder.encode_sequence::<2, 0, Self, _>(tag, |encoder| {
             self.age.encode(encoder)?;
             self.name.encode(encoder)?;
             Ok(())
-        })?;
+        }, identifier)?;
 
         Ok(())
     }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 Welcome to `rasn` (pronounced "raisin"), a safe `#[no_std]` ASN.1 codec framework.
 That enables you to safely create, share, and handle ASN.1 data types from and to different encoding rules. If you are unfamiliar with ASN.1 and encoding formats like BER/DER, I would recommend reading [*"A Warm Welcome to ASN.1 and DER"*][lenc] by Let's Encrypt as a quick introduction before continuing. In short it is an "Interface Description Language" (and data model) with a set of encoding formats (called rules) for that model. It was originally designed in the late 1980s and is used throughout the industry especially in telecommunications and cryptography.
 
+The [`rasn` compiler][compiler] can be used to generate `rasn` bindings for ASN.1 modules.
+
 [ghs]: https://github.com/sponsors/XAMPPRocky
 [lenc]: https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
+[compiler]: https://github.com/librasn/compiler
 
 ## Features
 
@@ -37,6 +40,7 @@ The encoder and decoder have been written in 100% safe Rust and fuzzed with [Ame
 - JSON Encoding Rules (JER)
 - Octet Encoding Rules (OER)
 - Canonical Octet Encoding Rules (COER)
+- XML Encoding Rules (XER)
 
 [bun]: https://aflplus.plus
 

--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -7,7 +7,7 @@
 // Wrap with black_box to prevent the compiler from optimizing out the code
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rasn::{ber, oer, uper};
+use rasn::{ber, oer, uper, xer};
 
 #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused)]
 pub mod world3d {
@@ -154,10 +154,12 @@ macro_rules! rasn_dec_fn {
 rasn_enc_fn!(uper_rasn_enc, uper);
 rasn_enc_fn!(oer_rasn_enc, oer);
 rasn_enc_fn!(ber_rasn_enc, ber);
+rasn_enc_fn!(xer_rasn_enc, xer);
 
 rasn_dec_fn!(uper_rasn_dec, uper);
 rasn_dec_fn!(oer_rasn_dec, oer);
 rasn_dec_fn!(ber_rasn_dec, ber);
+rasn_dec_fn!(xer_rasn_dec, xer);
 
 criterion_group!(
     benches,
@@ -166,6 +168,8 @@ criterion_group!(
     oer_rasn_enc,
     oer_rasn_dec,
     ber_rasn_enc,
-    ber_rasn_dec
+    ber_rasn_dec,
+    xer_rasn_enc,
+    xer_rasn_dec
 );
 criterion_main!(benches);

--- a/macros/macros_impl/src/asn_type.rs
+++ b/macros/macros_impl/src/asn_type.rs
@@ -91,8 +91,8 @@ pub fn derive_struct_impl(
     let constraints_def = config.constraints.const_static_def(crate_root);
 
     let alt_identifier = config.identifier.as_ref().map_or(
-        quote!(const IDENTIFIER: Option<&'static str> = Some(#name_literal);),
-        |id| quote!(const IDENTIFIER: Option<&'static str> = Some(#id);),
+        quote!(const IDENTIFIER: #crate_root::types::Identifier = #crate_root::types::Identifier(Some(#name_literal));),
+        |id| quote!(const IDENTIFIER: #crate_root::types::Identifier = #crate_root::types::Identifier(Some(#id));),
     );
 
     Ok(quote! {

--- a/macros/macros_impl/src/asn_type.rs
+++ b/macros/macros_impl/src/asn_type.rs
@@ -8,6 +8,7 @@ pub fn derive_struct_impl(
     container: syn::DataStruct,
     config: &Config,
 ) -> syn::Result<proc_macro2::TokenStream> {
+    let name_literal = name.to_string();
     let crate_root = &config.crate_root;
     let tag = config.tag_for_struct(&container.fields);
     let field_configs = container
@@ -90,7 +91,7 @@ pub fn derive_struct_impl(
     let constraints_def = config.constraints.const_static_def(crate_root);
 
     let alt_identifier = config.identifier.as_ref().map_or(
-        quote!(),
+        quote!(const IDENTIFIER: Option<&'static str> = Some(#name_literal);),
         |id| quote!(const IDENTIFIER: Option<&'static str> = Some(#id);),
     );
 

--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -811,6 +811,7 @@ impl<'a> FieldConfig<'a> {
             .as_ref()
             .map(|name| quote!(#name))
             .unwrap_or_else(|| quote!(#i));
+        let crate_root = &self.container_config.crate_root;
         let identifier = self
             .identifier
             .clone()
@@ -819,10 +820,9 @@ impl<'a> FieldConfig<'a> {
                 .ident
                 .as_ref()
                 .map(|i| LitStr::new(&i.to_string(), Span::call_site())))
-            .map(|i| quote!(Some(#i)))
-            .unwrap_or(quote!(None));
+            .map(|i| quote!(#crate_root::types::Identifier(Some(#i))))
+            .unwrap_or(quote!(#crate_root::types::Identifier::EMPTY));
         let mut ty = self.field.ty.clone();
-        let crate_root = &self.container_config.crate_root;
         ty.strip_lifetimes();
         let default_fn = self.default_fn().map(|d| quote!(#d,));
         let has_generics = !type_params.is_empty() && {

--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -1,4 +1,3 @@
-use proc_macro2::Span;
 use syn::LitStr;
 
 use crate::config::*;

--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -113,7 +113,7 @@ pub fn derive_struct_impl(
     Ok(quote! {
         #[allow(clippy::mutable_key_type)]
         impl #impl_generics  #crate_root::Encode for #name #ty_generics #where_clause {
-            fn encode_with_tag_and_constraints<'encoder, EN: #crate_root::Encoder<'encoder>>(&self, encoder: &mut EN, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints, identifier: Option<&'static str>) -> core::result::Result<(), EN::Error> {
+            fn encode_with_tag_and_constraints<'encoder, EN: #crate_root::Encoder<'encoder>>(&self, encoder: &mut EN, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints, identifier: #crate_root::types::Identifier) -> core::result::Result<(), EN::Error> {
                 #(#vars)*
 
                 #encode_impl
@@ -132,7 +132,10 @@ pub fn map_to_inner_type(
     identifier: Option<&LitStr>,
 ) -> proc_macro2::TokenStream {
     let inner_name = quote::format_ident!("Inner{}", name);
-    let identifier = identifier.map_or(quote!(Self::IDENTIFIER), |id| quote!(Some(#id)));
+    let identifier = identifier.map_or(
+        quote!(Self::IDENTIFIER),
+        |id| quote!(#crate_root::types::Identifier(Some(#id))),
+    );
 
     let mut inner_generics = generics.clone();
     let lifetime = syn::Lifetime::new(

--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -16,6 +16,7 @@ impl Enum<'_> {
     #[allow(clippy::too_many_lines)]
     pub fn impl_asntype(&self) -> syn::Result<proc_macro2::TokenStream> {
         let crate_root = &self.config.crate_root;
+        let name_literal = self.name.to_string();
 
         let tag = self.config.tag.as_ref().map_or_else(
             || {
@@ -172,7 +173,7 @@ impl Enum<'_> {
         });
 
         let alt_identifier = self.config.identifier.as_ref().map_or(
-            quote!(),
+            quote!(const IDENTIFIER: Option<&'static str> = Some(#name_literal);),
             |id| quote!(const IDENTIFIER: Option<&'static str> = Some(#id);),
         );
 
@@ -413,7 +414,7 @@ impl Enum<'_> {
                         self.generics,
                         crate_root,
                         variant_config.has_explicit_tag(),
-                        variant_identifier,
+                        None,
                     );
 
                     quote!(#name::#ident { #(#idents: #idents_prefixed),* } => { #encode_impl.map(|_| #tag_tokens) })
@@ -443,7 +444,7 @@ impl Enum<'_> {
                             });
                             quote!(#crate_root::Encode::encode_with_constraints_and_identifier(value, encoder, #constraint_name, Some(#variant_identifier)))
                         } else {
-                            quote!(#crate_root::Encode::encode_with_identifier(value, encoder, #variant_identifier))
+                            quote!(#crate_root::Encode::encode_with_identifier(value, encoder, Some(#variant_identifier)))
                     };
 
                     quote! {

--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -466,16 +466,30 @@ impl Enum<'_> {
             }
         });
 
+        let tag_match = &quote! {
+                match self {
+                    #(#tags),*
+                }
+        };
+        let encoder_closure_match = &quote! {
+                |encoder| match self {
+                    #(#variants),*
+                }
+        };
         let encode_variants = quote! {
             encoder.encode_choice::<Self>(
                 Self::CONSTRAINTS,
-                match self {
-                    #(#tags),*
-                },
-                |encoder| match self {
-                    #(#variants),*
-                },
+                #tag_match,
+                #encoder_closure_match,
                 Self::IDENTIFIER,
+            )
+        };
+        let encode_variants_with_identifier = quote! {
+            encoder.encode_choice::<Self>(
+                Self::CONSTRAINTS,
+                #tag_match,
+                #encoder_closure_match,
+                identifier,
             )
         };
 
@@ -550,6 +564,10 @@ impl Enum<'_> {
             fn encode<'encoder, E: #crate_root::Encoder<'encoder>>(&self, encoder: &mut E) -> core::result::Result<(), E::Error> {
                 #(#variant_constraints)*
                 #encode_impl.map(drop)
+            }
+            fn encode_with_identifier<'encoder, E: #crate_root::Encoder<'encoder>>(&self, encoder: &mut E, identifier: Option<&'static str>) -> core::result::Result<(), E::Error> {
+                #(#variant_constraints)*
+                #encode_variants_with_identifier.map(drop)
             }
         })
     }

--- a/macros/macros_impl/src/lib.rs
+++ b/macros/macros_impl/src/lib.rs
@@ -71,9 +71,10 @@ pub fn encode_derive_inner(input: DeriveInput) -> syn::Result<proc_macro2::Token
                     &self,
                     encoder: &mut E,
                     tag: #crate_root::types::Tag,
-                    _: #crate_root::prelude::Constraints,
+                    constraints: #crate_root::prelude::Constraints,
+                    identifier: Option<&'static str>,
                 ) -> Result<(), E::Error> {
-                    encoder.encode_null(tag).map(drop)
+                    encoder.encode_null(tag, identifier).map(drop)
                 }
             }
         },

--- a/macros/macros_impl/src/lib.rs
+++ b/macros/macros_impl/src/lib.rs
@@ -72,7 +72,7 @@ pub fn encode_derive_inner(input: DeriveInput) -> syn::Result<proc_macro2::Token
                     encoder: &mut E,
                     tag: #crate_root::types::Tag,
                     constraints: #crate_root::prelude::Constraints,
-                    identifier: Option<&'static str>,
+                    identifier: #crate_root::types::Identifier,
                 ) -> Result<(), E::Error> {
                     encoder.encode_null(tag, identifier).map(drop)
                 }

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -43,15 +43,17 @@ pub fn encode_scope(
 
 #[cfg(test)]
 mod tests {
+    use crate::error::DecodeErrorKind;
     use alloc::borrow::ToOwned;
     use alloc::vec;
     use alloc::vec::Vec;
+    use bitvec::order::Msb0;
     use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
-    use de::DecodeErrorKind;
 
-    use crate::types::*;
-
-    use super::*;
+    use crate::{
+        ber::{decode, encode},
+        types::*,
+    };
 
     #[derive(Clone, Copy, Hash, Debug, PartialEq)]
     struct C0;
@@ -90,7 +92,7 @@ mod tests {
         let bits = BitString::from_vec([0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..].to_owned());
         let padding_test = BitString::from_element(0x42);
         let padding_expected: &[u8] = &[0x03, 0x02, 0x00, 0x42];
-        let trailing_test = bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 0, 0, 0, 1, 1, 0];
+        let trailing_test = bitvec::bitvec![u8, Msb0; 1, 0, 0, 0, 0, 1, 1, 0];
         let trailing_expected: &[u8] = &[0x03, 0x02, 0x00, 0x86];
 
         assert_eq!(
@@ -240,7 +242,7 @@ mod tests {
                 encoder: &mut EN,
                 tag: crate::types::Tag,
                 _: Constraints,
-                _: Option<&'static str>,
+                _: crate::types::Identifier,
             ) -> Result<(), EN::Error> {
                 encoder.encode_set::<2, 0, Self, _>(
                     tag,
@@ -249,7 +251,7 @@ mod tests {
                         self.name.encode(encoder)?;
                         Ok(())
                     },
-                    None,
+                    crate::types::Identifier::EMPTY,
                 )?;
 
                 Ok(())

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -240,12 +240,13 @@ mod tests {
                 encoder: &mut EN,
                 tag: crate::types::Tag,
                 _: Constraints,
+                _: Option<&'static str>,
             ) -> Result<(), EN::Error> {
                 encoder.encode_set::<2, 0, Self, _>(tag, |encoder| {
                     self.age.encode(encoder)?;
                     self.name.encode(encoder)?;
                     Ok(())
-                })?;
+                }, None)?;
 
                 Ok(())
             }

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -242,11 +242,15 @@ mod tests {
                 _: Constraints,
                 _: Option<&'static str>,
             ) -> Result<(), EN::Error> {
-                encoder.encode_set::<2, 0, Self, _>(tag, |encoder| {
-                    self.age.encode(encoder)?;
-                    self.name.encode(encoder)?;
-                    Ok(())
-                }, None)?;
+                encoder.encode_set::<2, 0, Self, _>(
+                    tag,
+                    |encoder| {
+                        self.age.encode(encoder)?;
+                        self.name.encode(encoder)?;
+                        Ok(())
+                    },
+                    None,
+                )?;
 
                 Ok(())
             }

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -324,7 +324,7 @@ impl crate::Encoder<'_> for Encoder {
         Self::codec(self)
     }
 
-    fn encode_any(&mut self, _: Tag, value: &types::Any) -> Result<Self::Ok, Self::Error> {
+    fn encode_any(&mut self, _: Tag, value: &types::Any, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         if self.is_set_encoding {
             return Err(BerEncodeErrorKind::AnyInSet.into());
         }
@@ -339,6 +339,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::BitStr,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         if value.is_empty() {
             self.encode_primitive(tag, &[]);
@@ -361,7 +362,7 @@ impl crate::Encoder<'_> for Encoder {
         }
     }
 
-    fn encode_bool(&mut self, tag: Tag, value: bool) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(&mut self, tag: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[if value { 0xff } else { 0x00 }]);
         Ok(())
     }
@@ -371,6 +372,7 @@ impl crate::Encoder<'_> for Encoder {
         _: Constraints,
         _t: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         (encode_fn)(self).map(drop)
     }
@@ -379,9 +381,10 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let value = E::discriminant(value);
-        self.encode_integer(tag, Constraints::default(), &value)
+        self.encode_integer(tag, Constraints::default(), &value, None)
     }
 
     fn encode_integer<I: IntegerType>(
@@ -389,6 +392,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &I,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let (bytes, needed) = value.to_signed_bytes_be();
         self.encode_primitive(tag, &bytes.as_ref()[..needed]);
@@ -400,16 +404,17 @@ impl crate::Encoder<'_> for Encoder {
         _: Tag,
         _: Constraints,
         _: &R,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         Err(EncodeError::real_not_supported(self.codec()))
     }
 
-    fn encode_null(&mut self, tag: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[]);
         Ok(())
     }
 
-    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32]) -> Result<Self::Ok, Self::Error> {
+    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32], _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         let bytes = self.object_identifier_as_bytes(oid)?;
         self.encode_primitive(tag, &bytes);
         Ok(())
@@ -420,6 +425,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &[u8],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -429,6 +435,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::VisibleString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_iso646_bytes())
     }
@@ -438,6 +445,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::Ia5String,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_iso646_bytes())
     }
@@ -447,6 +455,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::GeneralString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -456,6 +465,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::GraphicString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -465,6 +475,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::PrintableString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -474,6 +485,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::NumericString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -483,6 +495,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _: Constraints,
         value: &types::TeletexString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, &value.to_bytes())
     }
@@ -492,6 +505,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::BmpString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, &value.to_bytes())
     }
@@ -501,6 +515,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _: Constraints,
         value: &str,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -509,6 +524,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &types::UtcTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(
             tag,
@@ -522,6 +538,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &types::GeneralizedTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(
             tag,
@@ -531,13 +548,13 @@ impl crate::Encoder<'_> for Encoder {
         Ok(())
     }
 
-    fn encode_date(&mut self, tag: Tag, value: &types::Date) -> Result<Self::Ok, Self::Error> {
+    fn encode_date(&mut self, tag: Tag, value: &types::Date, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, Self::naivedate_to_date_bytes(value).as_slice());
 
         Ok(())
     }
 
-    fn encode_some<E: Encode>(&mut self, value: &E) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
@@ -545,6 +562,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode_with_tag(self, tag)
     }
@@ -554,15 +572,16 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         constraints: Constraints,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        value.encode_with_tag_and_constraints(self, tag, constraints)
+        value.encode_with_tag_and_constraints(self, tag, constraints, None)
     }
 
-    fn encode_none<E: Encode>(&mut self) -> Result<Self::Ok, Self::Error> {
-        self.encode_none_with_tag(E::TAG)
+    fn encode_none<E: Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+        self.encode_none_with_tag(E::TAG, None)
     }
 
-    fn encode_none_with_tag(&mut self, _: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(&mut self, _: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
 
@@ -571,6 +590,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         values: &[E],
         _constraints: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut sequence_encoder = Self::new(self.config);
 
@@ -588,6 +608,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         values: &types::SetOf<E>,
         _constraints: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoded_values = values
             .to_vec()
@@ -613,6 +634,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &V,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         if value.is_present() {
             let mut encoder = Self::new(self.config);
@@ -626,6 +648,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -644,6 +667,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -663,14 +687,16 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         constraints: Constraints,
         value: E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        value.encode_with_tag_and_constraints(self, tag, constraints)
+        value.encode_with_tag_and_constraints(self, tag, constraints, None)
     }
 
     /// Encode a extension addition group value.
     fn encode_extension_addition_group<const RC: usize, const EC: usize, E>(
         &mut self,
         value: Option<&E>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + crate::types::Constructed<RC, EC>,
@@ -724,7 +750,7 @@ mod tests {
         fn oid_to_bytes(oid: &[u32]) -> Vec<u8> {
             use crate::Encoder;
             let mut enc = self::Encoder::new(EncoderOptions::ber());
-            enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, oid)
+            enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, oid, None)
                 .unwrap();
             enc.output
         }
@@ -842,7 +868,7 @@ mod tests {
                     field2.encode(encoder)?;
                     field1.encode(encoder)?;
                     Ok(())
-                })
+                }, None)
                 .unwrap();
 
             encoder.output()

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -328,7 +328,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _: Tag,
         value: &types::Any,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if self.is_set_encoding {
             return Err(BerEncodeErrorKind::AnyInSet.into());
@@ -344,7 +344,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::BitStr,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if value.is_empty() {
             self.encode_primitive(tag, &[]);
@@ -371,7 +371,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: bool,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[if value { 0xff } else { 0x00 }]);
         Ok(())
@@ -382,7 +382,7 @@ impl crate::Encoder<'_> for Encoder {
         _: Constraints,
         _t: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         (encode_fn)(self).map(drop)
     }
@@ -391,10 +391,15 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &E,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let value = E::discriminant(value);
-        self.encode_integer(tag, Constraints::default(), &value, None)
+        self.encode_integer(
+            tag,
+            Constraints::default(),
+            &value,
+            crate::types::Identifier::EMPTY,
+        )
     }
 
     fn encode_integer<I: IntegerType>(
@@ -402,7 +407,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &I,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let (bytes, needed) = value.to_signed_bytes_be();
         self.encode_primitive(tag, &bytes.as_ref()[..needed]);
@@ -414,12 +419,16 @@ impl crate::Encoder<'_> for Encoder {
         _: Tag,
         _: Constraints,
         _: &R,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         Err(EncodeError::real_not_supported(self.codec()))
     }
 
-    fn encode_null(&mut self, tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(
+        &mut self,
+        tag: Tag,
+        _: crate::types::Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[]);
         Ok(())
     }
@@ -428,7 +437,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         oid: &[u32],
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let bytes = self.object_identifier_as_bytes(oid)?;
         self.encode_primitive(tag, &bytes);
@@ -440,7 +449,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &[u8],
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -450,7 +459,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::VisibleString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_iso646_bytes())
     }
@@ -460,7 +469,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::Ia5String,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_iso646_bytes())
     }
@@ -470,7 +479,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::GeneralString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -480,7 +489,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::GraphicString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value)
     }
@@ -490,7 +499,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::PrintableString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -500,7 +509,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::NumericString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -510,7 +519,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _: Constraints,
         value: &types::TeletexString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, &value.to_bytes())
     }
@@ -520,7 +529,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _constraints: Constraints,
         value: &types::BmpString,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, &value.to_bytes())
     }
@@ -530,7 +539,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         _: Constraints,
         value: &str,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string_(tag, value.as_bytes())
     }
@@ -539,7 +548,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &types::UtcTime,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(
             tag,
@@ -553,7 +562,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &types::GeneralizedTime,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(
             tag,
@@ -567,7 +576,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &types::Date,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, Self::naivedate_to_date_bytes(value).as_slice());
 
@@ -577,7 +586,7 @@ impl crate::Encoder<'_> for Encoder {
     fn encode_some<E: Encode>(
         &mut self,
         value: &E,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -586,7 +595,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &E,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode_with_tag(self, tag)
     }
@@ -596,19 +605,27 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         constraints: Constraints,
         value: &E,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        value.encode_with_tag_and_constraints(self, tag, constraints, None)
+        value.encode_with_tag_and_constraints(
+            self,
+            tag,
+            constraints,
+            crate::types::Identifier::EMPTY,
+        )
     }
 
-    fn encode_none<E: Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
-        self.encode_none_with_tag(E::TAG, None)
+    fn encode_none<E: Encode>(
+        &mut self,
+        _: crate::types::Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.encode_none_with_tag(E::TAG, crate::types::Identifier::EMPTY)
     }
 
     fn encode_none_with_tag(
         &mut self,
         _: Tag,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
@@ -618,7 +635,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         values: &[E],
         _constraints: Constraints,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut sequence_encoder = Self::new(self.config);
 
@@ -636,7 +653,7 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         values: &types::SetOf<E>,
         _constraints: Constraints,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoded_values = values
             .to_vec()
@@ -662,7 +679,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         tag: Tag,
         value: &V,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if value.is_present() {
             let mut encoder = Self::new(self.config);
@@ -676,7 +693,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -695,7 +712,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -715,16 +732,21 @@ impl crate::Encoder<'_> for Encoder {
         tag: Tag,
         constraints: Constraints,
         value: E,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        value.encode_with_tag_and_constraints(self, tag, constraints, None)
+        value.encode_with_tag_and_constraints(
+            self,
+            tag,
+            constraints,
+            crate::types::Identifier::EMPTY,
+        )
     }
 
     /// Encode a extension addition group value.
     fn encode_extension_addition_group<const RC: usize, const EC: usize, E>(
         &mut self,
         value: Option<&E>,
-        _: Option<&'static str>,
+        _: crate::types::Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + crate::types::Constructed<RC, EC>,
@@ -735,14 +757,14 @@ impl crate::Encoder<'_> for Encoder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::ber::enc::{Encoder, EncoderOptions};
+    use crate::{types::*, Encode};
     use alloc::borrow::ToOwned;
     use alloc::vec;
 
     #[test]
     fn bit_string() {
-        let bitstring =
-            types::BitString::from_vec([0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..].to_owned());
+        let bitstring = BitString::from_vec([0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..].to_owned());
 
         let primitive_encoded = &[0x03, 0x07, 0x00, 0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..];
 
@@ -751,7 +773,7 @@ mod tests {
 
     #[test]
     fn identifier() {
-        fn ident_to_bytes(ident: Identifier) -> Vec<u8> {
+        fn ident_to_bytes(ident: crate::ber::Identifier) -> Vec<u8> {
             let mut enc = Encoder::new(EncoderOptions::ber());
             let bytes = enc.encode_identifier(ident);
             enc.append_byte_or_bytes(bytes);
@@ -760,7 +782,7 @@ mod tests {
 
         assert_eq!(
             &[0xFF, 0x7F,][..],
-            ident_to_bytes(Identifier::from_tag(
+            ident_to_bytes(crate::ber::Identifier::from_tag(
                 Tag::new(crate::types::Class::Private, 127),
                 true,
             ))
@@ -769,7 +791,7 @@ mod tests {
         // DATE Tag Rec. ITU-T X.680 (02/2021) section 8 Table 1
         assert_eq!(
             &[0x1F, 0x1F,][..],
-            ident_to_bytes(Identifier::from_tag(Tag::DATE, false,))
+            ident_to_bytes(crate::ber::Identifier::from_tag(Tag::DATE, false,))
         );
     }
 
@@ -778,7 +800,7 @@ mod tests {
         fn oid_to_bytes(oid: &[u32]) -> Vec<u8> {
             use crate::Encoder;
             let mut enc = self::Encoder::new(EncoderOptions::ber());
-            enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, oid, None)
+            enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, oid, Identifier::EMPTY)
                 .unwrap();
             enc.output
         }
@@ -831,11 +853,10 @@ mod tests {
 
     #[test]
     fn any() {
-        let bitstring =
-            types::BitString::from_vec([0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..].to_owned());
+        let bitstring = BitString::from_vec([0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..].to_owned());
 
         let primitive_encoded = &[0x03, 0x07, 0x00, 0x0A, 0x3B, 0x5F, 0x29, 0x1C, 0xD0][..];
-        let any = types::Any {
+        let any = Any {
             contents: primitive_encoded.into(),
         };
 
@@ -901,7 +922,7 @@ mod tests {
                         field1.encode(encoder)?;
                         Ok(())
                     },
-                    None,
+                    crate::types::Identifier::EMPTY,
                 )
                 .unwrap();
 

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -324,7 +324,12 @@ impl crate::Encoder<'_> for Encoder {
         Self::codec(self)
     }
 
-    fn encode_any(&mut self, _: Tag, value: &types::Any, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_any(
+        &mut self,
+        _: Tag,
+        value: &types::Any,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         if self.is_set_encoding {
             return Err(BerEncodeErrorKind::AnyInSet.into());
         }
@@ -362,7 +367,12 @@ impl crate::Encoder<'_> for Encoder {
         }
     }
 
-    fn encode_bool(&mut self, tag: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(
+        &mut self,
+        tag: Tag,
+        value: bool,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, &[if value { 0xff } else { 0x00 }]);
         Ok(())
     }
@@ -414,7 +424,12 @@ impl crate::Encoder<'_> for Encoder {
         Ok(())
     }
 
-    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32], _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_object_identifier(
+        &mut self,
+        tag: Tag,
+        oid: &[u32],
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         let bytes = self.object_identifier_as_bytes(oid)?;
         self.encode_primitive(tag, &bytes);
         Ok(())
@@ -548,13 +563,22 @@ impl crate::Encoder<'_> for Encoder {
         Ok(())
     }
 
-    fn encode_date(&mut self, tag: Tag, value: &types::Date, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_date(
+        &mut self,
+        tag: Tag,
+        value: &types::Date,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_primitive(tag, Self::naivedate_to_date_bytes(value).as_slice());
 
         Ok(())
     }
 
-    fn encode_some<E: Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: Encode>(
+        &mut self,
+        value: &E,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
@@ -581,7 +605,11 @@ impl crate::Encoder<'_> for Encoder {
         self.encode_none_with_tag(E::TAG, None)
     }
 
-    fn encode_none_with_tag(&mut self, _: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(
+        &mut self,
+        _: Tag,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
 
@@ -849,6 +877,8 @@ mod tests {
         let field2: Field2 = 2.into();
         let field3: Field3 = 3.into();
 
+        #[derive(AsnType)]
+        #[rasn(crate_root = "crate")]
         struct Set;
 
         impl crate::types::Constructed<3, 0> for Set {
@@ -863,12 +893,16 @@ mod tests {
         let output = {
             let mut encoder = Encoder::new_set(EncoderOptions::ber());
             encoder
-                .encode_set::<3, 0, Set, _>(Tag::SET, |encoder| {
-                    field3.encode(encoder)?;
-                    field2.encode(encoder)?;
-                    field1.encode(encoder)?;
-                    Ok(())
-                }, None)
+                .encode_set::<3, 0, Set, _>(
+                    Tag::SET,
+                    |encoder| {
+                        field3.encode(encoder)?;
+                        field2.encode(encoder)?;
+                        field1.encode(encoder)?;
+                        Ok(())
+                    },
+                    None,
+                )
                 .unwrap();
 
             encoder.output()

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -81,7 +81,7 @@ impl Codec {
             Self::Uper => crate::uper::decode(input),
             Self::Oer => crate::oer::decode(input),
             Self::Coer => crate::coer::decode(input),
-            Self::Xer => crate::coer::decode(input),
+            Self::Xer => crate::xer::decode(input),
             Self::Jer => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
                 |e| {
                     Err(crate::error::DecodeError::from_kind(

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -21,6 +21,8 @@ pub enum Codec {
     Oer,
     /// X.696 — Canonical Octet Encoding Rules
     Coer,
+    /// X.693 — XML Encoding Rules
+    Xer,
 }
 
 impl core::fmt::Display for Codec {
@@ -34,6 +36,7 @@ impl core::fmt::Display for Codec {
             Self::Jer => write!(f, "JER"),
             Self::Oer => write!(f, "OER"),
             Self::Coer => write!(f, "COER"),
+            Self::Xer => write!(f, "XER"),
         }
     }
 }
@@ -57,6 +60,7 @@ impl Codec {
             Self::Jer => crate::jer::encode(value).map(alloc::string::String::into_bytes),
             Self::Oer => crate::oer::encode(value),
             Self::Coer => crate::coer::encode(value),
+            Self::Xer => crate::xer::encode(value),
         }
     }
 
@@ -77,6 +81,7 @@ impl Codec {
             Self::Uper => crate::uper::decode(input),
             Self::Oer => crate::oer::decode(input),
             Self::Coer => crate::coer::decode(input),
+            Self::Xer => crate::coer::decode(input),
             Self::Jer => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
                 |e| {
                     Err(crate::error::DecodeError::from_kind(

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -1,7 +1,7 @@
 //! Generic ASN.1 encoding framework.
 
-use crate::types::RealType;
 use crate::types::{self, AsnType, Constraints, Enumerated, IntegerType, SetOf, Tag};
+use crate::types::{Identifier, RealType};
 use num_bigint::BigInt;
 pub use rasn_derive::Encode;
 
@@ -45,7 +45,7 @@ pub trait Encode: AsnType {
     fn encode_with_identifier<'b, E: Encoder<'b>>(
         &self,
         encoder: &mut E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         self.encode_with_tag_and_constraints(encoder, Self::TAG, Self::CONSTRAINTS, identifier)
     }
@@ -59,7 +59,7 @@ pub trait Encode: AsnType {
         &self,
         encoder: &mut E,
         tag: Tag,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         self.encode_with_tag_and_constraints(encoder, tag, Self::CONSTRAINTS, identifier)
     }
@@ -88,7 +88,7 @@ pub trait Encode: AsnType {
         &self,
         encoder: &mut E,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         self.encode_with_tag_and_constraints(encoder, Self::TAG, constraints, identifier)
     }
@@ -104,7 +104,7 @@ pub trait Encode: AsnType {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error>;
 }
 
@@ -134,7 +134,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &types::Any,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `BOOL` value.
@@ -142,7 +142,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: bool,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `BIT STRING` value.
@@ -151,7 +151,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::BitStr,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `ENUMERATED` value.
@@ -159,7 +159,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `OBJECT IDENTIFIER` value.
@@ -167,7 +167,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &[u32],
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `INTEGER` value.
@@ -176,7 +176,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &I,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `REAL` value.
@@ -185,15 +185,11 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &R,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `NULL` value.
-    fn encode_null(
-        &mut self,
-        tag: Tag,
-        identifier: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error>;
+    fn encode_null(&mut self, tag: Tag, identifier: Identifier) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `OCTET STRING` value.
     fn encode_octet_string(
@@ -201,7 +197,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &[u8],
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `GeneralString` value.
@@ -210,7 +206,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::GeneralString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `GraphicString` value.
@@ -219,7 +215,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::GraphicString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `Utf8String` value.
@@ -228,7 +224,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &str,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `VisibleString` value.
@@ -237,7 +233,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::VisibleString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `Ia5String` value.
@@ -246,7 +242,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::Ia5String,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `Ia5String` value.
@@ -255,7 +251,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::PrintableString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `NumericString` value.
@@ -264,7 +260,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::NumericString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `TeletexString` value.
@@ -273,7 +269,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::TeletexString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `BmpString` value.
@@ -282,7 +278,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &types::BmpString,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `GeneralizedTime` value.
@@ -290,7 +286,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &types::GeneralizedTime,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `UtcTime` value.
@@ -298,7 +294,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &types::UtcTime,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a 'Date' value.
@@ -306,7 +302,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &types::Date,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a explicitly tagged value.
@@ -314,7 +310,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &V,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `SEQUENCE` value.
@@ -328,7 +324,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -340,7 +336,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         value: &[E],
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a `SET` value.
@@ -354,7 +350,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &'b mut self,
         tag: Tag,
         value: F,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RC, EC>,
@@ -366,14 +362,14 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         value: &types::SetOf<E>,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode the value a field or skip if it matches the default..
     fn encode_or_default<E: Encode + Default + PartialEq>(
         &mut self,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if value != &E::default() {
             self.encode_some(value, identifier)
@@ -387,7 +383,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if value != &E::default() {
             self.encode_some_with_tag(tag, value, identifier)
@@ -400,7 +396,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
     fn encode_some<E: Encode>(
         &mut self,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode the present value of an optional field.
@@ -408,7 +404,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         tag: Tag,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_some_with_tag_and_constraints(tag, E::CONSTRAINTS, value, identifier)
     }
@@ -419,20 +415,17 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: &E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode the absent value of an optional field.
-    fn encode_none<E: Encode>(
-        &mut self,
-        identifier: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error>;
+    fn encode_none<E: Encode>(&mut self, identifier: Identifier) -> Result<Self::Ok, Self::Error>;
 
     /// Encode the absent value with `tag` of an optional field.
     fn encode_none_with_tag(
         &mut self,
         tag: Tag,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode the present value of an optional field.
@@ -440,7 +433,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         &mut self,
         value: &E,
         default: impl FnOnce() -> E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         match (*value != (default)()).then_some(value) {
             Some(value) => self.encode_some(value, identifier),
@@ -454,7 +447,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         value: &E,
         default: impl FnOnce() -> E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         match (*value != (default)()).then_some(value) {
             Some(value) => self.encode_some_with_tag(tag, value, identifier),
@@ -469,7 +462,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         constraints: Constraints,
         value: &E,
         default: impl FnOnce() -> E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         match (*value != (default)()).then_some(value) {
             Some(value) => {
@@ -485,7 +478,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         constraints: Constraints,
         value: &E,
         default: impl FnOnce() -> E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         match (*value != (default)()).then_some(value) {
             Some(value) => {
@@ -501,7 +494,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         constraints: Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a extension addition value.
@@ -510,7 +503,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         constraints: Constraints,
         value: E,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>;
 
     /// Encode a extension addition group value.
@@ -521,7 +514,7 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
     fn encode_extension_addition_group<const RC: usize, const EC: usize, E>(
         &mut self,
         value: Option<&E>,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + crate::types::Constructed<RC, EC>;
@@ -556,7 +549,7 @@ impl<E: Encode> Encode for &'_ E {
         &self,
         encoder: &mut EN,
         tag: Tag,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_tag_and_identifier(self, encoder, tag, identifier)
     }
@@ -564,7 +557,7 @@ impl<E: Encode> Encode for &'_ E {
     fn encode_with_identifier<'b, EN: Encoder<'b>>(
         &self,
         encoder: &mut EN,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_identifier(self, encoder, identifier)
     }
@@ -581,7 +574,7 @@ impl<E: Encode> Encode for &'_ E {
         &self,
         encoder: &mut EN,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_constraints_and_identifier(self, encoder, constraints, identifier)
     }
@@ -591,7 +584,7 @@ impl<E: Encode> Encode for &'_ E {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_tag_and_constraints(self, encoder, tag, constraints, identifier)
     }
@@ -603,7 +596,7 @@ impl Encode for () {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder.encode_null(tag, identifier).map(drop)
     }
@@ -634,7 +627,7 @@ impl<E: Encode> Encode for Option<E> {
         &self,
         encoder: &mut EN,
         tag: Tag,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         match self {
             Some(value) => encoder.encode_some_with_tag(tag, value, identifier),
@@ -664,7 +657,7 @@ impl<E: Encode> Encode for Option<E> {
         &self,
         encoder: &mut EN,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         match self {
             Some(value) => encoder.encode_some_with_tag_and_constraints(
@@ -681,7 +674,7 @@ impl<E: Encode> Encode for Option<E> {
     fn encode_with_identifier<'b, EN: Encoder<'b>>(
         &self,
         encoder: &mut EN,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         match self {
             Some(value) => encoder.encode_some_with_tag(Self::TAG, value, identifier),
@@ -695,7 +688,7 @@ impl<E: Encode> Encode for Option<E> {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         match self {
             Some(value) => {
@@ -714,7 +707,7 @@ impl Encode for bool {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder.encode_bool(tag, *self, identifier).map(drop)
     }
@@ -724,7 +717,7 @@ macro_rules! impl_integers {
     ($($int:ty),+) => {
         $(
             impl Encode for $int {
-                fn encode_with_tag_and_constraints<'b, E: Encoder<'b>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints, identifier: Option<&'static str>) -> Result<(), E::Error> {
+                fn encode_with_tag_and_constraints<'b, E: Encoder<'b>>(&self, encoder: &mut E, tag: Tag, constraints: Constraints, identifier: Identifier) -> Result<(), E::Error> {
                     encoder.encode_integer(
                         tag,
                         constraints,
@@ -759,7 +752,7 @@ impl Encode for BigInt {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_integer(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -773,7 +766,7 @@ impl<const START: i128, const END: i128> Encode for types::ConstrainedInteger<ST
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_integer(tag, constraints, &**self, identifier.or(Self::IDENTIFIER))
@@ -787,7 +780,7 @@ impl Encode for types::Integer {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_integer(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -802,7 +795,7 @@ impl Encode for f32 {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_real(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -817,7 +810,7 @@ impl Encode for f64 {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_real(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -831,7 +824,7 @@ impl Encode for types::OctetString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_octet_string(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -845,7 +838,7 @@ impl Encode for types::Utf8String {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_utf8_string(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -859,7 +852,7 @@ impl Encode for &'_ str {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_utf8_string(tag, constraints, self, identifier.or(Self::IDENTIFIER))
@@ -873,7 +866,7 @@ impl Encode for types::ObjectIdentifier {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_object_identifier(tag, self, identifier.or(Self::IDENTIFIER))
@@ -887,7 +880,7 @@ impl Encode for types::Oid {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_object_identifier(tag, self, identifier.or(Self::IDENTIFIER))
@@ -901,7 +894,7 @@ impl Encode for types::UtcTime {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_utc_time(tag, self, identifier.or(Self::IDENTIFIER))
@@ -915,7 +908,7 @@ impl Encode for types::GeneralizedTime {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_generalized_time(tag, self, identifier.or(Self::IDENTIFIER))
@@ -929,7 +922,7 @@ impl Encode for types::Any {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_any(tag, self, identifier.or(Self::IDENTIFIER))
@@ -961,7 +954,7 @@ impl<E: Encode> Encode for alloc::boxed::Box<E> {
     fn encode_with_identifier<'b, EN: Encoder<'b>>(
         &self,
         encoder: &mut EN,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_identifier(self, encoder, identifier)
     }
@@ -971,7 +964,7 @@ impl<E: Encode> Encode for alloc::boxed::Box<E> {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         E::encode_with_tag_and_constraints(
             self,
@@ -989,7 +982,7 @@ impl<E: Encode> Encode for alloc::vec::Vec<E> {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         encoder
             .encode_sequence_of(tag, self, constraints, identifier.or(Self::IDENTIFIER))
@@ -1003,7 +996,7 @@ impl<E: Encode + Eq + core::hash::Hash> Encode for SetOf<E> {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         encoder
             .encode_set_of(tag, self, constraints, identifier.or(Self::IDENTIFIER))
@@ -1017,7 +1010,7 @@ impl<E: Encode, const N: usize> Encode for [E; N] {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         encoder
             .encode_sequence_of(tag, self, constraints, identifier.or(Self::IDENTIFIER))
@@ -1031,7 +1024,7 @@ impl<T: AsnType, V: Encode> Encode for types::Implicit<T, V> {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         V::encode_with_tag_and_constraints(
             &self.value,
@@ -1050,7 +1043,7 @@ impl<T: AsnType, V: Encode> Encode for types::Explicit<T, V> {
         encoder: &mut E,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_explicit_prefix(tag, &self.value, identifier.or(Self::IDENTIFIER))

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,10 @@ pub mod strings {
 pub use decode::DecodeErrorKind;
 pub use decode::{
     BerDecodeErrorKind, CodecDecodeError, CoerDecodeErrorKind, DecodeError, DerDecodeErrorKind,
-    JerDecodeErrorKind, OerDecodeErrorKind,
+    JerDecodeErrorKind, OerDecodeErrorKind, XerDecodeErrorKind,
 };
 pub use encode::EncodeErrorKind;
 pub use encode::JerEncodeErrorKind;
-pub use encode::{BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError};
+pub use encode::{
+    BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError, XerEncodeErrorKind,
+};

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -822,33 +822,58 @@ pub enum AperDecodeErrorKind {}
 #[non_exhaustive]
 pub enum XerDecodeErrorKind {
     #[snafu(display("Unexpected end of input while decoding XER XML."))]
+    /// An error that indicates that the XML input ended unexpectedly
     EndOfXmlInput {},
     #[snafu(display(
         "Found mismatching XML value. Expected type {}. Found value {}.",
         needed,
         found
     ))]
+    /// An error that indicates an unexpected XML tag type or value
     XmlTypeMismatch {
+        /// the expected tag type or value
         needed: &'static str,
+        /// the encountered tag type or value
         found: alloc::string::String,
     },
     #[snafu(display("Found invalid character in octet string."))]
-    InvalidXerOctetstring { parse_int_err: ParseIntError },
+    /// An error that indicates a character in an octet string that does not conform to the hex alphabet
+    InvalidXerOctetstring {
+        /// Inner error thrown by the `parse` method
+        parse_int_err: ParseIntError,
+    },
     #[snafu(display("Encountered invalid value. {details}"))]
-    InvalidInput { details: &'static str },
+    /// An error that indicates invalid input XML
+    InvalidInput {
+        /// Error details from the underlying XML parser
+        details: &'static str,
+    },
     #[snafu(display("Found invalid open type encoding: {inner_err}"))]
+    /// An error that indicates invalid XML in an ASN.1 open type value
     InvalidOpenType {
+        /// Error details from the underlying XML parser
         inner_err: xml_no_std::writer::Error,
     },
     #[snafu(display("XML parser error: {details}"))]
-    XmlParser { details: alloc::string::String },
+    /// Miscellaneous error in the underlying XML parser
+    XmlParser {
+        /// Error details from the underlying XML parser
+        details: alloc::string::String,
+    },
     #[snafu(display("Error matching tag names: expected {needed}, found {found}"))]
+    /// An error indicating an unexpected XML tag name
     XmlTag {
+        /// The expected tag name
         needed: alloc::string::String,
+        /// The encountered tag name
         found: alloc::string::String,
     },
     #[snafu(display("Encoding violates ITU-T X.693 (02/2021): {details}"))]
-    SpecViolation { details: alloc::string::String },
+    /// An error that quotes the ITU-T X.693 paragraph being violated
+    SpecViolation {
+        /// Paragraph and excerpt from the ITU-T X.693 spec
+        details: alloc::string::String,
+    },
 }
 
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for OER.

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -473,7 +473,7 @@ mod tests {
         let oid = vec![3, 5, 4, 3];
 
         let mut enc = enc::Encoder::new(enc::EncoderOptions::ber());
-        let result = enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, &oid);
+        let result = enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, &oid, None);
         assert!(result.is_err());
         match result {
             Err(e) => match *e.kind {

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -435,11 +435,11 @@ pub enum AperEncodeErrorKind {}
 pub enum XerEncodeErrorKind {
     /// Upstream `xml` error
     XmlEncodingError { upstream: alloc::string::String },
-    #[snafu(display("Failed to retrieve field name."))]
-    FieldName,
     #[snafu(display("Failed to encode integer."))]
+    /// An error indicating an integer value outside of the supported bounds
     UnsupportedIntegerValue,
     #[snafu(display("Missing identifier for ASN.1 type."))]
+    /// An error indicating that the XML writer is missing information about the tag name of the item to encode
     MissingIdentifier,
 }
 
@@ -491,7 +491,7 @@ mod tests {
         let oid = vec![3, 5, 4, 3];
 
         let mut enc = enc::Encoder::new(enc::EncoderOptions::ber());
-        let result = enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, &oid, None);
+        let result = enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, &oid, Identifier::EMPTY);
         assert!(result.is_err());
         match result {
             Err(e) => match *e.kind {

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -19,6 +19,7 @@ pub enum CodecEncodeError {
     Aper(AperEncodeErrorKind),
     Jer(JerEncodeErrorKind),
     Coer(CoerEncodeErrorKind),
+    Xer(XerEncodeErrorKind),
 }
 macro_rules! impl_from {
     ($variant:ident, $error_kind:ty) => {
@@ -38,6 +39,7 @@ impl_from!(Uper, UperEncodeErrorKind);
 impl_from!(Aper, AperEncodeErrorKind);
 impl_from!(Jer, JerEncodeErrorKind);
 impl_from!(Coer, CoerEncodeErrorKind);
+impl_from!(Xer, XerEncodeErrorKind);
 
 impl From<CodecEncodeError> for EncodeError {
     fn from(error: CodecEncodeError) -> Self {
@@ -243,6 +245,7 @@ impl EncodeError {
             CodecEncodeError::Aper(_) => crate::Codec::Aper,
             CodecEncodeError::Jer(_) => crate::Codec::Jer,
             CodecEncodeError::Coer(_) => crate::Codec::Coer,
+            CodecEncodeError::Xer(_) => crate::Codec::Xer,
         };
         Self {
             kind: Box::new(EncodeErrorKind::CodecSpecific { inner }),
@@ -424,6 +427,21 @@ pub enum UperEncodeErrorKind {}
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum AperEncodeErrorKind {}
+
+/// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for XER.
+#[derive(Snafu, Debug)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum XerEncodeErrorKind {
+    /// Upstream `xml` error
+    XmlEncodingError { upstream: alloc::string::String },
+    #[snafu(display("Failed to retrieve field name."))]
+    FieldName,
+    #[snafu(display("Failed to encode integer."))]
+    UnsupportedIntegerValue,
+    #[snafu(display("Missing identifier for ASN.1 type."))]
+    MissingIdentifier,
+}
 
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for COER.
 #[derive(Snafu, Debug)]

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -434,7 +434,10 @@ pub enum AperEncodeErrorKind {}
 #[non_exhaustive]
 pub enum XerEncodeErrorKind {
     /// Upstream `xml` error
-    XmlEncodingError { upstream: alloc::string::String },
+    XmlEncodingError {
+        /// Stringified error of the underlying XML writer
+        upstream: alloc::string::String,
+    },
     #[snafu(display("Failed to encode integer."))]
     /// An error indicating an integer value outside of the supported bounds
     UnsupportedIntegerValue,

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -82,7 +82,12 @@ impl crate::Encoder<'_> for Encoder {
         self.encode_octet_string(t, Constraints::default(), &value.contents, None)
     }
 
-    fn encode_bool(&mut self, _: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(
+        &mut self,
+        _: Tag,
+        value: bool,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Bool(value))
     }
 
@@ -447,7 +452,11 @@ impl crate::Encoder<'_> for Encoder {
         )?))
     }
 
-    fn encode_some<E: crate::Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: crate::Encode>(
+        &mut self,
+        value: &E,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
@@ -461,12 +470,19 @@ impl crate::Encoder<'_> for Encoder {
         value.encode(self)
     }
 
-    fn encode_none<E: crate::Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: crate::Encode>(
+        &mut self,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }
 
-    fn encode_none_with_tag(&mut self, _t: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(
+        &mut self,
+        _t: Tag,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -8,7 +8,7 @@ type ValueMap = Map<alloc::string::String, Value>;
 
 use crate::{
     error::{EncodeError, JerEncodeErrorKind},
-    types::{variants, Constraints, IntegerType, Tag},
+    types::{variants, Constraints, Identifier, IntegerType, Tag},
 };
 
 use crate::types::RealType;
@@ -77,17 +77,17 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         t: crate::types::Tag,
         value: &crate::types::Any,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(t, Constraints::default(), &value.contents, None)
+        self.encode_octet_string(
+            t,
+            Constraints::default(),
+            &value.contents,
+            Identifier::EMPTY,
+        )
     }
 
-    fn encode_bool(
-        &mut self,
-        _: Tag,
-        value: bool,
-        _: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(&mut self, _: Tag, value: bool, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Bool(value))
     }
 
@@ -96,7 +96,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         constraints: crate::types::Constraints,
         value: &crate::types::BitStr,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut bitvec = value.to_bitvec();
         bitvec.force_align();
@@ -122,7 +122,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _: Tag,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(alloc::string::String::from(
             value.identifier(),
@@ -133,7 +133,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &[u32],
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             value
@@ -149,7 +149,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &I,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if let Some(as_i64) = value.to_i64() {
             self.update_root_or_constructed(Value::Number(as_i64.into()))
@@ -166,7 +166,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: Constraints,
         value: &R,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         use num_traits::{float::FloatCore, ToPrimitive, Zero};
 
@@ -191,7 +191,7 @@ impl crate::Encoder<'_> for Encoder {
         }
     }
 
-    fn encode_null(&mut self, _: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, _: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Null)
     }
 
@@ -200,7 +200,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &[u8],
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(value.iter().fold(
             alloc::string::String::new(),
@@ -216,7 +216,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::GeneralString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_vec())
@@ -229,7 +229,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::GraphicString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_vec())
@@ -242,7 +242,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &str,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(value.into()))
     }
@@ -252,7 +252,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::VisibleString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec())
@@ -265,7 +265,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::Ia5String,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec())
@@ -278,7 +278,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::PrintableString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_bytes().to_vec())
@@ -291,7 +291,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::NumericString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_bytes().to_vec())
@@ -304,7 +304,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         _value: &crate::types::TeletexString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         todo!()
     }
@@ -314,7 +314,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::BmpString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_bytes())
@@ -326,7 +326,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::GeneralizedTime,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(
@@ -340,7 +340,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::UtcTime,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(
@@ -354,7 +354,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::Date,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(crate::ber::enc::Encoder::naivedate_to_date_bytes(
@@ -368,7 +368,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _: Tag,
         value: &V,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -377,7 +377,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         __t: Tag,
         encoder_scope: F,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -410,7 +410,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         value: &[E],
         _c: crate::types::Constraints,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Array(value.iter().try_fold(
             alloc::vec![],
@@ -426,13 +426,13 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         value: F,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
         F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
     {
-        self.encode_sequence::<RL, EL, C, F>(tag, value, None)
+        self.encode_sequence::<RL, EL, C, F>(tag, value, Identifier::EMPTY)
     }
 
     fn encode_set_of<E: crate::Encode + Eq + core::hash::Hash>(
@@ -440,7 +440,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         value: &crate::types::SetOf<E>,
         _c: crate::types::Constraints,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Array(value.to_vec().iter().try_fold(
             alloc::vec![],
@@ -455,7 +455,7 @@ impl crate::Encoder<'_> for Encoder {
     fn encode_some<E: crate::Encode>(
         &mut self,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -465,24 +465,17 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
-    fn encode_none<E: crate::Encode>(
-        &mut self,
-        _: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: crate::Encode>(&mut self, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }
 
-    fn encode_none_with_tag(
-        &mut self,
-        _t: Tag,
-        _: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(&mut self, _t: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }
@@ -492,7 +485,7 @@ impl crate::Encoder<'_> for Encoder {
         _c: crate::types::Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let variants = variants::Variants::from_slice(
             &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
@@ -529,7 +522,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -537,14 +530,14 @@ impl crate::Encoder<'_> for Encoder {
     fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
         &mut self,
         value: Option<&E>,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: crate::Encode + crate::types::Constructed<RL, EL>,
     {
         match value {
             Some(v) => v.encode(self),
-            None => self.encode_none::<E>(None),
+            None => self.encode_none::<E>(Identifier::EMPTY),
         }
     }
 

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -77,11 +77,12 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         t: crate::types::Tag,
         value: &crate::types::Any,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(t, Constraints::default(), &value.contents)
+        self.encode_octet_string(t, Constraints::default(), &value.contents, None)
     }
 
-    fn encode_bool(&mut self, _: Tag, value: bool) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(&mut self, _: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Bool(value))
     }
 
@@ -90,6 +91,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         constraints: crate::types::Constraints,
         value: &crate::types::BitStr,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut bitvec = value.to_bitvec();
         bitvec.force_align();
@@ -115,6 +117,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(alloc::string::String::from(
             value.identifier(),
@@ -125,6 +128,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &[u32],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             value
@@ -140,6 +144,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &I,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         if let Some(as_i64) = value.to_i64() {
             self.update_root_or_constructed(Value::Number(as_i64.into()))
@@ -156,6 +161,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: Constraints,
         value: &R,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         use num_traits::{float::FloatCore, ToPrimitive, Zero};
 
@@ -180,7 +186,7 @@ impl crate::Encoder<'_> for Encoder {
         }
     }
 
-    fn encode_null(&mut self, _: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, _: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Null)
     }
 
@@ -189,6 +195,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &[u8],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(value.iter().fold(
             alloc::string::String::new(),
@@ -204,6 +211,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::GeneralString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_vec())
@@ -216,6 +224,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::GraphicString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_vec())
@@ -228,6 +237,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &str,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(value.into()))
     }
@@ -237,6 +247,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::VisibleString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec())
@@ -249,6 +260,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::Ia5String,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec())
@@ -261,6 +273,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::PrintableString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_bytes().to_vec())
@@ -273,6 +286,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::NumericString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.as_bytes().to_vec())
@@ -285,6 +299,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         _value: &crate::types::TeletexString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         todo!()
     }
@@ -294,6 +309,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &crate::types::BmpString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(value.to_bytes())
@@ -305,6 +321,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::GeneralizedTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(
@@ -318,6 +335,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::UtcTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(
@@ -331,6 +349,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _t: Tag,
         value: &crate::types::Date,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::String(
             alloc::string::String::from_utf8(crate::ber::enc::Encoder::naivedate_to_date_bytes(
@@ -344,6 +363,7 @@ impl crate::Encoder<'_> for Encoder {
         &mut self,
         _: Tag,
         value: &V,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -352,6 +372,7 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         __t: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -384,6 +405,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         value: &[E],
         _c: crate::types::Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Array(value.iter().try_fold(
             alloc::vec![],
@@ -399,12 +421,13 @@ impl crate::Encoder<'_> for Encoder {
         &'b mut self,
         tag: Tag,
         value: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
         F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
     {
-        self.encode_sequence::<RL, EL, C, F>(tag, value)
+        self.encode_sequence::<RL, EL, C, F>(tag, value, None)
     }
 
     fn encode_set_of<E: crate::Encode + Eq + core::hash::Hash>(
@@ -412,6 +435,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         value: &crate::types::SetOf<E>,
         _c: crate::types::Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.update_root_or_constructed(Value::Array(value.to_vec().iter().try_fold(
             alloc::vec![],
@@ -423,7 +447,7 @@ impl crate::Encoder<'_> for Encoder {
         )?))
     }
 
-    fn encode_some<E: crate::Encode>(&mut self, value: &E) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: crate::Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
@@ -432,16 +456,17 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
 
-    fn encode_none<E: crate::Encode>(&mut self) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: crate::Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }
 
-    fn encode_none_with_tag(&mut self, _t: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(&mut self, _t: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.stack.pop();
         Ok(())
     }
@@ -451,6 +476,7 @@ impl crate::Encoder<'_> for Encoder {
         _c: crate::types::Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let variants = variants::Variants::from_slice(
             &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
@@ -487,6 +513,7 @@ impl crate::Encoder<'_> for Encoder {
         _t: Tag,
         _c: crate::types::Constraints,
         value: E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         value.encode(self)
     }
@@ -494,13 +521,14 @@ impl crate::Encoder<'_> for Encoder {
     fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
         &mut self,
         value: Option<&E>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: crate::Encode + crate::types::Constructed<RL, EL>,
     {
         match value {
             Some(v) => v.encode(self),
-            None => self.encode_none::<E>(),
+            None => self.encode_none::<E>(None),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,10 @@ mod tests {
                 encoder: &mut E,
                 tag: Tag,
                 constraints: Constraints,
+                _: Option<&'static str>,
             ) -> Result<(), E::Error> {
                 encoder
-                    .encode_integer::<i128>(tag, constraints, &self.0.into())
+                    .encode_integer::<i128>(tag, constraints, &self.0.into(), None)
                     .map(drop)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,10 +152,10 @@ mod tests {
                 encoder: &mut E,
                 tag: Tag,
                 constraints: Constraints,
-                _: Option<&'static str>,
+                _: Identifier,
             ) -> Result<(), E::Error> {
                 encoder
-                    .encode_integer::<i128>(tag, constraints, &self.0.into(), None)
+                    .encode_integer::<i128>(tag, constraints, &self.0.into(), Identifier::EMPTY)
                     .map(drop)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod der;
 pub mod jer;
 pub mod oer;
 pub mod uper;
+pub mod xer;
 
 #[doc(inline)]
 pub use self::{

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -286,7 +286,7 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
                 });
                 return match length {
                     Ok(length) => {
-                        let bytes_required = (*length + 7) / 8;
+                        let bytes_required = (*length).div_ceil(8);
                         let data = &self
                             .extract_data_by_length(bytes_required)?
                             .view_bits::<Msb0>()[..*length];
@@ -439,7 +439,7 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
         let is_extensible = D::IS_EXTENSIBLE;
         let preamble_width =
             D::FIELDS.number_of_optional_and_default_fields() + is_extensible as usize;
-        let bytes = self.extract_data_by_length((preamble_width + 7) / 8)?;
+        let bytes = self.extract_data_by_length(preamble_width.div_ceil(8))?;
 
         let mut result = [false; RC];
         let mut extensible_present = false;

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -622,14 +622,24 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         self.options.current_codec()
     }
 
-    fn encode_any(&mut self, tag: Tag, value: &Any) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, <Constraints>::default(), &value.contents)
+    fn encode_any(
+        &mut self,
+        tag: Tag,
+        value: &Any,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.encode_octet_string(tag, <Constraints>::default(), &value.contents, None)
     }
 
     /// ITU-T X.696 9.
     /// False is encoded as a single zero octet. In COER, true is always encoded as 0xFF.
     /// In Basic-OER, any non-zero octet value represents true, but we support only canonical encoding.
-    fn encode_bool(&mut self, tag: Tag, value: bool) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(
+        &mut self,
+        tag: Tag,
+        value: bool,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.output
             .extend_from_slice(if value { &[0xffu8] } else { &[0x00u8] });
         self.extend(tag)
@@ -640,6 +650,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &BitStr,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // TODO When Rec. ITU-T X.680 | ISO/IEC 8824-1, 22.7 applies (i.e., the bitstring type is defined with a
         // "NamedBitList"), the bitstring value shall be encoded with trailing 0 bits added or removed as necessary to satisfy the
@@ -711,6 +722,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         &mut self,
         tag: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // 11.5 The presence of an extension marker in the definition of an enumerated type does not affect the encoding of
         // the values of the enumerated type.
@@ -732,6 +744,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         &mut self,
         tag: Tag,
         value: &[u32],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut enc = crate::ber::enc::Encoder::new(crate::ber::enc::EncoderOptions::ber());
         let mut octets = enc.object_identifier_as_bytes(value)?;
@@ -746,6 +759,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &I,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_integer_with_constraints(tag, &constraints, value)
     }
@@ -755,6 +769,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         _constraints: Constraints,
         value: &R,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let (bytes, len) = value.to_ieee754_bytes();
         self.output.extend_from_slice(&bytes.as_ref()[..len]);
@@ -763,7 +778,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         Ok(())
     }
 
-    fn encode_null(&mut self, _tag: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, _tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
 
@@ -772,6 +787,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &[u8],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         if self.check_fixed_size_constraint(value.len(), &constraints)? {
             self.output.extend_from_slice(value);
@@ -789,9 +805,10 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &GeneralString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // Seems like it can be encoded as it is...
-        self.encode_octet_string(tag, constraints, value)
+        self.encode_octet_string(tag, constraints, value, None)
     }
 
     fn encode_graphic_string(
@@ -799,9 +816,10 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &GraphicString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // Seems like it can be encoded as it is...
-        self.encode_octet_string(tag, constraints, value)
+        self.encode_octet_string(tag, constraints, value, None)
     }
 
     fn encode_utf8_string(
@@ -809,8 +827,9 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &str,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, value.as_bytes())
+        self.encode_octet_string(tag, constraints, value.as_bytes(), None)
     }
 
     fn encode_visible_string(
@@ -818,8 +837,9 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &VisibleString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, value.as_iso646_bytes())
+        self.encode_octet_string(tag, constraints, value.as_iso646_bytes(), None)
     }
 
     fn encode_ia5_string(
@@ -827,8 +847,9 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &Ia5String,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, value.as_iso646_bytes())
+        self.encode_octet_string(tag, constraints, value.as_iso646_bytes(), None)
     }
 
     fn encode_printable_string(
@@ -836,8 +857,9 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &PrintableString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, value.as_bytes())
+        self.encode_octet_string(tag, constraints, value.as_bytes(), None)
     }
 
     fn encode_numeric_string(
@@ -845,8 +867,9 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &NumericString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, value.as_bytes())
+        self.encode_octet_string(tag, constraints, value.as_bytes(), None)
     }
 
     fn encode_teletex_string(
@@ -854,11 +877,12 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &TeletexString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // X.690 8.23.5
         // TODO the octets specified in ISO/IEC 2022 for encodings in an 8-bit environment, using
         // the escape sequence and character codings registered in accordance with ISO/IEC 2375.
-        self.encode_octet_string(tag, constraints, &value.to_bytes())
+        self.encode_octet_string(tag, constraints, &value.to_bytes(), None)
     }
 
     fn encode_bmp_string(
@@ -866,41 +890,57 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &BmpString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, constraints, &value.to_bytes())
+        self.encode_octet_string(tag, constraints, &value.to_bytes(), None)
     }
 
     fn encode_generalized_time(
         &mut self,
         tag: Tag,
         value: &GeneralizedTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::enc::Encoder::datetime_to_canonical_generalized_time_bytes(value),
+            None,
         )
     }
 
-    fn encode_utc_time(&mut self, tag: Tag, value: &UtcTime) -> Result<Self::Ok, Self::Error> {
+    fn encode_utc_time(
+        &mut self,
+        tag: Tag,
+        value: &UtcTime,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::enc::Encoder::datetime_to_canonical_utc_time_bytes(value),
+            None,
         )
     }
 
-    fn encode_date(&mut self, tag: Tag, value: &Date) -> Result<Self::Ok, Self::Error> {
+    fn encode_date(
+        &mut self,
+        tag: Tag,
+        value: &Date,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::enc::Encoder::naivedate_to_date_bytes(value),
+            None,
         )
     }
     fn encode_explicit_prefix<V: Encode>(
         &mut self,
         tag: Tag,
         value: &V,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // Whether we have a choice type being encoded
         if V::TAG == Tag::EOC {
@@ -914,6 +954,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: Constructed<RL, EL>,
@@ -949,6 +990,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         value: &[E],
         _: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // It seems that constraints here are not C/OER visible? No mention in standard...
         self.encode_unconstrained_integer(&value.len(), false)?;
@@ -968,6 +1010,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: Constructed<RL, EL>,
@@ -996,11 +1039,16 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         value: &SetOf<E>,
         constraints: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_sequence_of(tag, &value.to_vec(), constraints)
+        self.encode_sequence_of(tag, &value.to_vec(), constraints, None)
     }
 
-    fn encode_some<E: Encode>(&mut self, value: &E) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: Encode>(
+        &mut self,
+        value: &E,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, true);
         value.encode(self)
     }
@@ -1010,17 +1058,22 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, true);
-        value.encode_with_tag_and_constraints(self, tag, constraints)
+        value.encode_with_tag_and_constraints(self, tag, constraints, None)
     }
 
-    fn encode_none<E: Encode>(&mut self) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, false);
         Ok(())
     }
 
-    fn encode_none_with_tag(&mut self, tag: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(
+        &mut self,
+        tag: Tag,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, false);
         Ok(())
     }
@@ -1030,6 +1083,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         _: Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // Encode tag
         let mut tag_buffer: BitArray<[u8; core::mem::size_of::<Tag>() + 1], Msb0> =
@@ -1062,6 +1116,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         tag: Tag,
         constraints: Constraints,
         value: E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         // let buffer_end = self.output.len();
         if value.is_present() {
@@ -1073,7 +1128,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
             // Swap the buffers here to avoid extra alloactions
             // Also helps us on playing with mutability checks...
             let mut encoder = Encoder::<0>::from_buffer(self.options, self.worker, self.output);
-            E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints)?;
+            E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints, None)?;
             // Truncate the actual output buffer to the original state
             encoder.worker.truncate(cursor);
             Self::encode_length(encoder.worker, encoder.output.len())?;
@@ -1087,6 +1142,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
     fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
         &mut self,
         value: Option<&E>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + Constructed<RL, EL>,

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -788,7 +788,12 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Self::codec(self)
     }
 
-    fn encode_any(&mut self, tag: Tag, value: &types::Any, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_any(
+        &mut self,
+        tag: Tag,
+        value: &types::Any,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(tag, Constraints::default(), &value.contents, None)
     }
 
@@ -840,7 +845,12 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Ok(())
     }
 
-    fn encode_bool(&mut self, tag: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(
+        &mut self,
+        tag: Tag,
+        value: bool,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.extend(tag, value);
         Ok(())
     }
@@ -910,7 +920,12 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Ok(())
     }
 
-    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32], _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_object_identifier(
+        &mut self,
+        tag: Tag,
+        oid: &[u32],
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         let mut encoder = crate::der::enc::Encoder::new(crate::der::enc::EncoderOptions::der());
         let der = encoder.object_identifier_as_bytes(oid)?;
         self.encode_octet_string(tag, Constraints::default(), &der, None)
@@ -1025,7 +1040,12 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         value: &types::UtcTime,
         _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
+        self.encode_octet_string(
+            tag,
+            Constraints::default(),
+            &crate::der::encode(value)?,
+            None,
+        )
     }
 
     fn encode_generalized_time(
@@ -1034,11 +1054,26 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         value: &types::GeneralizedTime,
         _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
+        self.encode_octet_string(
+            tag,
+            Constraints::default(),
+            &crate::der::encode(value)?,
+            None,
+        )
     }
 
-    fn encode_date(&mut self, tag: Tag, value: &types::Date, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
+    fn encode_date(
+        &mut self,
+        tag: Tag,
+        value: &types::Date,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.encode_octet_string(
+            tag,
+            Constraints::default(),
+            &crate::der::encode(value)?,
+            None,
+        )
     }
 
     fn encode_sequence_of<E: Encode>(
@@ -1102,7 +1137,11 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         }
     }
 
-    fn encode_some<E: Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: Encode>(
+        &mut self,
+        value: &E,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, true);
         value.encode(self)
     }
@@ -1133,7 +1172,11 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Ok(())
     }
 
-    fn encode_none_with_tag(&mut self, tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(
+        &mut self,
+        tag: Tag,
+        _: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, false);
         Ok(())
     }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -15,7 +15,7 @@ use crate::{
         strings::{
             should_be_indexed, BitStr, DynConstrainedCharacterString, StaticPermittedAlphabet,
         },
-        BitString, Constraints, Enumerated, IntegerType, Tag,
+        BitString, Constraints, Enumerated, Identifier, IntegerType, Tag,
     },
     Encode,
 };
@@ -792,9 +792,14 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &types::Any,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &value.contents, None)
+        self.encode_octet_string(
+            tag,
+            Constraints::default(),
+            &value.contents,
+            Identifier::EMPTY,
+        )
     }
 
     fn encode_bit_string(
@@ -802,7 +807,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &BitStr,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let bit_string_length = value.len();
@@ -849,7 +854,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: bool,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.extend(tag, value);
         Ok(())
@@ -859,7 +864,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let index = value.enumeration_index();
@@ -898,7 +903,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &I,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::new();
         self.encode_integer_into_buffer(constraints, value, &mut buffer)?;
@@ -911,12 +916,12 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         _: Tag,
         _: Constraints,
         _: &R,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         Err(Error::real_not_supported(self.codec()))
     }
 
-    fn encode_null(&mut self, _tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, _tag: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
 
@@ -924,11 +929,11 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         oid: &[u32],
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoder = crate::der::enc::Encoder::new(crate::der::enc::EncoderOptions::der());
         let der = encoder.object_identifier_as_bytes(oid)?;
-        self.encode_octet_string(tag, Constraints::default(), &der, None)
+        self.encode_octet_string(tag, Constraints::default(), &der, Identifier::EMPTY)
     }
 
     fn encode_octet_string(
@@ -936,7 +941,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &[u8],
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         self.encode_octet_string_into_buffer(constraints, value, &mut buffer)?;
@@ -949,7 +954,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::VisibleString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -959,7 +964,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::Ia5String,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -969,9 +974,9 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &types::GeneralString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value, None)
+        self.encode_octet_string(tag, Constraints::default(), value, Identifier::EMPTY)
     }
 
     fn encode_graphic_string(
@@ -979,9 +984,9 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &types::GraphicString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value, None)
+        self.encode_octet_string(tag, Constraints::default(), value, Identifier::EMPTY)
     }
 
     fn encode_printable_string(
@@ -989,7 +994,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::PrintableString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -999,7 +1004,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::NumericString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -1009,7 +1014,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::TeletexString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -1019,7 +1024,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::BmpString,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -1029,22 +1034,27 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &str,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value.as_bytes(), None)
+        self.encode_octet_string(
+            tag,
+            Constraints::default(),
+            value.as_bytes(),
+            Identifier::EMPTY,
+        )
     }
 
     fn encode_utc_time(
         &mut self,
         tag: Tag,
         value: &types::UtcTime,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::encode(value)?,
-            None,
+            Identifier::EMPTY,
         )
     }
 
@@ -1052,13 +1062,13 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &types::GeneralizedTime,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::encode(value)?,
-            None,
+            Identifier::EMPTY,
         )
     }
 
@@ -1066,13 +1076,13 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &types::Date,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_octet_string(
             tag,
             Constraints::default(),
             &crate::der::encode(value)?,
-            None,
+            Identifier::EMPTY,
         )
     }
 
@@ -1081,7 +1091,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         values: &[E],
         constraints: Constraints,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let options = self.options;
@@ -1119,16 +1129,16 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         values: &types::SetOf<E>,
         constraints: Constraints,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_sequence_of(tag, &values.to_vec(), constraints, None)
+        self.encode_sequence_of(tag, &values.to_vec(), constraints, Identifier::EMPTY)
     }
 
     fn encode_explicit_prefix<V: Encode>(
         &mut self,
         tag: Tag,
         value: &V,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         if V::TAG == Tag::EOC {
             value.encode(self)
@@ -1140,7 +1150,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
     fn encode_some<E: Encode>(
         &mut self,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, true);
         value.encode(self)
@@ -1150,7 +1160,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, true);
         value.encode_with_tag(self, tag)
@@ -1161,22 +1171,18 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, true);
-        value.encode_with_tag_and_constraints(self, tag, constraints, None)
+        value.encode_with_tag_and_constraints(self, tag, constraints, Identifier::EMPTY)
     }
 
-    fn encode_none<E: Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: Encode>(&mut self, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, false);
         Ok(())
     }
 
-    fn encode_none_with_tag(
-        &mut self,
-        tag: Tag,
-        _: Option<&'static str>,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(&mut self, tag: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, false);
         Ok(())
     }
@@ -1185,7 +1191,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -1200,7 +1206,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -1218,7 +1224,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         constraints: Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::new();
 
@@ -1296,11 +1302,17 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: E,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoder = Self::new(self.options.without_set_encoding());
         if value.is_present() {
-            E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints, None)?;
+            E::encode_with_tag_and_constraints(
+                &value,
+                &mut encoder,
+                tag,
+                constraints,
+                Identifier::EMPTY,
+            )?;
             self.extension_fields[self.extension_bitfield.0] = Some(encoder.output());
             self.set_extension_presence(true);
         } else {
@@ -1313,7 +1325,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
     fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
         &mut self,
         value: Option<&E>,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + crate::types::Constructed<RL, EL>,
@@ -1463,10 +1475,10 @@ mod tests {
                 encoder: &mut E,
                 tag: Tag,
                 constraints: Constraints,
-                _: Option<&'static str>,
+                _: Identifier,
             ) -> Result<(), E::Error> {
                 encoder
-                    .encode_integer::<i128>(tag, constraints, &self.0.into(), None)
+                    .encode_integer::<i128>(tag, constraints, &self.0.into(), Identifier::EMPTY)
                     .map(drop)
             }
         }
@@ -1490,20 +1502,20 @@ mod tests {
         let mut encoder = Encoder::<0, 0>::new(EncoderOptions::unaligned());
         const CONSTRAINT_1: Constraints = constraints!(value_constraint!(start: -1));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_1, &4096.into(), None)
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_1, &4096.into(), Identifier::EMPTY)
             .unwrap();
 
         assert_eq!(&[2, 0b00010000, 1], &*encoder.output.clone().into_vec());
         encoder.output.clear();
         const CONSTRAINT_2: Constraints = constraints!(value_constraint!(start: 1));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_2, &127.into(), None)
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_2, &127.into(), Identifier::EMPTY)
             .unwrap();
         assert_eq!(&[1, 0b01111110], &*encoder.output.clone().into_vec());
         encoder.output.clear();
         const CONSTRAINT_3: Constraints = constraints!(value_constraint!(start: 0));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_3, &128.into(), None)
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_3, &128.into(), Identifier::EMPTY)
             .unwrap();
         assert_eq!(&[1, 0b10000000], &*encoder.output.into_vec());
     }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -788,8 +788,8 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Self::codec(self)
     }
 
-    fn encode_any(&mut self, tag: Tag, value: &types::Any) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &value.contents)
+    fn encode_any(&mut self, tag: Tag, value: &types::Any, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+        self.encode_octet_string(tag, Constraints::default(), &value.contents, None)
     }
 
     fn encode_bit_string(
@@ -797,6 +797,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &BitStr,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let bit_string_length = value.len();
@@ -839,7 +840,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         Ok(())
     }
 
-    fn encode_bool(&mut self, tag: Tag, value: bool) -> Result<Self::Ok, Self::Error> {
+    fn encode_bool(&mut self, tag: Tag, value: bool, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.extend(tag, value);
         Ok(())
     }
@@ -848,6 +849,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let index = value.enumeration_index();
@@ -886,6 +888,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &I,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::new();
         self.encode_integer_into_buffer(constraints, value, &mut buffer)?;
@@ -898,18 +901,19 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         _: Tag,
         _: Constraints,
         _: &R,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         Err(Error::real_not_supported(self.codec()))
     }
 
-    fn encode_null(&mut self, _tag: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_null(&mut self, _tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         Ok(())
     }
 
-    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32]) -> Result<Self::Ok, Self::Error> {
+    fn encode_object_identifier(&mut self, tag: Tag, oid: &[u32], _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         let mut encoder = crate::der::enc::Encoder::new(crate::der::enc::EncoderOptions::der());
         let der = encoder.object_identifier_as_bytes(oid)?;
-        self.encode_octet_string(tag, Constraints::default(), &der)
+        self.encode_octet_string(tag, Constraints::default(), &der, None)
     }
 
     fn encode_octet_string(
@@ -917,6 +921,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &[u8],
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         self.encode_octet_string_into_buffer(constraints, value, &mut buffer)?;
@@ -929,6 +934,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::VisibleString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -938,6 +944,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::Ia5String,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -947,8 +954,9 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &types::GeneralString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value)
+        self.encode_octet_string(tag, Constraints::default(), value, None)
     }
 
     fn encode_graphic_string(
@@ -956,8 +964,9 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &types::GraphicString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value)
+        self.encode_octet_string(tag, Constraints::default(), value, None)
     }
 
     fn encode_printable_string(
@@ -965,6 +974,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::PrintableString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -974,6 +984,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::NumericString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -983,6 +994,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::TeletexString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -992,6 +1004,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &types::BmpString,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.encode_known_multiplier_string(tag, &constraints, value)
     }
@@ -1001,28 +1014,31 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         _: Constraints,
         value: &str,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), value.as_bytes())
+        self.encode_octet_string(tag, Constraints::default(), value.as_bytes(), None)
     }
 
     fn encode_utc_time(
         &mut self,
         tag: Tag,
         value: &types::UtcTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?)
+        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
     }
 
     fn encode_generalized_time(
         &mut self,
         tag: Tag,
         value: &types::GeneralizedTime,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?)
+        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
     }
 
-    fn encode_date(&mut self, tag: Tag, value: &types::Date) -> Result<Self::Ok, Self::Error> {
-        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?)
+    fn encode_date(&mut self, tag: Tag, value: &types::Date, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
+        self.encode_octet_string(tag, Constraints::default(), &crate::der::encode(value)?, None)
     }
 
     fn encode_sequence_of<E: Encode>(
@@ -1030,6 +1046,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         values: &[E],
         constraints: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::default();
         let options = self.options;
@@ -1067,14 +1084,16 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         values: &types::SetOf<E>,
         constraints: Constraints,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
-        self.encode_sequence_of(tag, &values.to_vec(), constraints)
+        self.encode_sequence_of(tag, &values.to_vec(), constraints, None)
     }
 
     fn encode_explicit_prefix<V: Encode>(
         &mut self,
         tag: Tag,
         value: &V,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         if V::TAG == Tag::EOC {
             value.encode(self)
@@ -1083,7 +1102,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         }
     }
 
-    fn encode_some<E: Encode>(&mut self, value: &E) -> Result<Self::Ok, Self::Error> {
+    fn encode_some<E: Encode>(&mut self, value: &E, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, true);
         value.encode(self)
     }
@@ -1092,6 +1111,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &mut self,
         tag: Tag,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, true);
         value.encode_with_tag(self, tag)
@@ -1102,17 +1122,18 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: &E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, true);
-        value.encode_with_tag_and_constraints(self, tag, constraints)
+        value.encode_with_tag_and_constraints(self, tag, constraints, None)
     }
 
-    fn encode_none<E: Encode>(&mut self) -> Result<Self::Ok, Self::Error> {
+    fn encode_none<E: Encode>(&mut self, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.set_presence(E::TAG, false);
         Ok(())
     }
 
-    fn encode_none_with_tag(&mut self, tag: Tag) -> Result<Self::Ok, Self::Error> {
+    fn encode_none_with_tag(&mut self, tag: Tag, _: Option<&'static str>) -> Result<Self::Ok, Self::Error> {
         self.set_presence(tag, false);
         Ok(())
     }
@@ -1121,6 +1142,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -1135,6 +1157,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         &'b mut self,
         tag: Tag,
         encoder_scope: F,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         C: crate::types::Constructed<RL, EL>,
@@ -1152,6 +1175,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         constraints: Constraints,
         tag: Tag,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::new();
 
@@ -1229,10 +1253,11 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         tag: Tag,
         constraints: Constraints,
         value: E,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error> {
         let mut encoder = Self::new(self.options.without_set_encoding());
         if value.is_present() {
-            E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints)?;
+            E::encode_with_tag_and_constraints(&value, &mut encoder, tag, constraints, None)?;
             self.extension_fields[self.extension_bitfield.0] = Some(encoder.output());
             self.set_extension_presence(true);
         } else {
@@ -1245,6 +1270,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
     fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
         &mut self,
         value: Option<&E>,
+        _: Option<&'static str>,
     ) -> Result<Self::Ok, Self::Error>
     where
         E: Encode + crate::types::Constructed<RL, EL>,
@@ -1394,9 +1420,10 @@ mod tests {
                 encoder: &mut E,
                 tag: Tag,
                 constraints: Constraints,
+                _: Option<&'static str>,
             ) -> Result<(), E::Error> {
                 encoder
-                    .encode_integer::<i128>(tag, constraints, &self.0.into())
+                    .encode_integer::<i128>(tag, constraints, &self.0.into(), None)
                     .map(drop)
             }
         }
@@ -1420,20 +1447,20 @@ mod tests {
         let mut encoder = Encoder::<0, 0>::new(EncoderOptions::unaligned());
         const CONSTRAINT_1: Constraints = constraints!(value_constraint!(start: -1));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_1, &4096.into())
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_1, &4096.into(), None)
             .unwrap();
 
         assert_eq!(&[2, 0b00010000, 1], &*encoder.output.clone().into_vec());
         encoder.output.clear();
         const CONSTRAINT_2: Constraints = constraints!(value_constraint!(start: 1));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_2, &127.into())
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_2, &127.into(), None)
             .unwrap();
         assert_eq!(&[1, 0b01111110], &*encoder.output.clone().into_vec());
         encoder.output.clear();
         const CONSTRAINT_3: Constraints = constraints!(value_constraint!(start: 0));
         encoder
-            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_3, &128.into())
+            .encode_integer::<i128>(Tag::INTEGER, CONSTRAINT_3, &128.into(), None)
             .unwrap();
         assert_eq!(&[1, 0b10000000], &*encoder.output.into_vec());
     }

--- a/src/types/constructed.rs
+++ b/src/types/constructed.rs
@@ -3,12 +3,10 @@
 use core::hash::{BuildHasher, Hash};
 use hashbrown::HashMap;
 
-use super::AsnType;
-
 /// A `SET` or `SEQUENCE` value.
 /// `RL` is the number of fields in the "root component list".
 /// `EL` is the number of fields in the list of extensions.
-pub trait Constructed<const RL: usize = 0, const EL: usize = 0>: AsnType {
+pub trait Constructed<const RL: usize = 0, const EL: usize = 0> {
     /// Fields contained in the "root component list".
     const FIELDS: super::fields::Fields<RL>;
     /// Whether the type is extensible.

--- a/src/types/constructed.rs
+++ b/src/types/constructed.rs
@@ -3,10 +3,12 @@
 use core::hash::{BuildHasher, Hash};
 use hashbrown::HashMap;
 
+use super::AsnType;
+
 /// A `SET` or `SEQUENCE` value.
 /// `RL` is the number of fields in the "root component list".
 /// `EL` is the number of fields in the list of extensions.
-pub trait Constructed<const RL: usize = 0, const EL: usize = 0> {
+pub trait Constructed<const RL: usize = 0, const EL: usize = 0>: AsnType {
     /// Fields contained in the "root component list".
     const FIELDS: super::fields::Fields<RL>;
     /// Whether the type is extensible.

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -2,9 +2,11 @@ use crate::prelude::Constraints;
 use crate::types::Date;
 use crate::{types::Tag, AsnType, Decode, Decoder, Encode, Encoder};
 
+use super::Identifier;
+
 impl AsnType for Date {
     const TAG: Tag = Tag::DATE;
-    const IDENTIFIER: Option<&'static str> = Some("DATE");
+    const IDENTIFIER: Identifier = Identifier::DATE;
 }
 
 impl Decode for Date {
@@ -23,7 +25,7 @@ impl Encode for Date {
         encoder: &mut E,
         tag: Tag,
         _constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder.encode_date(tag, self, identifier).map(drop)
     }

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -4,6 +4,7 @@ use crate::{types::Tag, AsnType, Decode, Decoder, Encode, Encoder};
 
 impl AsnType for Date {
     const TAG: Tag = Tag::DATE;
+    const IDENTIFIER: Option<&'static str> = Some("DATE");
 }
 
 impl Decode for Date {

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -22,7 +22,8 @@ impl Encode for Date {
         encoder: &mut E,
         tag: Tag,
         _constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_date(tag, self).map(drop)
+        encoder.encode_date(tag, self, identifier).map(drop)
     }
 }

--- a/src/types/identifier.rs
+++ b/src/types/identifier.rs
@@ -1,0 +1,97 @@
+/// The identifier of an ASN.1 type in an ASN.1 module. In most cases,
+/// the identifier is the human-readable type name as defined in the ASN.1 module.
+/// For built-in ASN.1 types, the XML tag names as defined in ITU-T X.680 (2021/02) §12.36
+/// are used. Some ASN.1 types, most notably open types, do not have a consistent identifier.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct Identifier(pub Option<&'static str>);
+
+impl Identifier {
+    /// Empty identifier value
+    pub const EMPTY: Self = Self(None);
+    /// Identifier for the built-in Bit String type
+    pub const BIT_STRING: Self = Self(Some("BIT_STRING"));
+    /// Identifier for the built-in Bool type
+    pub const BOOL: Self = Self(Some("BOOLEAN"));
+    /// Identifier for the built-in Choice type
+    pub const CHOICE: Self = Self(Some("CHOICE"));
+    /// Identifier for the built-in Date type
+    pub const DATE: Self = Self(Some("DATE"));
+    /// Identifier for the built-in Date Time type
+    pub const DATE_TIME: Self = Self(Some("DATE_TIME"));
+    /// Identifier for the built-in Duration type
+    pub const DURATION: Self = Self(Some("DURATION"));
+    /// Identifier for the built-in Embedded PDV type
+    pub const EMBEDDED_PDV: Self = Self(Some("SEQUENCE"));
+    /// Identifier for the built-in Enumerated type
+    pub const ENUMERATED: Self = Self(Some("ENUMERATED"));
+    /// Identifier for the built-in External type
+    pub const EXTERNAL: Self = Self(Some("SEQUENCE"));
+    /// Identifier for the built-in Instance_Of type
+    pub const INSTANCE_OF: Self = Self(Some("SEQUENCE"));
+    /// Identifier for the built-in Integer type
+    pub const INTEGER: Self = Self(Some("INTEGER"));
+    /// Identifier for the built-in Iri type
+    pub const IRI: Self = Self(Some("OID_IRI"));
+    /// Identifier for the built-in Null type
+    pub const NULL: Self = Self(Some("NULL"));
+    /// Identifier for the built-in Object_Identifier type
+    pub const OBJECT_IDENTIFIER: Self = Self(Some("OBJECT_IDENTIFIER"));
+    /// Identifier for the built-in Octet String type
+    pub const OCTET_STRING: Self = Self(Some("OCTET_STRING"));
+    /// Identifier for the built-in Real type
+    pub const REAL: Self = Self(Some("REAL"));
+    /// Identifier for the built-in Relative Iri type
+    pub const RELATIVE_IRI: Self = Self(Some("RELATIVE_OID_IRI"));
+    /// Identifier for the built-in Relative Oid type
+    pub const RELATIVE_OID: Self = Self(Some("RELATIVE_OID"));
+    /// Identifier for the built-in Sequence type
+    pub const SEQUENCE: Self = Self(Some("SEQUENCE"));
+    /// Identifier for the built-in Sequence Of type
+    pub const SEQUENCE_OF: Self = Self(Some("SEQUENCE_OF"));
+    /// Identifier for the built-in Set type
+    pub const SET: Self = Self(Some("SET"));
+    /// Identifier for the built-in Set Of type
+    pub const SET_OF: Self = Self(Some("SET_OF"));
+    /// Identifier for the built-in Time type
+    pub const TIME: Self = Self(Some("TIME"));
+    /// Identifier for the built-in Time Of Day type
+    pub const TIME_OF_DAY: Self = Self(Some("TIME_OF_DAY"));
+    /// Identifier for the built-in Unrestricted Character String type
+    pub const UNRESTRICTED_CHARACTER_STRING: Self = Self(Some("SEQUENCE"));
+    /// Identifier for the built-in Bmp String type
+    pub const BMP_STRING: Self = Self(Some("BMPString"));
+    /// Identifier for the built-in Ia5 String type
+    pub const IA5_STRING: Self = Self(Some("IA5String"));
+    /// Identifier for the built-in General String type
+    pub const GENERAL_STRING: Self = Self(Some("GeneralString"));
+    /// Identifier for the built-in Graphic String type
+    pub const GRAPHIC_STRING: Self = Self(Some("GraphicString"));
+    /// Identifier for the built-in Numeric String type
+    pub const NUMERIC_STRING: Self = Self(Some("NumericString"));
+    /// Identifier for the built-in Printable String type
+    pub const PRINTABLE_STRING: Self = Self(Some("PrintableString"));
+    /// Identifier for the built-in Teletex String type
+    pub const TELETEX_STRING: Self = Self(Some("TeletexString"));
+    /// Identifier for the built-in Visible String type
+    pub const VISIBLE_STRING: Self = Self(Some("VisibleString"));
+    /// Identifier for the built-in Utf8 String type
+    pub const UTF8_STRING: Self = Self(Some("UTF8String"));
+    /// Identifier for the built-in Generalized Time type
+    pub const GENERALIZED_TIME: Self = Self(Some("GeneralizedTime"));
+    /// Identifier for the built-in Utc Time type
+    pub const UTC_TIME: Self = Self(Some("UTCTime"));
+
+    /// Returns a reference of `self` if the identifier is not empty, or `other` if it is.
+    pub fn or(&self, other: Self) -> Self {
+        if self.0.is_none() {
+            other
+        } else {
+            *self
+        }
+    }
+
+    /// Returns the undelying string or panics if identifier is empty.
+    pub fn unwrap(&self) -> &'static str {
+        self.0.unwrap()
+    }
+}

--- a/src/types/instance.rs
+++ b/src/types/instance.rs
@@ -39,12 +39,13 @@ impl<T: crate::Encode> crate::Encode for InstanceOf<T> {
         encoder: &mut EN,
         tag: Tag,
         _: Constraints,
+        identifier: Option<&'static str>,
     ) -> core::result::Result<(), EN::Error> {
         encoder.encode_sequence::<2, 0, Self, _>(tag, |sequence| {
             self.type_id.encode(sequence)?;
-            sequence.encode_explicit_prefix(Tag::new(Class::Context, 0), &self.value)?;
+            sequence.encode_explicit_prefix(Tag::new(Class::Context, 0), &self.value, identifier)?;
             Ok(())
-        })?;
+        }, identifier)?;
 
         Ok(())
     }

--- a/src/types/instance.rs
+++ b/src/types/instance.rs
@@ -41,11 +41,19 @@ impl<T: crate::Encode> crate::Encode for InstanceOf<T> {
         _: Constraints,
         identifier: Option<&'static str>,
     ) -> core::result::Result<(), EN::Error> {
-        encoder.encode_sequence::<2, 0, Self, _>(tag, |sequence| {
-            self.type_id.encode(sequence)?;
-            sequence.encode_explicit_prefix(Tag::new(Class::Context, 0), &self.value, identifier)?;
-            Ok(())
-        }, identifier)?;
+        encoder.encode_sequence::<2, 0, Self, _>(
+            tag,
+            |sequence| {
+                self.type_id.encode(sequence)?;
+                sequence.encode_explicit_prefix(
+                    Tag::new(Class::Context, 0),
+                    &self.value,
+                    identifier,
+                )?;
+                Ok(())
+            },
+            identifier,
+        )?;
 
         Ok(())
     }

--- a/src/types/instance.rs
+++ b/src/types/instance.rs
@@ -1,4 +1,4 @@
-use super::{AsnType, Class, Constraints, ObjectIdentifier, Tag};
+use super::{AsnType, Class, Constraints, Identifier, ObjectIdentifier, Tag};
 use crate::{
     de::Decoder,
     enc::Encoder,
@@ -16,6 +16,7 @@ pub struct InstanceOf<T> {
 
 impl<T> AsnType for InstanceOf<T> {
     const TAG: Tag = Tag::EXTERNAL;
+    const IDENTIFIER: Identifier = Identifier::INSTANCE_OF;
 }
 
 impl<T: crate::Decode> crate::Decode for InstanceOf<T> {
@@ -39,7 +40,7 @@ impl<T: crate::Encode> crate::Encode for InstanceOf<T> {
         encoder: &mut EN,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> core::result::Result<(), EN::Error> {
         encoder.encode_sequence::<2, 0, Self, _>(
             tag,

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -678,7 +678,7 @@ macro_rules! integer_type_impl {
                     1
                 } else {
                     let significant_bits = Self::WIDTH as usize - self.leading_zeros() as usize;
-                    (significant_bits + 7) / 8
+                    significant_bits.div_ceil(8)
                 }
             }
             #[inline(always)]

--- a/src/types/real.rs
+++ b/src/types/real.rs
@@ -6,6 +6,15 @@ pub trait RealType: Sized + core::fmt::Debug + core::fmt::Display {
     /// The byte level width of the floating point type.
     const BYTE_WIDTH: usize;
 
+    /// The infinity (∞) value
+    const INFINITY: Self;
+
+    /// The negative infinity (-∞) value
+    const NEG_INFINITY: Self;
+
+    /// The Not-a-Number value
+    const NAN: Self;
+
     /// Returns the IEEE 754 encoded bytes of the real type, byte count defined in `usize`
     fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize);
 
@@ -17,11 +26,23 @@ pub trait RealType: Sized + core::fmt::Debug + core::fmt::Display {
 
     /// Attempts to convert `Self` into a generic floating point type
     fn try_to_float(&self) -> Option<impl FloatCore>;
+
+    /// Returns `true` if the value is positive infinity
+    fn is_infinity(&self) -> bool;
+
+    /// Returns `true` if the value is negative infinity
+    fn is_neg_infinity(&self) -> bool;
+
+    /// Returns `true` if the value is NaN
+    fn is_nan(&self) -> bool;
 }
 
 #[cfg(feature = "f64")]
 impl RealType for f64 {
     const BYTE_WIDTH: usize = core::mem::size_of::<Self>();
+    const INFINITY: Self = Self::INFINITY;
+    const NEG_INFINITY: Self = Self::NEG_INFINITY;
+    const NAN: Self = Self::NAN;
 
     #[inline]
     fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize) {
@@ -45,11 +66,29 @@ impl RealType for f64 {
     fn try_to_float(&self) -> Option<impl FloatCore> {
         Some(*self)
     }
+
+    #[inline]
+    fn is_infinity(&self) -> bool {
+        *self == Self::INFINITY
+    }
+
+    #[inline]
+    fn is_neg_infinity(&self) -> bool {
+        *self == Self::NEG_INFINITY
+    }
+
+    #[inline]
+    fn is_nan(&self) -> bool {
+        *self == Self::NAN
+    }
 }
 
 #[cfg(feature = "f32")]
 impl RealType for f32 {
     const BYTE_WIDTH: usize = core::mem::size_of::<Self>();
+    const INFINITY: Self = Self::INFINITY;
+    const NEG_INFINITY: Self = Self::NEG_INFINITY;
+    const NAN: Self = Self::NAN;
 
     #[inline]
     fn to_ieee754_bytes(&self) -> (impl AsRef<[u8]>, usize) {
@@ -72,6 +111,21 @@ impl RealType for f32 {
 
     fn try_to_float(&self) -> Option<impl FloatCore> {
         Some(*self)
+    }
+
+    #[inline]
+    fn is_infinity(&self) -> bool {
+        *self == Self::INFINITY
+    }
+
+    #[inline]
+    fn is_neg_infinity(&self) -> bool {
+        *self == Self::NEG_INFINITY
+    }
+
+    #[inline]
+    fn is_nan(&self) -> bool {
+        *self == Self::NAN
     }
 }
 

--- a/src/types/real.rs
+++ b/src/types/real.rs
@@ -79,7 +79,7 @@ impl RealType for f64 {
 
     #[inline]
     fn is_nan(&self) -> bool {
-        *self == Self::NAN
+        Self::is_nan(*self)
     }
 }
 
@@ -125,7 +125,7 @@ impl RealType for f32 {
 
     #[inline]
     fn is_nan(&self) -> bool {
-        *self == Self::NAN
+        Self::is_nan(*self)
     }
 }
 

--- a/src/types/strings/bit.rs
+++ b/src/types/strings/bit.rs
@@ -43,7 +43,7 @@ pub type BitStr = bitvec::slice::BitSlice<u8, bitvec::order::Msb0>;
 
 impl AsnType for BitString {
     const TAG: Tag = Tag::BIT_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
+    const IDENTIFIER: Identifier = Identifier::BIT_STRING;
 }
 
 impl Decode for BitString {
@@ -62,7 +62,7 @@ impl Encode for BitString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_bit_string(tag, constraints, self, identifier)
@@ -72,7 +72,7 @@ impl Encode for BitString {
 
 impl AsnType for BitStr {
     const TAG: Tag = Tag::BIT_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
+    const IDENTIFIER: Identifier = Identifier::BIT_STRING;
 }
 
 impl Encode for BitStr {
@@ -81,7 +81,7 @@ impl Encode for BitStr {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_bit_string(tag, constraints, self, identifier)
@@ -92,7 +92,7 @@ impl Encode for BitStr {
 impl<const N: usize> AsnType for FixedBitString<N> {
     const TAG: Tag = Tag::BIT_STRING;
     const CONSTRAINTS: Constraints = constraints!(size_constraint!(N));
-    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
+    const IDENTIFIER: Identifier = Identifier::BIT_STRING;
 }
 
 impl<const N: usize> Decode for FixedBitString<N> {
@@ -122,7 +122,7 @@ impl<const N: usize> Encode for FixedBitString<N> {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_bit_string(tag, constraints, &self[..N], identifier)

--- a/src/types/strings/bit.rs
+++ b/src/types/strings/bit.rs
@@ -43,6 +43,7 @@ pub type BitStr = bitvec::slice::BitSlice<u8, bitvec::order::Msb0>;
 
 impl AsnType for BitString {
     const TAG: Tag = Tag::BIT_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
 }
 
 impl Decode for BitString {
@@ -63,12 +64,15 @@ impl Encode for BitString {
         constraints: Constraints,
         identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bit_string(tag, constraints, self, identifier).map(drop)
+        encoder
+            .encode_bit_string(tag, constraints, self, identifier)
+            .map(drop)
     }
 }
 
 impl AsnType for BitStr {
     const TAG: Tag = Tag::BIT_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
 }
 
 impl Encode for BitStr {
@@ -79,13 +83,16 @@ impl Encode for BitStr {
         constraints: Constraints,
         identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bit_string(tag, constraints, self, identifier).map(drop)
+        encoder
+            .encode_bit_string(tag, constraints, self, identifier)
+            .map(drop)
     }
 }
 
 impl<const N: usize> AsnType for FixedBitString<N> {
     const TAG: Tag = Tag::BIT_STRING;
     const CONSTRAINTS: Constraints = constraints!(size_constraint!(N));
+    const IDENTIFIER: Option<&'static str> = Some("BIT_STRING");
 }
 
 impl<const N: usize> Decode for FixedBitString<N> {

--- a/src/types/strings/bit.rs
+++ b/src/types/strings/bit.rs
@@ -61,8 +61,9 @@ impl Encode for BitString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bit_string(tag, constraints, self).map(drop)
+        encoder.encode_bit_string(tag, constraints, self, identifier).map(drop)
     }
 }
 
@@ -76,8 +77,9 @@ impl Encode for BitStr {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bit_string(tag, constraints, self).map(drop)
+        encoder.encode_bit_string(tag, constraints, self, identifier).map(drop)
     }
 }
 
@@ -113,9 +115,10 @@ impl<const N: usize> Encode for FixedBitString<N> {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_bit_string(tag, constraints, &self[..N])
+            .encode_bit_string(tag, constraints, &self[..N], identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/bmp.rs
+++ b/src/types/strings/bmp.rs
@@ -56,8 +56,9 @@ impl Encode for BmpString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bmp_string(tag, constraints, self).map(drop)
+        encoder.encode_bmp_string(tag, constraints, self, identifier).map(drop)
     }
 }
 

--- a/src/types/strings/bmp.rs
+++ b/src/types/strings/bmp.rs
@@ -48,6 +48,7 @@ impl StaticPermittedAlphabet for BmpString {
 
 impl AsnType for BmpString {
     const TAG: Tag = Tag::BMP_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("BMPString");
 }
 
 impl Encode for BmpString {
@@ -58,7 +59,9 @@ impl Encode for BmpString {
         constraints: Constraints,
         identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_bmp_string(tag, constraints, self, identifier).map(drop)
+        encoder
+            .encode_bmp_string(tag, constraints, self, identifier)
+            .map(drop)
     }
 }
 

--- a/src/types/strings/bmp.rs
+++ b/src/types/strings/bmp.rs
@@ -48,7 +48,7 @@ impl StaticPermittedAlphabet for BmpString {
 
 impl AsnType for BmpString {
     const TAG: Tag = Tag::BMP_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("BMPString");
+    const IDENTIFIER: Identifier = Identifier::BMP_STRING;
 }
 
 impl Encode for BmpString {
@@ -57,7 +57,7 @@ impl Encode for BmpString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_bmp_string(tag, constraints, self, identifier)

--- a/src/types/strings/general.rs
+++ b/src/types/strings/general.rs
@@ -70,7 +70,7 @@ impl StaticPermittedAlphabet for GeneralString {
 
 impl AsnType for GeneralString {
     const TAG: Tag = Tag::GENERAL_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("GeneralString");
+    const IDENTIFIER: Identifier = Identifier::GENERAL_STRING;
 }
 
 impl Decode for GeneralString {
@@ -89,7 +89,7 @@ impl Encode for GeneralString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_general_string(tag, constraints, self, identifier)

--- a/src/types/strings/general.rs
+++ b/src/types/strings/general.rs
@@ -88,9 +88,10 @@ impl Encode for GeneralString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_general_string(tag, constraints, self)
+            .encode_general_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/general.rs
+++ b/src/types/strings/general.rs
@@ -70,6 +70,7 @@ impl StaticPermittedAlphabet for GeneralString {
 
 impl AsnType for GeneralString {
     const TAG: Tag = Tag::GENERAL_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("GeneralString");
 }
 
 impl Decode for GeneralString {

--- a/src/types/strings/graphic.rs
+++ b/src/types/strings/graphic.rs
@@ -83,9 +83,10 @@ impl Encode for GraphicString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_graphic_string(tag, constraints, self)
+            .encode_graphic_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/graphic.rs
+++ b/src/types/strings/graphic.rs
@@ -65,7 +65,7 @@ impl StaticPermittedAlphabet for GraphicString {
 
 impl AsnType for GraphicString {
     const TAG: Tag = Tag::GRAPHIC_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("GraphicString");
+    const IDENTIFIER: Identifier = Identifier::GRAPHIC_STRING;
 }
 
 impl Decode for GraphicString {
@@ -84,7 +84,7 @@ impl Encode for GraphicString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_graphic_string(tag, constraints, self, identifier)

--- a/src/types/strings/graphic.rs
+++ b/src/types/strings/graphic.rs
@@ -65,6 +65,7 @@ impl StaticPermittedAlphabet for GraphicString {
 
 impl AsnType for GraphicString {
     const TAG: Tag = Tag::GRAPHIC_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("GraphicString");
 }
 
 impl Decode for GraphicString {

--- a/src/types/strings/ia5.rs
+++ b/src/types/strings/ia5.rs
@@ -64,7 +64,7 @@ impl super::StaticPermittedAlphabet for Ia5String {
 
 impl AsnType for Ia5String {
     const TAG: Tag = Tag::IA5_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("IA5String");
+    const IDENTIFIER: Identifier = Identifier::IA5_STRING;
 }
 
 impl Encode for Ia5String {
@@ -73,7 +73,7 @@ impl Encode for Ia5String {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_ia5_string(tag, constraints, self, identifier)

--- a/src/types/strings/ia5.rs
+++ b/src/types/strings/ia5.rs
@@ -64,6 +64,7 @@ impl super::StaticPermittedAlphabet for Ia5String {
 
 impl AsnType for Ia5String {
     const TAG: Tag = Tag::IA5_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("IA5String");
 }
 
 impl Encode for Ia5String {
@@ -74,7 +75,9 @@ impl Encode for Ia5String {
         constraints: Constraints,
         identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_ia5_string(tag, constraints, self, identifier).map(drop)
+        encoder
+            .encode_ia5_string(tag, constraints, self, identifier)
+            .map(drop)
     }
 }
 

--- a/src/types/strings/ia5.rs
+++ b/src/types/strings/ia5.rs
@@ -72,8 +72,9 @@ impl Encode for Ia5String {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
-        encoder.encode_ia5_string(tag, constraints, self).map(drop)
+        encoder.encode_ia5_string(tag, constraints, self, identifier).map(drop)
     }
 }
 

--- a/src/types/strings/numeric.rs
+++ b/src/types/strings/numeric.rs
@@ -61,9 +61,10 @@ impl Encode for NumericString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_numeric_string(tag, constraints, self)
+            .encode_numeric_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/numeric.rs
+++ b/src/types/strings/numeric.rs
@@ -53,7 +53,7 @@ impl StaticPermittedAlphabet for NumericString {
 
 impl AsnType for NumericString {
     const TAG: Tag = Tag::NUMERIC_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("NumericString");
+    const IDENTIFIER: Identifier = Identifier::NUMERIC_STRING;
 }
 
 impl Encode for NumericString {
@@ -62,7 +62,7 @@ impl Encode for NumericString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_numeric_string(tag, constraints, self, identifier)

--- a/src/types/strings/numeric.rs
+++ b/src/types/strings/numeric.rs
@@ -53,6 +53,7 @@ impl StaticPermittedAlphabet for NumericString {
 
 impl AsnType for NumericString {
     const TAG: Tag = Tag::NUMERIC_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("NumericString");
 }
 
 impl Encode for NumericString {

--- a/src/types/strings/octet.rs
+++ b/src/types/strings/octet.rs
@@ -102,9 +102,10 @@ impl<const N: usize> Encode for FixedOctetString<N> {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_octet_string(tag, constraints, &self.0)
+            .encode_octet_string(tag, constraints, &self.0, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/octet.rs
+++ b/src/types/strings/octet.rs
@@ -67,6 +67,7 @@ impl<const N: usize> core::ops::DerefMut for FixedOctetString<N> {
 impl<const N: usize> AsnType for FixedOctetString<N> {
     const TAG: Tag = Tag::OCTET_STRING;
     const CONSTRAINTS: Constraints = constraints!(size_constraint!(N));
+    const IDENTIFIER: Option<&'static str> = Some("OCTET_STRING");
 }
 
 impl<const N: usize> Decode for FixedOctetString<N> {

--- a/src/types/strings/octet.rs
+++ b/src/types/strings/octet.rs
@@ -67,7 +67,7 @@ impl<const N: usize> core::ops::DerefMut for FixedOctetString<N> {
 impl<const N: usize> AsnType for FixedOctetString<N> {
     const TAG: Tag = Tag::OCTET_STRING;
     const CONSTRAINTS: Constraints = constraints!(size_constraint!(N));
-    const IDENTIFIER: Option<&'static str> = Some("OCTET_STRING");
+    const IDENTIFIER: Identifier = Identifier::OCTET_STRING;
 }
 
 impl<const N: usize> Decode for FixedOctetString<N> {
@@ -103,7 +103,7 @@ impl<const N: usize> Encode for FixedOctetString<N> {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_octet_string(tag, constraints, &self.0, identifier)

--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -63,6 +63,7 @@ impl StaticPermittedAlphabet for PrintableString {
 
 impl AsnType for PrintableString {
     const TAG: Tag = Tag::PRINTABLE_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("PrintableString");
 }
 
 impl Encode for PrintableString {

--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -71,9 +71,10 @@ impl Encode for PrintableString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_printable_string(tag, constraints, self)
+            .encode_printable_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -63,7 +63,7 @@ impl StaticPermittedAlphabet for PrintableString {
 
 impl AsnType for PrintableString {
     const TAG: Tag = Tag::PRINTABLE_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("PrintableString");
+    const IDENTIFIER: Identifier = Identifier::PRINTABLE_STRING;
 }
 
 impl Encode for PrintableString {
@@ -72,7 +72,7 @@ impl Encode for PrintableString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_printable_string(tag, constraints, self, identifier)

--- a/src/types/strings/teletex.rs
+++ b/src/types/strings/teletex.rs
@@ -53,7 +53,7 @@ impl StaticPermittedAlphabet for TeletexString {
 
 impl AsnType for TeletexString {
     const TAG: Tag = Tag::TELETEX_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("TeletexString");
+    const IDENTIFIER: Identifier = Identifier::TELETEX_STRING;
 }
 
 impl Encode for TeletexString {
@@ -62,7 +62,7 @@ impl Encode for TeletexString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_teletex_string(tag, constraints, self, identifier)

--- a/src/types/strings/teletex.rs
+++ b/src/types/strings/teletex.rs
@@ -61,9 +61,10 @@ impl Encode for TeletexString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_teletex_string(tag, constraints, self)
+            .encode_teletex_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/teletex.rs
+++ b/src/types/strings/teletex.rs
@@ -53,6 +53,7 @@ impl StaticPermittedAlphabet for TeletexString {
 
 impl AsnType for TeletexString {
     const TAG: Tag = Tag::TELETEX_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("TeletexString");
 }
 
 impl Encode for TeletexString {

--- a/src/types/strings/visible.rs
+++ b/src/types/strings/visible.rs
@@ -83,9 +83,10 @@ impl Encode for VisibleString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), E::Error> {
         encoder
-            .encode_visible_string(tag, constraints, self)
+            .encode_visible_string(tag, constraints, self, identifier)
             .map(drop)
     }
 }

--- a/src/types/strings/visible.rs
+++ b/src/types/strings/visible.rs
@@ -75,6 +75,7 @@ impl core::fmt::Display for VisibleString {
 
 impl AsnType for VisibleString {
     const TAG: Tag = Tag::VISIBLE_STRING;
+    const IDENTIFIER: Option<&'static str> = Some("VisibleString");
 }
 
 impl Encode for VisibleString {

--- a/src/types/strings/visible.rs
+++ b/src/types/strings/visible.rs
@@ -75,7 +75,7 @@ impl core::fmt::Display for VisibleString {
 
 impl AsnType for VisibleString {
     const TAG: Tag = Tag::VISIBLE_STRING;
-    const IDENTIFIER: Option<&'static str> = Some("VisibleString");
+    const IDENTIFIER: Identifier = Identifier::VISIBLE_STRING;
 }
 
 impl Encode for VisibleString {
@@ -84,7 +84,7 @@ impl Encode for VisibleString {
         encoder: &mut E,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), E::Error> {
         encoder
             .encode_visible_string(tag, constraints, self, identifier)

--- a/src/xer.rs
+++ b/src/xer.rs
@@ -1,0 +1,444 @@
+//! XML Encoding Rules.
+
+pub mod de;
+pub mod enc;
+
+const BOOLEAN_TRUE_TAG: &str = "true";
+const BOOLEAN_FALSE_TAG: &str = "false";
+const UTC_TIME_TYPE_TAG: &str = "UTCTime";
+const PLUS_INFINITY_TAG: &str = "PLUS-INFINITY";
+const MINUS_INFINITY_TAG: &str = "MINUS-INFINITY";
+const NAN_TAG: &str = "NOT-A-NUMBER";
+const PLUS_INFINITY_VALUE: &str = "INF";
+const MINUS_INFINITY_VALUE: &str = "-INF";
+const NAN_VALUE: &str = "NaN";
+
+/// Attempts to decode `T` from `input` using XER.
+/// # Errors
+/// Returns error specific to XER decoder if decoding is not possible.
+pub fn decode<T: crate::Decode>(input: &[u8]) -> Result<T, crate::error::DecodeError> {
+    T::decode(&mut de::Decoder::new(input)?)
+}
+
+/// Attempts to encode `value` to XER.
+/// # Errors
+/// Returns error specific to XER encoder if encoding is not possible.
+pub fn encode<T: crate::Encode>(
+    value: &T,
+) -> Result<alloc::vec::Vec<u8>, crate::error::EncodeError> {
+    let mut encoder = enc::Encoder::new();
+    value.encode(&mut encoder)?;
+    Ok(encoder.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitvec::bitvec;
+    use bitvec::order::Msb0;
+
+    use crate::prelude::*;
+    use crate::xer::{decode, encode};
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    #[non_exhaustive]
+    struct NestedTestA {
+        wine: bool,
+        grappa: OctetString,
+        inner: InnerTestA,
+        #[rasn(extension_addition)]
+        oid: Option<ObjectIdentifier>,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct InnerTestA {
+        hidden: Option<bool>,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate", identifier = "Enum-Sequence")]
+    struct EnumSequence {
+        #[rasn(identifier = "enum-field")]
+        enum_field: EnumType,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate", identifier = "Deep-Sequence")]
+    struct DeepSequence {
+        nested: NestedTestA,
+        recursion: RecursiveChoice,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(choice, crate_root = "crate")]
+    enum RecursiveChoice {
+        Leaf,
+        Fruit(bool),
+        Recursion(Box<RecursiveChoice>),
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq, Copy, Clone, Eq, Hash)]
+    #[rasn(enumerated, automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum EnumType {
+        #[rasn(identifier = "eins")]
+        First,
+        #[rasn(identifier = "zwei")]
+        Second,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(choice, automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum ChoiceType {
+        #[rasn(identifier = "enum")]
+        EnumVariant(EnumType),
+        #[allow(non_camel_case_types)]
+        nested(InnerTestA),
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags, delegate)]
+    #[rasn(crate_root = "crate")]
+    struct ChoiceDelegate(pub ChoiceType);
+
+    type SequenceOfChoices = Vec<ChoiceType>;
+    type SequenceOfDelegateChoices = Vec<ChoiceDelegate>;
+    type SequenceOfEnumSequences = Vec<EnumSequence>;
+    type SequenceOfBitStrings = Vec<BitString>;
+    type SequenceOfEnums = Vec<EnumType>;
+    type SequenceOfNulls = Vec<()>;
+    type SequenceOfIntegers = Vec<i32>;
+    type SequenceOfSequenceOfSequences = Vec<Vec<InnerTestA>>;
+
+    type SetOfEnumSequences = SetOf<EnumSequence>;
+    type SetOfEnums = SetOf<EnumType>;
+    type SetOfNulls = SetOf<()>;
+    type SetOfIntegers = SetOf<i32>;
+    type SetOfSequenceOfSequences = SetOf<Vec<InnerTestA>>;
+
+    macro_rules! round_trip {
+        ($test_name:ident, $type:ident, $value:expr, $expected_ty:literal, $expected_val:literal) => {
+            #[test]
+            fn $test_name() {
+                #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+                #[rasn(automatic_tags, delegate)]
+                #[rasn(crate_root = "crate")]
+                struct DelegateType(pub $type);
+
+                #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+                #[rasn(automatic_tags, delegate)]
+                #[rasn(crate_root = "crate")]
+                struct NestedDelegateType(pub DelegateType);
+
+                #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+                #[rasn(automatic_tags, delegate, identifier = "Alias")]
+                #[rasn(crate_root = "crate")]
+                struct AliasDelegateType(pub $type);
+
+                let input = $value;
+                let encoded = String::from_utf8(encode(&input).unwrap()).unwrap();
+                let expected = String::from("<")
+                    + $expected_ty
+                    + ">"
+                    + $expected_val
+                    + "</"
+                    + $expected_ty
+                    + ">";
+                let decoded = decode::<$type>(expected.as_bytes()).unwrap();
+                assert_eq!(input, decoded);
+                assert_eq!(encoded, expected);
+
+                let input = DelegateType($value);
+                let encoded = String::from_utf8(encode(&input).unwrap()).unwrap();
+                let expected = String::from("<DelegateType>") + $expected_val + "</DelegateType>";
+                let decoded = decode::<DelegateType>(expected.as_bytes()).unwrap();
+                assert_eq!(input, decoded);
+                assert_eq!(encoded, expected);
+
+                let input = NestedDelegateType(DelegateType($value));
+                let encoded = String::from_utf8(encode(&input).unwrap()).unwrap();
+                let expected =
+                    String::from("<NestedDelegateType>") + $expected_val + "</NestedDelegateType>";
+                let decoded = decode::<NestedDelegateType>(expected.as_bytes()).unwrap();
+                assert_eq!(input, decoded);
+                assert_eq!(encoded, expected);
+
+                let input = AliasDelegateType($value);
+                let encoded = String::from_utf8(encode(&input).unwrap()).unwrap();
+                let expected = String::from("<Alias>") + $expected_val + "</Alias>";
+                let decoded = decode::<AliasDelegateType>(expected.as_bytes()).unwrap();
+                assert_eq!(input, decoded);
+                assert_eq!(encoded, expected);
+            }
+        };
+    }
+
+    round_trip!(boolean_true, bool, true, "BOOLEAN", "<true />");
+    round_trip!(boolean_false, bool, false, "BOOLEAN", "<false />");
+    round_trip!(integer_sml, Integer, Integer::from(1), "INTEGER", "1");
+    round_trip!(integer_neg, Integer, Integer::from(-2), "INTEGER", "-2");
+    round_trip!(integer_u8, u8, 212, "INTEGER", "212");
+    round_trip!(
+        integer_i64,
+        i64,
+        -2141247653269i64,
+        "INTEGER",
+        "-2141247653269"
+    );
+    round_trip!(
+        bit_string,
+        BitString,
+        bitvec![u8, Msb0; 1,0,1,1,0,0,1],
+        "BIT_STRING",
+        "1011001"
+    );
+    round_trip!(
+        octet_string,
+        OctetString,
+        OctetString::from([255u8, 0, 8, 10].to_vec()),
+        "OCTET_STRING",
+        "FF00080A"
+    );
+    round_trip!(
+        ia5_string,
+        Ia5String,
+        Ia5String::from_iso646_bytes(&[0x30, 0x31, 0x32, 0x33, 0x34, 0x35]).unwrap(),
+        "IA5String",
+        "012345"
+    );
+    round_trip!(
+        numeric_string,
+        NumericString,
+        NumericString::from_bytes(&[0x30, 0x31, 0x32, 0x33, 0x34, 0x35]).unwrap(),
+        "NumericString",
+        "012345"
+    );
+    round_trip!(
+        utf8_string,
+        Utf8String,
+        "012345".to_string(),
+        "UTF8String",
+        "012345"
+    );
+    round_trip!(
+        object_identifier,
+        ObjectIdentifier,
+        ObjectIdentifier::from(Oid::const_new(&[1, 654, 2, 1])),
+        "OBJECT_IDENTIFIER",
+        "1.654.2.1"
+    );
+    round_trip!(
+        sequence,
+        InnerTestA,
+        InnerTestA {
+            hidden: Some(false)
+        },
+        "InnerTestA",
+        "<hidden><false /></hidden>"
+    );
+    round_trip!(
+        enumerated,
+        EnumType,
+        EnumType::First,
+        "EnumType",
+        "<eins />"
+    );
+    round_trip!(
+        choice,
+        ChoiceType,
+        ChoiceType::nested(InnerTestA { hidden: Some(true) }),
+        "ChoiceType",
+        "<nested><hidden><true /></hidden></nested>"
+    );
+    round_trip!(
+        choice_with_none_value,
+        ChoiceType,
+        ChoiceType::nested(InnerTestA { hidden: None }),
+        "ChoiceType",
+        "<nested />"
+    );
+    round_trip!(
+        enum_in_choice,
+        ChoiceType,
+        ChoiceType::EnumVariant(EnumType::Second),
+        "ChoiceType",
+        "<enum><zwei /></enum>"
+    );
+    round_trip!(
+        choice_recursion,
+        RecursiveChoice,
+        RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Fruit(true))))))))),
+        "RecursiveChoice",
+        "<Recursion><Recursion><Recursion><Recursion><Fruit><true /></Fruit></Recursion></Recursion></Recursion></Recursion>"
+    );
+    round_trip!(
+        recursive_choice_eventually_empty,
+        RecursiveChoice,
+        RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Recursion(Box::new(RecursiveChoice::Leaf)))))))),
+        "RecursiveChoice",
+        "<Recursion><Recursion><Recursion><Recursion><Leaf /></Recursion></Recursion></Recursion></Recursion>"
+    );
+    round_trip!(
+        deep_sequence,
+        DeepSequence,
+        DeepSequence { nested: NestedTestA { wine: true, grappa: vec![0, 1, 2, 3].into(), inner: InnerTestA { hidden: Some(false) }, oid: None }, recursion: RecursiveChoice::Leaf },
+        "Deep-Sequence",
+        "<nested><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner></nested><recursion><Leaf /></recursion>"
+    );
+    round_trip!(
+        extended_sequence,
+        NestedTestA,
+        NestedTestA {
+            wine: true,
+            grappa: vec![0, 1, 2, 3].into(),
+            inner: InnerTestA {
+                hidden: Some(false),
+            },
+            oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1]))),
+        },
+        "NestedTestA",
+        "<wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid>"
+    );
+    round_trip!(
+        extended_sequence_with_inner_none,
+        NestedTestA,
+        NestedTestA {
+            wine: true,
+            grappa: vec![0, 1, 2, 3].into(),
+            inner: InnerTestA { hidden: None },
+            oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1])))
+        },
+        "NestedTestA",
+        "<wine><true /></wine><grappa>00010203</grappa><inner /><oid>1.8270.4.1</oid>"
+    );
+    round_trip!(
+        extensible_sequence_without_extensions,
+        NestedTestA,
+        NestedTestA {
+            wine: true,
+            grappa: vec![0, 1, 2, 3].into(),
+            inner: InnerTestA { hidden: None },
+            oid: None
+        },
+        "NestedTestA",
+        "<wine><true /></wine><grappa>00010203</grappa><inner />"
+    );
+    round_trip!(
+        sequence_of_nulls,
+        SequenceOfNulls,
+        vec![(), (), ()],
+        "SEQUENCE_OF",
+        "<NULL /><NULL /><NULL />"
+    );
+    round_trip!(
+        sequence_of_choices,
+        SequenceOfChoices,
+        vec![
+            ChoiceType::EnumVariant(EnumType::First),
+            ChoiceType::EnumVariant(EnumType::Second)
+        ],
+        "SEQUENCE_OF",
+        "<enum><eins /></enum><enum><zwei /></enum>"
+    );
+    round_trip!(
+        sequence_of_delegate_choices,
+        SequenceOfDelegateChoices,
+        vec![
+            ChoiceDelegate(ChoiceType::EnumVariant(EnumType::First)),
+            ChoiceDelegate(ChoiceType::EnumVariant(EnumType::Second))
+        ],
+        "SEQUENCE_OF",
+        "<enum><eins /></enum><enum><zwei /></enum>"
+    );
+    round_trip!(
+        sequence_of_enums,
+        SequenceOfEnums,
+        vec![EnumType::First, EnumType::Second],
+        "SEQUENCE_OF",
+        "<eins /><zwei />"
+    );
+    round_trip!(
+        sequence_of_bitstrings,
+        SequenceOfBitStrings,
+        vec![bitvec![u8, Msb0; 1,0,1,1,0,0,1]],
+        "SEQUENCE_OF",
+        "<BIT_STRING>1011001</BIT_STRING>"
+    );
+    round_trip!(
+        sequence_of_integers,
+        SequenceOfIntegers,
+        vec![-1, 2, 3],
+        "SEQUENCE_OF",
+        "<INTEGER>-1</INTEGER><INTEGER>2</INTEGER><INTEGER>3</INTEGER>"
+    );
+    round_trip!(
+        sequence_of_sequence_of_sequences,
+        SequenceOfSequenceOfSequences,
+        vec![vec![InnerTestA { hidden: Some(true) }, InnerTestA { hidden: Some(false) }], vec![InnerTestA { hidden: None }], vec![]],
+        "SEQUENCE_OF",
+        "<SEQUENCE_OF><InnerTestA><hidden><true /></hidden></InnerTestA><InnerTestA><hidden><false /></hidden></InnerTestA></SEQUENCE_OF><SEQUENCE_OF><InnerTestA /></SEQUENCE_OF><SEQUENCE_OF />"
+    );
+    round_trip!(
+        sequence_of_enum_sequences,
+        SequenceOfEnumSequences,
+        vec![
+            EnumSequence {
+                enum_field: EnumType::First
+            },
+            EnumSequence {
+                enum_field: EnumType::Second
+            }
+        ],
+        "SEQUENCE_OF",
+        "<Enum-Sequence><enum-field><eins /></enum-field></Enum-Sequence><Enum-Sequence><enum-field><zwei /></enum-field></Enum-Sequence>"
+    );
+    round_trip!(
+        set_of_nulls,
+        SetOfNulls,
+        SetOf::from_vec(vec![(), (), ()]),
+        "SET_OF",
+        "<NULL /><NULL /><NULL />"
+    );
+    round_trip!(
+        set_of_enums,
+        SetOfEnums,
+        SetOf::from_vec(vec![EnumType::First, EnumType::Second]),
+        "SET_OF",
+        "<eins /><zwei />"
+    );
+    round_trip!(
+        set_of_integers,
+        SetOfIntegers,
+        SetOf::from_vec(vec![-1, 2, 3]),
+        "SET_OF",
+        "<INTEGER>3</INTEGER><INTEGER>2</INTEGER><INTEGER>-1</INTEGER>"
+    );
+    round_trip!(
+        set_of_sequence_of_sequences,
+        SetOfSequenceOfSequences,
+        SetOf::from_vec(vec![vec![InnerTestA { hidden: Some(true) }, InnerTestA { hidden: Some(false) }], vec![InnerTestA { hidden: None }], vec![]]),
+        "SET_OF",
+        "<SEQUENCE_OF><InnerTestA /></SEQUENCE_OF><SEQUENCE_OF><InnerTestA><hidden><true /></hidden></InnerTestA><InnerTestA><hidden><false /></hidden></InnerTestA></SEQUENCE_OF><SEQUENCE_OF />"
+    );
+    round_trip!(
+        set_of_enum_sequences,
+        SetOfEnumSequences,
+        SetOf::from_vec(vec![
+            EnumSequence {
+                enum_field: EnumType::First
+            },
+            EnumSequence {
+                enum_field: EnumType::Second
+            }
+        ]),
+        "SET_OF",
+        "<Enum-Sequence><enum-field><eins /></enum-field></Enum-Sequence><Enum-Sequence><enum-field><zwei /></enum-field></Enum-Sequence>"
+    );
+}

--- a/src/xer/de.rs
+++ b/src/xer/de.rs
@@ -1,0 +1,1468 @@
+//! # Decoding XER
+extern crate alloc;
+
+use crate::alloc::string::ToString;
+use core::borrow::Borrow;
+
+use chrono::format::Item;
+use xml_no_std::{
+    attribute::Attribute, common::XmlVersion, name::OwnedName, namespace::Namespace,
+    reader::XmlEvent, ParserConfig,
+};
+
+use crate::{
+    error::*,
+    types::{fields::Fields, *},
+    xer::BOOLEAN_TRUE_TAG,
+    Decode,
+};
+
+use self::fields::Field;
+
+use super::{BOOLEAN_FALSE_TAG, BOOLEAN_TYPE_TAG};
+
+const OPTIONAL_ITEM_NOT_PRESENT: &str = "§_NOT_PRESENT_§";
+
+macro_rules! error {
+    ($kind:ident, $($arg:tt)*) => {
+        DecodeError::from(XerDecodeErrorKind::$kind {
+            details: alloc::format!($($arg)*)
+        })
+    };
+    ($kind:ident) => {
+        DecodeError::from(XerDecodeErrorKind::$kind { })
+    };
+}
+
+macro_rules! tag {
+    ($event:ident, $this:ident, $tag:expr) => {
+        match $this.next_element() {
+            Some(XmlEvent::$event { name, .. }) => {
+                if name.local_name.as_str() == $tag {
+                    Ok(())
+                } else {
+                    Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                        needed: $tag,
+                        found: alloc::format!("{name:?}"),
+                    }))
+                }
+            }
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: $tag,
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        }
+    };
+    ($event:ident, $this:ident) => {
+        match $this.next_element() {
+            Some(XmlEvent::$event { .. }) => Ok(()),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "StartElement or EndElement",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        }
+    };
+}
+
+macro_rules! decode_string {
+    ($this:ident, $tryfrom:path, $tag:path, $needed:literal) => {{
+        tag!(StartElement, $this)?;
+        let value = match $this.next_element() {
+            Some(XmlEvent::Characters(value)) => $tryfrom(value).map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    $tag,
+                    alloc::format!("Error transforming string: {e:?}"),
+                    crate::Codec::Xer,
+                )
+            }),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: $needed,
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, $this)?;
+        value
+    }};
+}
+
+macro_rules! decode_time {
+    ($this:ident, $decode_fn:path) => {{
+        tag!(StartElement, $this)?;
+        let value = match $this.next_element() {
+            Some(XmlEvent::Characters(value)) => $decode_fn(value),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "Time value",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, $this)?;
+        value
+    }};
+}
+
+macro_rules! value_or_empty {
+    ($this:ident, $parser:ident, $expected:expr) => {{
+        let value = match $this.peek() {
+            Some(XmlEvent::Characters(s)) => $parser(s),
+            Some(XmlEvent::EndElement { .. }) => return Ok(<_>::default()),
+            Some(elem) => {
+                return Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                    needed: $expected,
+                    found: alloc::format!("{elem:?}"),
+                }))
+            }
+            _ => return Err(DecodeError::from(XerDecodeErrorKind::EndOfXmlInput {})),
+        };
+        let _ = $this.next_element();
+        value
+    }};
+}
+
+#[derive(Debug)]
+struct XerElement {
+    events: alloc::collections::VecDeque<XmlEvent>,
+}
+
+impl XerElement {
+    pub fn next(&mut self) -> Option<XmlEvent> {
+        self.events.pop_front()
+    }
+
+    pub fn peek(&self) -> Option<&XmlEvent> {
+        self.events.front()
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+}
+
+impl<I: IntoIterator<Item = XmlEvent>> From<I> for XerElement {
+    fn from(value: I) -> Self {
+        XerElement {
+            events: value.into_iter().collect(),
+        }
+    }
+}
+
+pub struct Decoder {
+    stack: alloc::vec::Vec<XerElement>,
+    in_list: bool,
+}
+
+impl Decoder {
+    pub fn new(input: &[u8]) -> Result<Self, <Decoder as crate::de::Decoder>::Error> {
+        let mut reader = ParserConfig::default().create_reader(input.iter());
+        let next = reader.next().map_err(|e| error!(XmlParser, "{e:?}"))?;
+        check_prolog(&next)?;
+        let mut elements = alloc::collections::VecDeque::new();
+        'read_xml: loop {
+            let next = reader.next().map_err(|e| error!(XmlParser, "{e:?}"))?;
+            if next == XmlEvent::EndDocument {
+                break 'read_xml;
+            } else {
+                elements.push_back(next);
+            }
+        }
+        elements.try_into()
+    }
+
+    pub fn next_element(&mut self) -> Option<XmlEvent> {
+        if let Some(mut elem) = self.stack.pop() {
+            let event = elem.next();
+            if !elem.events.is_empty() {
+                self.stack.push(elem);
+            }
+            event
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.stack.iter().fold(0, |acc, evt| acc + evt.len())
+    }
+
+    pub fn peek(&self) -> Option<&XmlEvent> {
+        self.stack.last().and_then(XerElement::peek)
+    }
+
+    pub fn sort_by_field_tag_order(
+        &mut self,
+        field_indices: &[(usize, Field)],
+    ) -> Result<(), DecodeError> {
+        let field_names = field_indices.iter().map(|(_, f)| f.name).collect();
+        self.sort_by_field_name_order(field_names)
+    }
+
+    pub fn sort_by_field_name_order(
+        &mut self,
+        field_names: alloc::vec::Vec<&str>,
+    ) -> Result<(), DecodeError> {
+        let stack = core::mem::take(&mut self.stack);
+        let mut reordered = stack.into_iter().try_fold(
+            alloc::collections::BTreeMap::<usize, XerElement>::new(),
+            |mut acc, elem| {
+                let index = match elem.peek() {
+                    Some(XmlEvent::StartElement { name, .. }) => field_names
+                        .iter()
+                        .enumerate()
+                        .find_map(|(i, f)| (*f == name.local_name.as_str()).then_some(i))
+                        .ok_or_else(|| {
+                            XerDecodeErrorKind::XmlTag {
+                                needed: name.local_name.clone(),
+                                found: "nothing".into(),
+                            }
+                            .into()
+                        }),
+                    e => Err(error!(XmlParser, "Expected opening tag, found {e:?}")),
+                };
+                index.map(|i| {
+                    acc.insert(i, elem);
+                    acc
+                })
+            },
+        )?;
+        for i in (0..field_names.len()).rev() {
+            self.stack.push(reordered.remove(&i).unwrap_or(XerElement {
+                events: alloc::vec![XmlEvent::Characters(OPTIONAL_ITEM_NOT_PRESENT.into())].into(),
+            }))
+        }
+        Ok(())
+    }
+
+    fn into_list_decoder(mut self) -> Self {
+        self.in_list = true;
+        self
+    }
+
+    fn from_stack_elems<E: IntoIterator<Item = XmlEvent>, I: IntoIterator<Item = E>>(
+        elems: I,
+    ) -> Self {
+        Decoder {
+            stack: elems.into_iter().map(|i| XerElement::from(i)).collect(),
+            in_list: false,
+        }
+    }
+}
+
+impl TryFrom<alloc::collections::VecDeque<XmlEvent>> for Decoder {
+    type Error = DecodeError;
+    fn try_from(value: alloc::collections::VecDeque<XmlEvent>) -> Result<Self, Self::Error> {
+        let (mut stack, mut events, mut tag) =
+            (alloc::vec![], alloc::collections::VecDeque::new(), None);
+        'xml_elements: for evt in value {
+            match (&tag, evt) {
+                (_, XmlEvent::Whitespace(_)) => continue 'xml_elements,
+                (
+                    None,
+                    XmlEvent::StartElement {
+                        name,
+                        attributes,
+                        namespace,
+                    },
+                ) => {
+                    tag = Some(name.clone());
+                    events.push_back(XmlEvent::StartElement {
+                        name,
+                        attributes,
+                        namespace,
+                    })
+                }
+                (None, _) => {
+                    continue 'xml_elements;
+                }
+                (Some(t), XmlEvent::EndElement { name }) => {
+                    if &name == t {
+                        events.push_back(XmlEvent::EndElement { name });
+                        let collected_events: alloc::collections::VecDeque<XmlEvent> =
+                            core::mem::take(&mut events);
+                        stack.push(XerElement {
+                            events: collected_events,
+                        });
+                        tag = None;
+                    } else {
+                        events.push_back(XmlEvent::EndElement { name });
+                    }
+                }
+                (Some(_), XmlEvent::EndDocument) => return Err(error!(EndOfXmlInput)),
+                (Some(_), event) => events.push_back(event),
+            }
+        }
+        Ok(Self {
+            stack,
+            in_list: false,
+        })
+    }
+}
+
+fn check_prolog(prolog: &XmlEvent) -> Result<(), DecodeError> {
+    if let XmlEvent::StartDocument {
+        version, encoding, ..
+    } = prolog
+    {
+        if version != &XmlVersion::Version10 || encoding != &alloc::string::String::from("UTF-8") {
+            Err(error!(
+                SpecViolation,
+                r#"§8.2 The XML prolog shall either be empty; or shall consist of [...] <?xml
+                version="1.0"
+                encoding="UTF-8"?>"#
+            ))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(error!(XmlParser, "Expected XML prolog, found {:?}", prolog))
+    }
+}
+
+impl crate::Decoder for Decoder {
+    type Error = DecodeError;
+
+    fn codec(&self) -> crate::Codec {
+        crate::Codec::Xer
+    }
+
+    fn decode_any(&mut self) -> Result<crate::types::Any, Self::Error> {
+        tag!(StartElement, self)?;
+        let mut events = self
+            .stack
+            .pop()
+            .ok_or_else(|| error!(EndOfXmlInput))?
+            .events;
+        events.pop_back();
+        let mut xml_writer = xml_no_std::EmitterConfig::new()
+            .write_document_declaration(false)
+            .create_writer();
+
+        for reader_event in events {
+            match reader_event {
+                XmlEvent::EndDocument => return Err(XerDecodeErrorKind::EndOfXmlInput {}.into()),
+                XmlEvent::StartElement {
+                    name,
+                    attributes,
+                    namespace,
+                } => {
+                    let event = xml_no_std::writer::XmlEvent::StartElement {
+                        name: name.borrow(),
+                        namespace: namespace.borrow(),
+                        attributes: attributes
+                            .iter()
+                            .map(|attr| Attribute::new(attr.name.borrow(), &attr.value))
+                            .collect(),
+                    };
+                    xml_writer
+                        .write(event)
+                        .map_err(|e| XerDecodeErrorKind::InvalidOpenType { inner_err: e })?;
+                }
+                XmlEvent::Characters(text) => {
+                    let text = text.borrow();
+                    let event = xml_no_std::writer::XmlEvent::Characters(text);
+                    xml_writer
+                        .write(event)
+                        .map_err(|e| XerDecodeErrorKind::InvalidOpenType { inner_err: e })?;
+                }
+                XmlEvent::Comment(text) => {
+                    let text = text.borrow();
+                    let event = xml_no_std::writer::XmlEvent::Comment(text);
+                    xml_writer
+                        .write(event)
+                        .map_err(|e| XerDecodeErrorKind::InvalidOpenType { inner_err: e })?;
+                }
+                other => {
+                    if let Some(writer_event) = other.as_writer_event() {
+                        xml_writer
+                            .write(writer_event)
+                            .map_err(|e| XerDecodeErrorKind::InvalidOpenType { inner_err: e })?;
+                    }
+                }
+            }
+        }
+        Ok(Any {
+            contents: xml_writer.into_inner().into_bytes(),
+        })
+    }
+
+    fn decode_bit_string(
+        &mut self,
+        __tag: Tag,
+        __constraints: Constraints,
+    ) -> Result<crate::types::BitString, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = value_or_empty!(self, parse_bitstring_value, "`1` or `0`");
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_bool(&mut self, __tag: Tag) -> Result<bool, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = match self.next_element() {
+            Some(XmlEvent::StartElement { name, .. }) => {
+                if name.local_name.as_str() == BOOLEAN_TRUE_TAG {
+                    tag!(EndElement, self, BOOLEAN_TRUE_TAG).map(|_| true)
+                } else if name.local_name.as_str() == BOOLEAN_FALSE_TAG {
+                    tag!(EndElement, self, BOOLEAN_FALSE_TAG).map(|_| false)
+                } else {
+                    Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                        needed: "`<true/>` or `<false/>`",
+                        found: alloc::format!("{name:?}"),
+                    }))
+                }
+            }
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: BOOLEAN_TYPE_TAG,
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_enumerated<E: Enumerated>(&mut self, __tag: Tag) -> Result<E, Self::Error> {
+        if !self.in_list {
+            tag!(StartElement, self)?;
+        }
+        let value = match self.next_element() {
+            Some(XmlEvent::StartElement {
+                name: OwnedName { local_name, .. },
+                ..
+            }) => {
+                if let Some(e) = E::from_identifier(&local_name) {
+                    tag!(EndElement, self).map(|_| e)
+                } else {
+                    Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                        needed: "enumerated value",
+                        found: local_name,
+                    }))
+                }
+            }
+            Some(XmlEvent::Characters(c)) => E::from_identifier(&c).ok_or(DecodeError::from(
+                XerDecodeErrorKind::XmlTypeMismatch {
+                    needed: "enumerated value",
+                    found: c,
+                },
+            )),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "enumerated value",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_integer(
+        &mut self,
+        __tag: Tag,
+        __constraints: Constraints,
+    ) -> Result<crate::types::Integer, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = match self.next_element() {
+            Some(XmlEvent::Characters(value)) => {
+                if let Ok(int) = value.parse::<i128>() {
+                    Ok(crate::types::Integer::from(int))
+                } else {
+                    Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                        needed: "integer value",
+                        found: value,
+                    }))
+                }
+            }
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "integer value",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_null(&mut self, _tag: Tag) -> Result<(), Self::Error> {
+        tag!(StartElement, self)?;
+        tag!(EndElement, self)?;
+        Ok(())
+    }
+
+    fn decode_object_identifier(
+        &mut self,
+        _tag: Tag,
+    ) -> Result<crate::types::ObjectIdentifier, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = match self.next_element() {
+            Some(XmlEvent::Characters(value)) => parse_object_identifier(&value),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "'.'-separated numeric object identifier arcs",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_sequence<D, DF, F>(
+        &mut self,
+        _tag: Tag,
+        _default_initializer_fn: Option<DF>,
+        decode_fn: F,
+    ) -> Result<D, Self::Error>
+    where
+        D: crate::types::Constructed,
+        DF: FnOnce() -> D,
+        F: FnOnce(&mut Self) -> Result<D, Self::Error>,
+    {
+        tag!(StartElement, self)?;
+        let field_names = [D::FIELDS, D::EXTENDED_FIELDS.unwrap_or(Fields::empty())]
+            .iter()
+            .flat_map(|f| f.iter())
+            .map(|f| f.name)
+            .collect::<alloc::vec::Vec<&str>>();
+        let events = self
+            .stack
+            .pop()
+            .ok_or_else(|| error!(EndOfXmlInput))?
+            .events;
+        let mut sequence_decoder = Decoder::try_from(events)?;
+        sequence_decoder.sort_by_field_name_order(field_names)?;
+        (decode_fn)(&mut sequence_decoder)
+    }
+
+    fn decode_sequence_of<D: Decode>(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<alloc::vec::Vec<D>, Self::Error> {
+        decode_sequence_or_set_items(self)
+    }
+
+    fn decode_set_of<D: Decode + Ord>(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::SetOf<D>, Self::Error> {
+        let items = decode_sequence_or_set_items(self)?;
+        Ok(items.into_iter().collect())
+    }
+
+    fn decode_octet_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<alloc::vec::Vec<u8>, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = value_or_empty!(self, parse_octetstring_value, "hexadecimal characters");
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_utf8_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::Utf8String, Self::Error> {
+        tag!(StartElement, self)?;
+        let value = match self.next_element() {
+            Some(XmlEvent::Characters(value)) => Ok(value),
+            Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "UTF8 string value",
+                found: alloc::format!("{elem:?}"),
+            })),
+            None => Err(error!(EndOfXmlInput)),
+        };
+        tag!(EndElement, self)?;
+        value
+    }
+
+    fn decode_visible_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::VisibleString, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::VisibleString::try_from,
+            Tag::VISIBLE_STRING,
+            "VisibleString value"
+        )
+    }
+
+    fn decode_general_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::GeneralString, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::GeneralString::try_from,
+            Tag::GENERAL_STRING,
+            "GeneralString value"
+        )
+    }
+
+    fn decode_ia5_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::Ia5String, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::Ia5String::try_from,
+            Tag::IA5_STRING,
+            "IA5String value"
+        )
+    }
+
+    fn decode_printable_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::PrintableString, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::PrintableString::try_from,
+            Tag::PRINTABLE_STRING,
+            "PrintableString value"
+        )
+    }
+
+    fn decode_numeric_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::NumericString, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::NumericString::try_from,
+            Tag::NUMERIC_STRING,
+            "NumericString value"
+        )
+    }
+
+    fn decode_teletex_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::TeletexString, Self::Error> {
+        todo!()
+    }
+
+    fn decode_bmp_string(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<crate::types::BmpString, Self::Error> {
+        decode_string!(
+            self,
+            crate::types::BmpString::try_from,
+            Tag::BMP_STRING,
+            "BMP String value"
+        )
+    }
+
+    fn decode_explicit_prefix<D: Decode>(&mut self, _tag: Tag) -> Result<D, Self::Error> {
+        D::decode(self)
+    }
+
+    fn decode_utc_time(&mut self, _tag: Tag) -> Result<crate::types::UtcTime, Self::Error> {
+        decode_time!(self, crate::ber::de::Decoder::parse_any_utc_time_string)
+    }
+
+    fn decode_generalized_time(
+        &mut self,
+        _tag: Tag,
+    ) -> Result<crate::types::GeneralizedTime, Self::Error> {
+        decode_time!(
+            self,
+            crate::ber::de::Decoder::parse_any_generalized_time_string
+        )
+    }
+
+    fn decode_set<FIELDS, SET, D, F>(
+        &mut self,
+        __tag: Tag,
+        decode_fn: D,
+        field_fn: F,
+    ) -> Result<SET, Self::Error>
+    where
+        SET: Decode + crate::types::Constructed,
+        FIELDS: Decode,
+        D: Fn(&mut Self, usize, Tag) -> Result<FIELDS, Self::Error>,
+        F: FnOnce(alloc::vec::Vec<FIELDS>) -> Result<SET, Self::Error>,
+    {
+        tag!(StartElement, self)?;
+        let events = self
+            .stack
+            .pop()
+            .ok_or_else(|| error!(EndOfXmlInput))?
+            .events;
+        let mut field_indices = SET::FIELDS
+            .iter()
+            .enumerate()
+            .collect::<alloc::vec::Vec<_>>();
+        let mut fields = alloc::vec![];
+        field_indices
+            .sort_by(|(_, a), (_, b)| a.tag_tree.smallest_tag().cmp(&b.tag_tree.smallest_tag()));
+        let mut sequence_decoder = Decoder::try_from(events)?;
+        sequence_decoder.sort_by_field_tag_order(&field_indices)?;
+        for (index, field) in field_indices.into_iter() {
+            fields.push((decode_fn)(&mut sequence_decoder, index, field.tag)?);
+        }
+
+        for (index, field) in SET::EXTENDED_FIELDS
+            .iter()
+            .flat_map(|fields| fields.iter())
+            .enumerate()
+        {
+            fields.push((decode_fn)(
+                &mut sequence_decoder,
+                index + SET::FIELDS.len(),
+                field.tag,
+            )?)
+        }
+
+        (field_fn)(fields)
+    }
+
+    fn decode_choice<D>(&mut self, _constraints: Constraints) -> Result<D, Self::Error>
+    where
+        D: crate::types::DecodeChoice,
+    {
+        tag!(StartElement, self)?;
+        match self.peek() {
+            Some(XmlEvent::StartElement { name, .. }) => {
+                let tag = D::IDENTIFIERS
+                    .iter()
+                    .enumerate()
+                    .find(|(_, id)| id.eq_ignore_ascii_case(&name.local_name))
+                    .and_then(|(i, _)| {
+                        variants::Variants::from_slice(
+                            &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
+                        )
+                        .get(i)
+                        .cloned()
+                    })
+                    .unwrap_or(Tag::EOC);
+                let events = self
+                    .stack
+                    .pop()
+                    .ok_or_else(|| error!(EndOfXmlInput))?
+                    .events;
+                let mut variant_decoder = Decoder::try_from(events)?;
+                D::from_tag(&mut variant_decoder, tag)
+            }
+            elem => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+                needed: "Start element of choice option",
+                found: alloc::format!("{elem:?}"),
+            })),
+        }
+    }
+
+    fn decode_optional<D: Decode>(&mut self) -> Result<Option<D>, Self::Error> {
+        match self.peek() {
+            Some(XmlEvent::Characters(c)) if c == OPTIONAL_ITEM_NOT_PRESENT => {
+                let _ = self.next_element();
+                return Ok(None);
+            }
+            _ => (),
+        }
+        D::decode(self).map(Some)
+    }
+
+    fn decode_optional_with_tag<D: Decode>(&mut self, _tag: Tag) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_optional_with_constraints<D: Decode>(
+        &mut self,
+        _constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_optional_with_tag_and_constraints<D: Decode>(
+        &mut self,
+        _tag: Tag,
+        _constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_extension_addition_with_constraints<D>(
+        &mut self,
+        _constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_optional()
+    }
+
+    fn decode_extension_addition_group<D: Decode + crate::types::Constructed>(
+        &mut self,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+}
+
+fn parse_bitstring_value(val: &str) -> Result<BitString, DecodeError> {
+    // TODO: Add support for X.680 §22.9 XMLIdentifierLists
+    if !val
+        .chars()
+        .all(|c| c == '1' || c == '0' || c.is_whitespace())
+    {
+        return Err(error!(
+            SpecViolation,
+            r#"§12.11 An "xmlbstring" shall consist of an arbitrary number (possibly zero) of zeros, ones or white-space"#
+        ));
+    }
+    Ok(BitString::from_iter(val.chars().filter_map(|c| {
+        (c == '1').then_some(true).or((c == '0').then_some(false))
+    })))
+}
+
+fn parse_octetstring_value(val: &str) -> Result<alloc::vec::Vec<u8>, DecodeError> {
+    (0..val.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&val[i..i + 2], 16))
+        .collect::<Result<alloc::vec::Vec<_>, _>>()
+        .map_err(|e| XerDecodeErrorKind::InvalidXerOctetstring { parse_int_err: e }.into())
+}
+
+fn parse_object_identifier(val: &str) -> Result<ObjectIdentifier, DecodeError> {
+    let arcs = val
+        .split('.')
+        .try_fold(alloc::vec::Vec::<u32>::new(), |mut acc, curr| {
+            curr.parse()
+                .map(|i| {
+                    acc.push(i);
+                    acc
+                })
+                .map_err(|_| {
+                    DecodeError::from(XerDecodeErrorKind::InvalidInput {
+                        details: "Invalid Object Identifier value.",
+                    })
+                })
+        })?;
+    ObjectIdentifier::new(arcs).ok_or_else(|| {
+        XerDecodeErrorKind::InvalidInput {
+            details: "Invalid Object Identifier value.",
+        }
+        .into()
+    })
+}
+
+fn decode_sequence_or_set_items<D: Decode>(
+    decoder: &mut Decoder,
+) -> Result<alloc::vec::Vec<D>, DecodeError> {
+    let identifier = match decoder.next_element() {
+        Some(XmlEvent::StartElement { name, .. }) => Ok(name),
+        elem => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
+            needed: "StartElement of SEQUENCE OF",
+            found: alloc::format!("{elem:?}"),
+        })),
+    }?;
+
+    let mut inner_decoder: Decoder = if let Some(XmlEvent::Characters(c)) = decoder.peek() {
+        let mut elems = alloc::vec![alloc::vec![XmlEvent::EndElement {
+            name: identifier.clone()
+        }]];
+        elems.extend(c.split_ascii_whitespace().map(|item| {
+            alloc::vec![
+                XmlEvent::StartElement {
+                    name: OwnedName {
+                        local_name: D::IDENTIFIER.unwrap_or("dummy").to_string(),
+                        namespace: None,
+                        prefix: None,
+                    },
+                    attributes: alloc::vec::Vec::new(),
+                    namespace: Namespace::empty(),
+                },
+                XmlEvent::Characters(item.to_string()),
+                XmlEvent::EndElement {
+                    name: OwnedName {
+                        local_name: D::IDENTIFIER.unwrap_or("dummy").to_string(),
+                        namespace: None,
+                        prefix: None,
+                    },
+                },
+            ]
+        }));
+        let _ = decoder.stack.pop();
+        Decoder::from_stack_elems(elems)
+    } else {
+        decoder
+            .stack
+            .pop()
+            .ok_or_else(|| error!(EndOfXmlInput))?
+            .events
+            .try_into()?
+    }
+    .into_list_decoder();
+
+    let mut items = alloc::vec::Vec::new();
+    loop {
+        match inner_decoder.peek() {
+            Some(XmlEvent::EndElement { name }) if name == &identifier => break,
+            None => break,
+            _ => items.push(D::decode(&mut inner_decoder)?),
+        }
+    }
+    items.reverse();
+
+    Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! decode_test_1 {
+        ($suite:ident, $method:ident, $xml:literal, $expected:expr) => {
+            #[test]
+            fn $suite() {
+                let mut decoder = Decoder::new($xml.as_bytes()).unwrap();
+                assert_eq!(
+                    crate::Decoder::$method(&mut decoder, Tag::CHOICE).unwrap(),
+                    $expected
+                )
+            }
+        };
+    }
+
+    macro_rules! decode_test_2 {
+        ($suite:ident, $method:ident, $xml:literal, $expected:expr) => {
+            #[test]
+            fn $suite() {
+                let mut decoder = Decoder::new($xml.as_bytes()).unwrap();
+                assert_eq!(
+                    crate::Decoder::$method(&mut decoder, Tag::CHOICE, <_>::default()).unwrap(),
+                    $expected
+                )
+            }
+        };
+    }
+
+    #[test]
+    fn creates_decoder() {
+        Decoder::new(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+        <Actual>
+          <errorCode>
+            <local>1</local>
+          </errorCode>
+          <parameter>
+            <BOOLEAN><false/></BOOLEAN>
+          </parameter>
+        </Actual>"#
+                .as_bytes(),
+        )
+        .unwrap();
+    }
+
+    decode_test_1!(
+        boolean_true,
+        decode_bool,
+        "<BOOLEAN><true/></BOOLEAN>",
+        true
+    );
+    decode_test_1!(
+        boolean_false,
+        decode_bool,
+        "<BOOLEAN><false/></BOOLEAN>",
+        false
+    );
+    decode_test_2!(
+        bit_string,
+        decode_bit_string,
+        "<BIT_STRING>1010</BIT_STRING>",
+        bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+    );
+    decode_test_2!(
+        bit_string_ws,
+        decode_bit_string,
+        "<BIT_STRING>  1   0  1  0  </BIT_STRING>",
+        bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+    );
+    decode_test_2!(
+        bit_string_empty,
+        decode_bit_string,
+        "<BIT_STRING/>",
+        bitvec::bitvec![u8, bitvec::prelude::Msb0;]
+    );
+
+    #[derive(AsnType, Decode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct TestTypeA {
+        wine: bool,
+        grappa: BitString,
+    }
+
+    #[derive(AsnType, Decode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct TestTypeParent {
+        sinmin: bool,
+        nested: TestTypeA,
+    }
+
+    #[test]
+    fn sequence() {
+        let mut decoder = Decoder::new(
+            "<TestTypeA><grappa>1010</grappa><wine><false/></wine></TestTypeA>".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            TestTypeA::decode(&mut decoder).unwrap(),
+            TestTypeA {
+                wine: false,
+                grappa: bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+            }
+        )
+    }
+
+    #[test]
+    fn sequence_nested() {
+        let mut decoder = Decoder::new(
+            "<TestTypeParent><nested><grappa>1 11 1 </grappa><wine><false/></wine></nested><sinmin><true/></sinmin></TestTypeParent>".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            TestTypeParent::decode(&mut decoder).unwrap(),
+            TestTypeParent {
+                nested: TestTypeA {
+                    wine: false,
+                    grappa: bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 1, 1, 1]
+                },
+                sinmin: true
+            }
+        )
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    #[rasn(set)]
+    struct TestSetA {
+        wine: bool,
+        grappa: BitString,
+    }
+
+    #[test]
+    fn set() {
+        let mut decoder = Decoder::new(
+            "<TestTypeA><grappa>1010</grappa><wine><false/></wine></TestTypeA>".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            TestSetA::decode(&mut decoder).unwrap(),
+            TestSetA {
+                wine: false,
+                grappa: bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+            }
+        )
+    }
+
+    decode_test_2!(
+        positive_int,
+        decode_integer,
+        "<INTEGER>1283749501626451264</INTEGER>",
+        crate::types::Integer::from(1283749501626451264_i128)
+    );
+
+    decode_test_2!(
+        negative_int,
+        decode_integer,
+        "<INTEGER>-124142</INTEGER>",
+        crate::types::Integer::from(-124142)
+    );
+
+    #[derive(AsnType, Decode, Debug, PartialEq, Clone, Copy)]
+    #[rasn(enumerated)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum TestEnum {
+        #[rasn(identifier = "option-A")]
+        OptionA,
+        #[rasn(identifier = "option-B")]
+        OptionB,
+    }
+
+    #[test]
+    fn enumerated() {
+        let mut decoder = Decoder::new("<TestEnum><option-B/></TestEnum>".as_bytes()).unwrap();
+        assert_eq!(TestEnum::decode(&mut decoder).unwrap(), TestEnum::OptionB);
+        assert_eq!(decoder.len(), 0);
+        let mut decoder = Decoder::new("<TestEnum>option-B</TestEnum>".as_bytes()).unwrap();
+        assert_eq!(TestEnum::decode(&mut decoder).unwrap(), TestEnum::OptionB);
+        assert_eq!(decoder.len(), 0);
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    #[rasn(crate_root = "crate")]
+    struct SeqOfType(SequenceOf<Integer>);
+
+    #[test]
+    fn sequence_of() {
+        let mut decoder = Decoder::new(
+            r#"<SeqOfType>
+            <INTEGER>-1</INTEGER>
+            <INTEGER>-5</INTEGER>
+            <INTEGER>0</INTEGER>
+            <INTEGER>55</INTEGER>
+            <INTEGER>212424214</INTEGER>
+          </SeqOfType>"#
+                .as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            SeqOfType::decode(&mut decoder).unwrap(),
+            SeqOfType(vec![
+                Integer::from(-1),
+                Integer::from(-5),
+                Integer::from(0),
+                Integer::from(55),
+                Integer::from(212424214)
+            ])
+        )
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    #[rasn(crate_root = "crate")]
+    struct NestedSeqOf(SequenceOf<SeqOfType>);
+
+    #[test]
+    fn nested_sequence_of() {
+        let mut decoder = Decoder::new(
+            r#"<NestedSeqOf>
+                <SeqOfType>
+                    <INTEGER>-1</INTEGER>
+                    <INTEGER>-5</INTEGER>
+                    <INTEGER>0</INTEGER>
+                    <INTEGER>55</INTEGER>
+                    <INTEGER>212424214</INTEGER>
+                </SeqOfType>
+                <SeqOfType>
+                    <INTEGER>1</INTEGER>
+                    <INTEGER>5</INTEGER>
+                    <INTEGER>0</INTEGER>
+                    <INTEGER>55</INTEGER>
+                    <INTEGER>212424214</INTEGER>
+                </SeqOfType>
+            </NestedSeqOf>"#
+                .as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            NestedSeqOf::decode(&mut decoder).unwrap(),
+            NestedSeqOf(vec![
+                SeqOfType(vec![
+                    Integer::from(-1),
+                    Integer::from(-5),
+                    Integer::from(0),
+                    Integer::from(55),
+                    Integer::from(212424214)
+                ]),
+                SeqOfType(vec![
+                    Integer::from(1),
+                    Integer::from(5),
+                    Integer::from(0),
+                    Integer::from(55),
+                    Integer::from(212424214)
+                ])
+            ])
+        )
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    #[rasn(crate_root = "crate")]
+    struct SetOfType(crate::types::SetOf<Integer>);
+
+    #[test]
+    fn set_of() {
+        let mut decoder = Decoder::new(
+            r#"<SeqOfType>
+            <INTEGER>-1</INTEGER>
+            <INTEGER>-5</INTEGER>
+            <INTEGER>0</INTEGER>
+            <INTEGER>55</INTEGER>
+            <INTEGER>212424214</INTEGER>
+          </SeqOfType>"#
+                .as_bytes(),
+        )
+        .unwrap();
+        let expected: crate::types::SetOf<Integer> = [
+            Integer::from(-1),
+            Integer::from(-5),
+            Integer::from(0),
+            Integer::from(55),
+            Integer::from(212424214),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            SetOfType::decode(&mut decoder).unwrap(),
+            SetOfType(expected)
+        )
+    }
+
+    #[test]
+    fn generalized_time() {
+        let mut decoder =
+            Decoder::new(r#"<TimeType>20001231235959.999+0000</TimeType>"#.as_bytes()).unwrap();
+
+        assert_eq!(
+            crate::types::GeneralizedTime::decode(&mut decoder).unwrap(),
+            GeneralizedTime::from(
+                chrono::NaiveDate::from_ymd_opt(2000, 12, 31)
+                    .unwrap()
+                    .and_hms_milli_opt(23, 59, 59, 999)
+                    .unwrap()
+                    .and_utc()
+            )
+        )
+    }
+
+    #[test]
+    fn utc_time() {
+        let mut decoder = Decoder::new(r#"<TimeType>991231235900Z</TimeType>"#.as_bytes()).unwrap();
+
+        assert_eq!(
+            crate::types::UtcTime::decode(&mut decoder).unwrap(),
+            UtcTime::from(
+                chrono::NaiveDate::from_ymd_opt(1999, 12, 31)
+                    .unwrap()
+                    .and_hms_opt(23, 59, 0)
+                    .unwrap()
+                    .and_utc()
+            )
+        )
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(choice)]
+    #[rasn(crate_root = "crate")]
+    enum ChoiceType {
+        #[rasn(identifier = "int")]
+        Int(u8),
+        #[rasn(identifier = "bool")]
+        Bool(bool),
+    }
+
+    #[test]
+    fn choice() {
+        let mut decoder = Decoder::new(
+            r#"<ChoiceType>
+            <int>5</int>
+          </ChoiceType>"#
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ChoiceType::decode(&mut decoder).unwrap(),
+            ChoiceType::Int(5)
+        )
+    }
+
+    #[test]
+    fn sequence_of_choices() {
+        let mut decoder = Decoder::new(
+            r#"
+        <SEQUENCE_OF>
+            <ChoiceType>
+                <int>5</int>
+            </ChoiceType>
+            <ChoiceType>
+                <bool><false/></bool>
+            </ChoiceType>
+        </SEQUENCE_OF>"#
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            SequenceOf::<ChoiceType>::decode(&mut decoder).unwrap(),
+            vec![ChoiceType::Int(5), ChoiceType::Bool(false)]
+        )
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct OptionalTest {
+        wine: Option<bool>,
+        grappa: BitString,
+    }
+
+    #[test]
+    fn optional_present() {
+        let mut decoder = Decoder::new(
+            "<TestTypeA><grappa>1010</grappa><wine><false/></wine></TestTypeA>".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            OptionalTest::decode(&mut decoder).unwrap(),
+            OptionalTest {
+                wine: Some(false),
+                grappa: bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+            }
+        );
+    }
+
+    #[test]
+    fn optional_absent() {
+        let mut decoder =
+            Decoder::new("<TestTypeA><grappa>1010</grappa></TestTypeA>".as_bytes()).unwrap();
+        assert_eq!(
+            OptionalTest::decode(&mut decoder).unwrap(),
+            OptionalTest {
+                wine: None,
+                grappa: bitvec::bitvec![u8, bitvec::prelude::Msb0; 1, 0, 1, 0]
+            }
+        );
+    }
+
+    #[derive(AsnType, Debug, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct AnyTest {
+        grappa: Any,
+    }
+
+    #[test]
+    fn decodes_any() {
+        let mut decoder = Decoder::new(
+            "<AnyTest><grappa><Actual><Hello>7</Hello><Text>Text</Text></Actual></grappa></AnyTest>".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            "<Actual><Hello>7</Hello><Text>Text</Text></Actual>".as_bytes(),
+            AnyTest::decode(&mut decoder).unwrap().grappa.contents
+        )
+    }
+
+    #[test]
+    fn decodes_object_identifier() {
+        let mut decoder =
+            Decoder::new("<OBJECT_IDENTIFIER>1.0.8571.2.1</OBJECT_IDENTIFIER>".as_bytes()).unwrap();
+        assert_eq!(
+            ObjectIdentifier::decode(&mut decoder).unwrap(),
+            ObjectIdentifier::new(&[1, 0, 8571, 2, 1]).unwrap()
+        )
+    }
+
+    #[test]
+    fn mapem() {
+        use crate::Encode;
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(delegate, crate_root = "crate", size("1..=63"))]
+        pub struct DescriptiveName(pub Ia5String);
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(automatic_tags, crate_root = "crate")]
+        #[non_exhaustive]
+        pub struct IntersectionGeometry {
+            pub name: Option<DescriptiveName>,
+        }
+        impl IntersectionGeometry {
+            pub fn new(name: Option<DescriptiveName>) -> Self {
+                Self { name }
+            }
+        }
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(delegate, crate_root = "crate", size("1..=32"))]
+        pub struct IntersectionGeometryList(pub SequenceOf<IntersectionGeometry>);
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(automatic_tags, crate_root = "crate")]
+        #[allow(clippy::upper_case_acronyms)]
+        pub struct MAPEM {
+            pub map: MapData,
+        }
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(automatic_tags, crate_root = "crate")]
+        #[non_exhaustive]
+        pub struct MapData {
+            pub intersections: Option<IntersectionGeometryList>,
+        }
+        impl MapData {
+            pub fn new(intersections: Option<IntersectionGeometryList>) -> Self {
+                Self { intersections }
+            }
+        }
+
+        let encoded = r#"<?xml version="1.0"?><MAPEM><map><intersections><IntersectionGeometry><name>MAP_ITS_00\19\19.3</name></IntersectionGeometry></intersections></map></MAPEM>"#;
+        assert_eq!(
+            MAPEM {
+                map: MapData::new(Some(IntersectionGeometryList(vec![
+                    IntersectionGeometry::new(Some(DescriptiveName(
+                        Ia5String::from_iso646_bytes(r#"MAP_ITS_00\19\19.3"#.as_bytes()).unwrap()
+                    )))
+                ])))
+            },
+            crate::xer::decode::<MAPEM>(encoded.as_bytes()).unwrap()
+        );
+    }
+
+    #[derive(AsnType, Debug, Clone, Decode, PartialEq)]
+    #[rasn(automatic_tags, crate_root = "crate")]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct ZoneIds(pub SequenceOf<Zid>);
+
+    #[derive(AsnType, Debug, Clone, Decode, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    #[rasn(automatic_tags, crate_root = "crate")]
+    #[rasn(delegate, value("1..=32", extensible))]
+    pub struct Zid(pub Integer);
+
+    #[derive(AsnType, Debug, Clone, Decode, PartialEq)]
+    #[rasn(automatic_tags, crate_root = "crate")]
+    #[non_exhaustive]
+    pub struct GicPart {
+        #[rasn(identifier = "detectionZoneIds")]
+        pub detection_zone_ids: Option<ZoneIds>,
+        #[rasn(identifier = "relevanceZoneIds")]
+        pub relevance_zone_ids: Option<ZoneIds>,
+        pub direction: Option<u32>,
+    }
+
+    #[test]
+    fn simple_type_sequence_of() {
+        let mut encoded = r#"<ZoneIds>2 5</ZoneIds>"#;
+        assert_eq!(
+            ZoneIds(vec![Zid(2.into()), Zid(5.into())]),
+            crate::xer::decode::<ZoneIds>(encoded.as_bytes()).unwrap()
+        );
+        encoded = r#"<ZoneIds>2</ZoneIds>"#;
+        assert_eq!(
+            ZoneIds(vec![Zid(2.into())]),
+            crate::xer::decode::<ZoneIds>(encoded.as_bytes()).unwrap()
+        );
+        encoded = r#"<GicPart>
+                        <detectionZoneIds>2</detectionZoneIds>
+                        <relevanceZoneIds>1</relevanceZoneIds>
+                        <direction>0</direction>
+                    </GicPart>"#;
+        assert_eq!(
+            GicPart {
+                detection_zone_ids: Some(ZoneIds(alloc::vec![Zid(2.into())])),
+                relevance_zone_ids: Some(ZoneIds(alloc::vec![Zid(1.into())])),
+                direction: Some(0),
+            },
+            crate::xer::decode::<GicPart>(encoded.as_bytes()).unwrap()
+        );
+    }
+}

--- a/src/xer/de.rs
+++ b/src/xer/de.rs
@@ -460,7 +460,7 @@ impl crate::Decoder for Decoder {
             Some(XmlEvent::Characters(c)) if c == "false" => Ok(false),
             Some(XmlEvent::Characters(c)) if c == "true" => Ok(true),
             Some(elem) => Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
-                needed: bool::IDENTIFIER.unwrap(),
+                needed: bool::IDENTIFIER.0.unwrap(),
                 found: alloc::format!("{elem:?}"),
             })),
             None => Err(error!(EndOfXmlInput)),
@@ -1039,7 +1039,7 @@ fn decode_sequence_or_set_items<D: Decode>(
             alloc::vec![
                 XmlEvent::StartElement {
                     name: OwnedName {
-                        local_name: D::IDENTIFIER.unwrap_or("dummy").to_string(),
+                        local_name: D::IDENTIFIER.0.unwrap_or("dummy").to_string(),
                         namespace: None,
                         prefix: None,
                     },
@@ -1049,7 +1049,7 @@ fn decode_sequence_or_set_items<D: Decode>(
                 XmlEvent::Characters(item.to_string()),
                 XmlEvent::EndElement {
                     name: OwnedName {
-                        local_name: D::IDENTIFIER.unwrap_or("dummy").to_string(),
+                        local_name: D::IDENTIFIER.0.unwrap_or("dummy").to_string(),
                         namespace: None,
                         prefix: None,
                     },
@@ -1095,13 +1095,7 @@ fn decode_sequence_or_set_items<D: Decode>(
 #[cfg(test)]
 mod tests {
     use super::Decoder;
-    use crate::{
-        types::{
-            Any, BitString, Constraints, GeneralizedTime, Ia5String, Integer, ObjectIdentifier,
-            SequenceOf, SetOf, Tag, UtcTime,
-        },
-        AsnType, Decode, Decoder as _,
-    };
+    use crate::{types::*, AsnType, Decode, Decoder as _};
     use bitvec::order::Msb0;
 
     macro_rules! decode_test_1 {

--- a/src/xer/enc.rs
+++ b/src/xer/enc.rs
@@ -501,7 +501,6 @@ impl crate::Encoder<'_> for Encoder {
     {
         let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
             identifier
-                .or(C::IDENTIFIER)
                 .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
         ));
         self.write_start_element(&xml_tag)?;
@@ -554,7 +553,6 @@ impl crate::Encoder<'_> for Encoder {
     {
         let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
             identifier
-                .or(C::IDENTIFIER)
                 .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
         ));
         self.write_start_element(&xml_tag)?;
@@ -691,7 +689,7 @@ impl crate::Encoder<'_> for Encoder {
     ) -> Result<Self::Ok, Self::Error> {
         wrap_in_tags!(
             self,
-            Cow::Borrowed(identifier.or(f64::IDENTIFIER).unwrap()),
+            Cow::Borrowed(identifier.unwrap_or("REAL")),
             write_real,
             value
         )

--- a/src/xer/enc.rs
+++ b/src/xer/enc.rs
@@ -1,0 +1,917 @@
+//! # Encoding XER.
+use core::{borrow::Borrow, fmt::Write, ops::Deref};
+
+use crate::{
+    alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    },
+    types::{
+        fields::Fields, variants::Variants, Any, BitStr, Enumerated, GeneralizedTime, UtcTime,
+    },
+    xer::{
+        BIT_STRING_TYPE_TAG, BMP_STRING_TYPE_TAG, GENERALIZED_TIME_TYPE_TAG,
+        GENERAL_STRING_TYPE_TAG, IA5_STRING_TYPE_TAG, INTEGER_TYPE_TAG, NULL_TYPE_TAG,
+        NUMERIC_STRING_TYPE_TAG, OBJECT_IDENTIFIER_TYPE_TAG, OCTET_STRING_TYPE_TAG,
+        PRINTABLE_STRING_TYPE_TAG, UTC_TIME_TYPE_TAG, UTF8_STRING_TYPE_TAG,
+        VISIBLE_STRING_TYPE_TAG,
+    },
+};
+use alloc::borrow::Cow;
+use num_bigint::BigInt;
+use xml_no_std::{
+    attribute::Attribute, name::Name, namespace::Namespace, writer::XmlEvent, EventWriter,
+    ParserConfig,
+};
+
+use crate::error::{EncodeError, XerEncodeErrorKind};
+
+use super::{BOOLEAN_FALSE_TAG, BOOLEAN_TRUE_TAG, BOOLEAN_TYPE_TAG};
+
+macro_rules! wrap_in_tags {
+    ($this:ident, $tag:expr, $inner:ident, $($args:expr)*) => {{
+        let xml_tag = $this.field_tag_stack.pop().unwrap_or($tag);
+        $this.write_start_element(&xml_tag)?;
+        $this.$inner($($args),*)?;
+        $this.write_end_element(&xml_tag)
+    }};
+}
+
+macro_rules! try_wrap_in_tags {
+    ($this:ident, $inner:ident, $($args:expr)*) => {{
+        let xml_tag = $this.field_tag_stack
+            .pop()
+            .ok_or_else(|| XerEncodeErrorKind::FieldName)?;
+        $this.write_start_element(&xml_tag)?;
+        $this.$inner($($args),*)?;
+        $this.write_end_element(&xml_tag)
+    }};
+}
+
+pub struct Encoder {
+    field_tag_stack: Vec<Cow<'static, str>>,
+    writer: EventWriter,
+}
+
+impl Default for Encoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Encoder {
+    pub fn new() -> Self {
+        Self {
+            writer: xml_no_std::EmitterConfig::new()
+                .write_document_declaration(false)
+                .create_writer(),
+            field_tag_stack: Vec::new(),
+        }
+    }
+
+    pub fn finish(self) -> Vec<u8> {
+        self.writer.into_inner().into_bytes()
+    }
+
+    fn write(&mut self, event: XmlEvent<'_>) -> Result<(), EncodeError> {
+        self.writer.write(event).map_err(|e| {
+            EncodeError::from(XerEncodeErrorKind::XmlEncodingError {
+                upstream: e.to_string(),
+            })
+        })
+    }
+
+    fn write_start_element<S: AsRef<str>>(&mut self, value: S) -> Result<(), EncodeError> {
+        self.write(XmlEvent::StartElement {
+            name: Name::local(value.as_ref()),
+            attributes: Cow::Borrowed(&[]),
+            namespace: Namespace::empty().borrow(),
+        })
+    }
+
+    fn write_end_element<S: AsRef<str>>(&mut self, value: S) -> Result<(), EncodeError> {
+        self.write(XmlEvent::EndElement {
+            name: Some(Name::local(value.as_ref())),
+        })
+    }
+}
+
+impl crate::Encoder for Encoder {
+    type Ok = ();
+
+    type Error = EncodeError;
+
+    fn codec(&self) -> crate::Codec {
+        crate::Codec::Xer
+    }
+
+    fn encode_any(
+        &mut self,
+        __tag: crate::Tag,
+        value: &crate::types::Any,
+    ) -> Result<Self::Ok, Self::Error> {
+        try_wrap_in_tags!(self, write_any, value)
+    }
+
+    fn encode_bool(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: bool,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(BOOLEAN_TYPE_TAG)),
+            write_bool,
+            value
+        )
+    }
+
+    fn encode_bit_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::BitStr,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(BIT_STRING_TYPE_TAG)),
+            write_bitstring,
+            value
+        )
+    }
+
+    fn encode_enumerated<E: crate::types::Enumerated>(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: &E,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(
+                identifier
+                    .or(E::IDENTIFIER)
+                    .ok_or(XerEncodeErrorKind::MissingIdentifier)?
+            ),
+            write_enumerated,
+            value
+        )
+    }
+
+    fn encode_object_identifier(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: &[u32],
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(OBJECT_IDENTIFIER_TYPE_TAG)),
+            write_object_identifier,
+            value
+        )
+    }
+
+    fn encode_integer(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &num_bigint::BigInt,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(INTEGER_TYPE_TAG)),
+            write_integer,
+            value
+        )
+    }
+
+    fn encode_null(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(NULL_TYPE_TAG)),
+            write_null,
+        )
+    }
+
+    fn encode_octet_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &[u8],
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(OCTET_STRING_TYPE_TAG)),
+            write_octet_string,
+            value
+        )
+    }
+
+    fn encode_general_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::GeneralString,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(GENERAL_STRING_TYPE_TAG)),
+            write_string_type,
+            &String::from_utf8(value.deref().to_vec()).map_err(|e| {
+                XerEncodeErrorKind::XmlEncodingError {
+                    upstream: e.to_string(),
+                }
+            })?
+        )
+    }
+
+    fn encode_utf8_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &str,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(UTF8_STRING_TYPE_TAG)),
+            write_string_type,
+            value
+        )
+    }
+
+    fn encode_visible_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::VisibleString,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(VISIBLE_STRING_TYPE_TAG)),
+            write_string_type,
+            &value.to_string()
+        )
+    }
+
+    fn encode_ia5_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::Ia5String,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(IA5_STRING_TYPE_TAG)),
+            write_string_type,
+            &value.to_string()
+        )
+    }
+
+    fn encode_printable_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::PrintableString,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(PRINTABLE_STRING_TYPE_TAG)),
+            write_string_type,
+            &String::from_utf8(value.as_bytes().to_vec()).map_err(|e| {
+                XerEncodeErrorKind::XmlEncodingError {
+                    upstream: e.to_string(),
+                }
+            })?
+        )
+    }
+
+    fn encode_numeric_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::NumericString,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(NUMERIC_STRING_TYPE_TAG)),
+            write_string_type,
+            &String::from_utf8(value.as_bytes().to_vec()).map_err(|e| {
+                XerEncodeErrorKind::XmlEncodingError {
+                    upstream: e.to_string(),
+                }
+            })?
+        )
+    }
+
+    fn encode_teletex_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        _identifier: Option<&'static str>,
+        _value: &crate::types::TeletexString,
+    ) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn encode_bmp_string(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+        value: &crate::types::BmpString,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(BMP_STRING_TYPE_TAG)),
+            write_string_type,
+            &String::from_utf8(value.to_bytes()).map_err(|e| {
+                XerEncodeErrorKind::XmlEncodingError {
+                    upstream: e.to_string(),
+                }
+            })?
+        )
+    }
+
+    fn encode_generalized_time(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: &crate::types::GeneralizedTime,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(GENERALIZED_TIME_TYPE_TAG)),
+            write_generalized_time,
+            value
+        )
+    }
+
+    fn encode_utc_time(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: &crate::types::UtcTime,
+    ) -> Result<Self::Ok, Self::Error> {
+        wrap_in_tags!(
+            self,
+            Cow::Borrowed(identifier.unwrap_or(UTC_TIME_TYPE_TAG)),
+            write_utc_time,
+            value
+        )
+    }
+
+    fn encode_explicit_prefix<V: crate::Encode>(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        value: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self, identifier)
+    }
+
+    fn encode_sequence<C, F>(
+        &mut self,
+        _tag: crate::Tag,
+        identifier: Option<&'static str>,
+        encoder_scope: F,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        C: crate::types::Constructed,
+        F: FnOnce(&mut Self) -> Result<(), Self::Error>,
+    {
+        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+            identifier
+                .or(C::IDENTIFIER)
+                .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+        ));
+        self.write_start_element(&xml_tag)?;
+
+        let mut ids = C::FIELDS
+            .identifiers()
+            .chain(C::EXTENDED_FIELDS.unwrap_or(Fields::empty()).identifiers())
+            .map(|id| Cow::<str>::Owned(id.to_string()))
+            .collect::<Vec<_>>();
+        ids.reverse();
+        ids.into_iter().for_each(|id| self.field_tag_stack.push(id));
+        encoder_scope(self)?;
+
+        self.write_end_element(xml_tag)
+    }
+
+    fn encode_sequence_of<E: crate::Encode>(
+        &mut self,
+        _tag: crate::Tag,
+        value: &[E],
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+            identifier.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+        ));
+        self.write_start_element(&xml_tag)?;
+        for elem in value {
+            elem.encode(self, E::IDENTIFIER)?;
+        }
+        self.write_end_element(xml_tag)
+    }
+
+    fn encode_set<C, F>(
+        &mut self,
+        _tag: crate::Tag,
+        value: F,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        C: crate::types::Constructed,
+        F: FnOnce(&mut Self) -> Result<(), Self::Error>,
+    {
+        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+            identifier
+                .or(C::IDENTIFIER)
+                .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+        ));
+        self.write_start_element(&xml_tag)?;
+
+        let mut ids = C::FIELDS
+            .identifiers()
+            .chain(C::EXTENDED_FIELDS.unwrap_or(Fields::empty()).identifiers())
+            .map(|id| Cow::<str>::Owned(id.to_string()))
+            .collect::<Vec<_>>();
+        ids.reverse();
+        ids.into_iter().for_each(|id| self.field_tag_stack.push(id));
+        value(self)?;
+
+        self.write_end_element(xml_tag)
+    }
+
+    fn encode_set_of<E: crate::Encode>(
+        &mut self,
+        _tag: crate::Tag,
+        value: &crate::types::SetOf<E>,
+        _constraints: crate::types::Constraints,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+            identifier.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+        ));
+        self.write_start_element(&xml_tag)?;
+        for elem in value {
+            elem.encode(self, E::IDENTIFIER)?;
+        }
+        self.write_end_element(xml_tag)
+    }
+
+    fn encode_some<E: crate::Encode>(
+        &mut self,
+        value: &E,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self, identifier)
+    }
+
+    fn encode_some_with_tag_and_constraints<E: crate::Encode>(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        value: &E,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.encode_some(value, identifier)
+    }
+
+    fn encode_none<E: crate::Encode>(&mut self) -> Result<Self::Ok, Self::Error> {
+        self.field_tag_stack.pop();
+        Ok(())
+    }
+
+    fn encode_none_with_tag(&mut self, _tag: crate::Tag) -> Result<Self::Ok, Self::Error> {
+        self.field_tag_stack.pop();
+        Ok(())
+    }
+
+    fn encode_choice<E: crate::Encode + crate::types::Choice>(
+        &mut self,
+        _constraints: crate::types::Constraints,
+        tag: crate::Tag,
+        encode_fn: impl FnOnce(&mut Self) -> Result<crate::Tag, Self::Error>,
+        identifier: Option<&'static str>,
+    ) -> Result<Self::Ok, Self::Error> {
+        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+            identifier
+                .or(E::IDENTIFIER)
+                .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+        ));
+        self.write_start_element(&xml_tag)?;
+
+        let variants =
+            Variants::from_slice(&[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat());
+
+        let identifier = variants
+            .iter()
+            .enumerate()
+            .find_map(|(i, &variant_tag)| {
+                (tag == variant_tag)
+                    .then_some(E::IDENTIFIERS.get(i))
+                    .flatten()
+            })
+            .ok_or_else(|| crate::error::EncodeError::variant_not_in_choice(self.codec()))?;
+
+        self.write_start_element(identifier)?;
+        encode_fn(self)?;
+        self.write_end_element(identifier)?;
+
+        self.write_end_element(&xml_tag)
+    }
+
+    fn encode_extension_addition<E: crate::Encode>(
+        &mut self,
+        _tag: crate::Tag,
+        _constraints: crate::types::Constraints,
+        value: E,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self, None)
+    }
+
+    fn encode_extension_addition_group<E>(
+        &mut self,
+        value: Option<&E>,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        E: crate::Encode + crate::types::Constructed,
+    {
+        match value {
+            Some(v) => v.encode(self, None),
+            None => self.encode_none::<E>(),
+        }
+    }
+}
+
+impl Encoder {
+    fn write_bool(&mut self, value: bool) -> Result<(), EncodeError> {
+        if value {
+            self.write_start_element(BOOLEAN_TRUE_TAG)?;
+            self.write_end_element(BOOLEAN_TRUE_TAG)
+        } else {
+            self.write_start_element(BOOLEAN_FALSE_TAG)?;
+            self.write_end_element(BOOLEAN_FALSE_TAG)
+        }
+    }
+
+    fn write_bitstring(&mut self, value: &BitStr) -> Result<(), EncodeError> {
+        if value.is_empty() {
+            Ok(())
+        } else {
+            self.write(XmlEvent::Characters(
+                value
+                    .iter()
+                    .map(|bit| if *bit { '1' } else { '0' })
+                    .collect::<String>()
+                    .as_str(),
+            ))
+        }
+    }
+
+    fn write_enumerated<E: Enumerated>(&mut self, value: &E) -> Result<(), EncodeError> {
+        self.write_start_element(value.identifier())?;
+        self.write_end_element(value.identifier())
+    }
+
+    fn write_integer(&mut self, value: &BigInt) -> Result<(), EncodeError> {
+        self.write(XmlEvent::Characters(&value.to_str_radix(10)))
+    }
+
+    fn write_object_identifier(&mut self, value: &[u32]) -> Result<(), EncodeError> {
+        self.write(XmlEvent::Characters(
+            &value
+                .iter()
+                .map(|arc| arc.to_string())
+                .collect::<Vec<String>>()
+                .join("."),
+        ))
+    }
+
+    fn write_null(&mut self) -> Result<(), EncodeError> {
+        Ok(())
+    }
+
+    fn write_octet_string(&mut self, value: &[u8]) -> Result<(), EncodeError> {
+        if value.is_empty() {
+            Ok(())
+        } else {
+            self.write(XmlEvent::Characters(
+                value
+                    .iter()
+                    .try_fold(String::new(), |mut acc, byte| {
+                        write!(&mut acc, "{byte:02X?}").map(|_| acc)
+                    })
+                    .map_err(|e| XerEncodeErrorKind::XmlEncodingError {
+                        upstream: e.to_string(),
+                    })?
+                    .as_str(),
+            ))
+        }
+    }
+
+    fn write_string_type(&mut self, value: &str) -> Result<(), EncodeError> {
+        self.write(XmlEvent::Characters(value))
+    }
+
+    fn write_generalized_time(&mut self, value: &GeneralizedTime) -> Result<(), EncodeError> {
+        self.write(XmlEvent::Characters(
+            &String::from_utf8(
+                crate::ber::enc::Encoder::datetime_to_canonical_generalized_time_bytes(value),
+            )
+            .map_err(|e| XerEncodeErrorKind::XmlEncodingError {
+                upstream: e.to_string(),
+            })?,
+        ))
+    }
+
+    fn write_utc_time(&mut self, value: &UtcTime) -> Result<(), EncodeError> {
+        self.write(XmlEvent::Characters(
+            &String::from_utf8(
+                crate::ber::enc::Encoder::datetime_to_canonical_utc_time_bytes(value),
+            )
+            .map_err(|e| XerEncodeErrorKind::XmlEncodingError {
+                upstream: e.to_string(),
+            })?,
+        ))
+    }
+
+    fn write_any(&mut self, value: &Any) -> Result<(), EncodeError> {
+        let mut reader = ParserConfig::default().create_reader(value.contents.iter());
+        while let Ok(evt) = reader.next() {
+            match evt {
+                xml_no_std::reader::XmlEvent::StartDocument { .. } => {
+                    return Err(XerEncodeErrorKind::XmlEncodingError {
+                        upstream: "Any-type values must not contain XML prolog!".to_string(),
+                    }
+                    .into())
+                }
+                xml_no_std::reader::XmlEvent::EndDocument => break,
+                xml_no_std::reader::XmlEvent::ProcessingInstruction { name, data } => {
+                    self.write(XmlEvent::ProcessingInstruction {
+                        name: &name,
+                        data: data.as_deref(),
+                    })?;
+                }
+                xml_no_std::reader::XmlEvent::StartElement {
+                    name,
+                    attributes,
+                    namespace,
+                } => {
+                    self.write(XmlEvent::StartElement {
+                        name: name.borrow(),
+                        namespace: namespace.borrow(),
+                        attributes: attributes
+                            .iter()
+                            .map(|attr| Attribute::new(attr.name.borrow(), &attr.value))
+                            .collect(),
+                    })?;
+                }
+                xml_no_std::reader::XmlEvent::EndElement { name } => {
+                    self.write(XmlEvent::EndElement {
+                        name: Some(name.borrow()),
+                    })?;
+                }
+                xml_no_std::reader::XmlEvent::CData(cdata) => {
+                    self.write(XmlEvent::CData(&cdata))?;
+                }
+                xml_no_std::reader::XmlEvent::Comment(comment) => {
+                    self.write(XmlEvent::Comment(&comment))?;
+                }
+                xml_no_std::reader::XmlEvent::Characters(characters) => {
+                    self.write(XmlEvent::Characters(&characters))?;
+                }
+                xml_no_std::reader::XmlEvent::Whitespace(_) => {
+                    continue;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitvec::bitvec;
+    use bitvec::order::Msb0;
+
+    use crate::prelude::*;
+    use crate::xer::encode;
+
+    #[derive(AsnType, Debug, Encode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    #[non_exhaustive]
+    struct NestedTestA {
+        wine: bool,
+        grappa: OctetString,
+        inner: InnerTestA,
+        #[rasn(extension_addition)]
+        oid: Option<ObjectIdentifier>,
+    }
+
+    #[derive(AsnType, Debug, Encode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct InnerTestA {
+        hidden: Option<bool>,
+    }
+
+    #[test]
+    fn encodes_nested_extensible_sequence() {
+        assert_eq!(
+            String::from_utf8(encode(&NestedTestA {
+                wine: true,
+                grappa: vec![0, 1, 2, 3].into(),
+                inner: InnerTestA { hidden: Some(false) },
+                oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1])))
+            })
+            .unwrap()).unwrap(),
+            "<NestedTestA><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid></NestedTestA>"
+        );
+        assert_eq!(
+            String::from_utf8(encode(&NestedTestA {
+                wine: true,
+                grappa: vec![0, 1, 2, 3].into(),
+                inner: InnerTestA { hidden: None },
+                oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1])))
+            })
+            .unwrap()).unwrap(),
+            "<NestedTestA><wine><true /></wine><grappa>00010203</grappa><inner /><oid>1.8270.4.1</oid></NestedTestA>"
+        );
+        assert_eq!(
+            String::from_utf8(
+                encode(&NestedTestA {
+                    wine: true,
+                    grappa: vec![0, 1, 2, 3].into(),
+                    inner: InnerTestA { hidden: None },
+                    oid: None
+                })
+                .unwrap()
+            )
+            .unwrap(),
+            "<NestedTestA><wine><true /></wine><grappa>00010203</grappa><inner /></NestedTestA>"
+        )
+    }
+
+    macro_rules! basic_types {
+        ($test_name:ident, $type:ident, $value:expr, $expected_ty:literal, $expected_val:literal) => {
+            #[test]
+            fn $test_name() {
+                #[derive(AsnType, Debug, Encode, PartialEq)]
+                #[rasn(automatic_tags, delegate)]
+                #[rasn(crate_root = "crate")]
+                struct DelegateType(pub $type);
+
+                #[derive(AsnType, Debug, Encode, PartialEq)]
+                #[rasn(automatic_tags, delegate)]
+                #[rasn(crate_root = "crate")]
+                struct NestedDelegateType(pub DelegateType);
+
+                #[derive(AsnType, Debug, Encode, PartialEq)]
+                #[rasn(automatic_tags, delegate, identifier = "Alias")]
+                #[rasn(crate_root = "crate")]
+                struct AliasDelegateType(pub $type);
+
+                assert_eq!(
+                    String::from_utf8(encode(&$value).unwrap()).unwrap(),
+                    String::from("<")
+                        + $expected_ty
+                        + ">"
+                        + $expected_val
+                        + "</"
+                        + $expected_ty
+                        + ">"
+                );
+                assert_eq!(
+                    String::from_utf8(encode(&DelegateType($value)).unwrap()).unwrap(),
+                    String::from("<DelegateType>") + $expected_val + "</DelegateType>"
+                );
+                assert_eq!(
+                    String::from_utf8(encode(&NestedDelegateType(DelegateType($value))).unwrap())
+                        .unwrap(),
+                    String::from("<NestedDelegateType>") + $expected_val + "</NestedDelegateType>"
+                );
+                assert_eq!(
+                    String::from_utf8(encode(&AliasDelegateType($value)).unwrap()).unwrap(),
+                    String::from("<Alias>") + $expected_val + "</Alias>"
+                );
+            }
+        };
+    }
+
+    #[derive(AsnType, Debug, Encode, PartialEq, Copy, Clone)]
+    #[rasn(enumerated, automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum EnumType {
+        #[rasn(identifier = "eins")]
+        First,
+        #[rasn(identifier = "zwei")]
+        Second,
+    }
+
+    #[derive(AsnType, Debug, Encode, PartialEq)]
+    #[rasn(choice, automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum ChoiceType {
+        #[rasn(identifier = "enum")]
+        EnumVariant(EnumType),
+        nested(InnerTestA),
+    }
+
+    basic_types!(boolean_true, bool, true, "BOOLEAN", "<true />");
+    basic_types!(boolean_false, bool, false, "BOOLEAN", "<false />");
+    basic_types!(integer_sml, Integer, Integer::from(1), "INTEGER", "1");
+    basic_types!(integer_neg, Integer, Integer::from(-2), "INTEGER", "-2");
+    basic_types!(integer_u8, u8, 212, "INTEGER", "212");
+    basic_types!(
+        integer_i64,
+        i64,
+        -2141247653269i64,
+        "INTEGER",
+        "-2141247653269"
+    );
+    basic_types!(
+        bit_string,
+        BitString,
+        bitvec![u8, Msb0; 1,0,1,1,0,0,1],
+        "BIT_STRING",
+        "1011001"
+    );
+    basic_types!(
+        octet_string,
+        OctetString,
+        OctetString::from([255u8, 0, 8, 10].to_vec()),
+        "OCTET_STRING",
+        "FF00080A"
+    );
+    basic_types!(
+        ia5_string,
+        Ia5String,
+        Ia5String::from_iso646_bytes(&[0x30, 0x31, 0x32, 0x33, 0x34, 0x35]).unwrap(),
+        "IA5String",
+        "012345"
+    );
+    basic_types!(
+        numeric_string,
+        NumericString,
+        NumericString::from_bytes(&[0x30, 0x31, 0x32, 0x33, 0x34, 0x35]).unwrap(),
+        "NumericString",
+        "012345"
+    );
+    basic_types!(
+        utf8_string,
+        Utf8String,
+        "012345".to_string(),
+        "UTF8String",
+        "012345"
+    );
+    basic_types!(
+        object_identifier,
+        ObjectIdentifier,
+        ObjectIdentifier::from(Oid::const_new(&[1, 654, 2, 1])),
+        "OBJECT_IDENTIFIER",
+        "1.654.2.1"
+    );
+    basic_types!(
+        sequence,
+        InnerTestA,
+        InnerTestA {
+            hidden: Some(false)
+        },
+        "InnerTestA",
+        "<hidden><false /></hidden>"
+    );
+    basic_types!(
+        enumerated,
+        EnumType,
+        EnumType::First,
+        "EnumType",
+        "<eins />"
+    );
+    basic_types!(
+        choice,
+        ChoiceType,
+        ChoiceType::nested(InnerTestA { hidden: None }),
+        "ChoiceType",
+        "<nested><InnerTestA /></nested>"
+    );
+}

--- a/standards/kerberos/tests/issue111.rs
+++ b/standards/kerberos/tests/issue111.rs
@@ -1,6 +1,6 @@
 use rasn::{
     ber,
-    types::{Class, Constraints, Tag},
+    types::{Class, Constraints, Tag, Identifier},
     Decoder, Encoder,
 };
 
@@ -26,7 +26,7 @@ fn kerberos_flags_enc() {
             Tag::new(Class::Universal, 3),
             Constraints::default(),
             &bitstring,
-            None,
+            Identifier::EMPTY,
         )
         .unwrap();
     assert_eq!(

--- a/standards/kerberos/tests/issue111.rs
+++ b/standards/kerberos/tests/issue111.rs
@@ -26,6 +26,7 @@ fn kerberos_flags_enc() {
             Tag::new(Class::Universal, 3),
             Constraints::default(),
             &bitstring,
+            None,
         )
         .unwrap();
     assert_eq!(

--- a/standards/kerberos/tests/issue111.rs
+++ b/standards/kerberos/tests/issue111.rs
@@ -1,6 +1,6 @@
 use rasn::{
     ber,
-    types::{Class, Constraints, Tag, Identifier},
+    types::{Class, Constraints, Identifier, Tag},
     Decoder, Encoder,
 };
 

--- a/standards/ldap/src/lib.rs
+++ b/standards/ldap/src/lib.rs
@@ -64,7 +64,7 @@ impl rasn::Encode for LdapString {
         encoder: &mut EN,
         tag: rasn::types::Tag,
         constraints: rasn::types::Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> core::result::Result<(), EN::Error> {
         encoder.encode_octet_string(tag, constraints, self.0.as_bytes(), identifier)?;
         Ok(())

--- a/standards/ldap/src/lib.rs
+++ b/standards/ldap/src/lib.rs
@@ -64,8 +64,9 @@ impl rasn::Encode for LdapString {
         encoder: &mut EN,
         tag: rasn::types::Tag,
         constraints: rasn::types::Constraints,
+        identifier: Option<&'static str>,
     ) -> core::result::Result<(), EN::Error> {
-        encoder.encode_octet_string(tag, constraints, self.0.as_bytes())?;
+        encoder.encode_octet_string(tag, constraints, self.0.as_bytes(), identifier)?;
         Ok(())
     }
 }

--- a/standards/mib/src/lib.rs
+++ b/standards/mib/src/lib.rs
@@ -291,6 +291,7 @@ pub mod interfaces {
             encoder: &mut EN,
             tag: Tag,
             constraints: Constraints,
+            identifier: Option<&'static str>,
         ) -> Result<(), EN::Error> {
             self.to_opaque()
                 .map_err(|e| {
@@ -299,7 +300,7 @@ pub mod interfaces {
                         encoder.codec(),
                     )
                 })?
-                .encode_with_tag_and_constraints(encoder, tag, constraints)
+                .encode_with_tag_and_constraints(encoder, tag, constraints, identifier)
         }
     }
 

--- a/standards/mib/src/lib.rs
+++ b/standards/mib/src/lib.rs
@@ -291,7 +291,7 @@ pub mod interfaces {
             encoder: &mut EN,
             tag: Tag,
             constraints: Constraints,
-            identifier: Option<&'static str>,
+            identifier: Identifier,
         ) -> Result<(), EN::Error> {
             self.to_opaque()
                 .map_err(|e| {

--- a/standards/pkix/tests/digicert.rs
+++ b/standards/pkix/tests/digicert.rs
@@ -25,11 +25,16 @@ fn extensions() {
         encoder.encode_sequence::<2, 0, Sequence, _>(
             Tag::SEQUENCE,
             |encoder| {
-                encoder.encode_bool(Tag::BOOL, true, None)?;
-                encoder.encode_integer::<u32>(Tag::INTEGER, Constraints::default(), &0u32, None)?;
+                encoder.encode_bool(Tag::BOOL, true, Identifier::EMPTY)?;
+                encoder.encode_integer::<u32>(
+                    Tag::INTEGER,
+                    Constraints::default(),
+                    &0u32,
+                    Identifier::EMPTY,
+                )?;
                 Ok(())
             },
-            None,
+            Identifier::EMPTY,
         )?;
 
         Ok(())

--- a/standards/pkix/tests/digicert.rs
+++ b/standards/pkix/tests/digicert.rs
@@ -22,11 +22,15 @@ fn extensions() {
             _i: Integer,
         }
 
-        encoder.encode_sequence::<2, 0, Sequence, _>(Tag::SEQUENCE, |encoder| {
-            encoder.encode_bool(Tag::BOOL, true)?;
-            encoder.encode_integer::<u32>(Tag::INTEGER, Constraints::default(), &0u32)?;
-            Ok(())
-        })?;
+        encoder.encode_sequence::<2, 0, Sequence, _>(
+            Tag::SEQUENCE,
+            |encoder| {
+                encoder.encode_bool(Tag::BOOL, true, None)?;
+                encoder.encode_integer::<u32>(Tag::INTEGER, Constraints::default(), &0u32, None)?;
+                Ok(())
+            },
+            None,
+        )?;
 
         Ok(())
     })

--- a/standards/smi/src/macros.rs
+++ b/standards/smi/src/macros.rs
@@ -88,10 +88,11 @@ macro_rules! opaque_impls {
                 encoder: &mut EN,
                 tag: $crate::rasn::types::Tag,
                 constraints: $crate::rasn::types::Constraints,
+                identifier: Option<&'static str>,
             ) -> Result<(), EN::Error> {
                 self.to_opaque()
                     .map_err(|e| $crate::rasn::error::EncodeError::opaque_conversion_failed(e.to_string(), encoder.codec()))?
-                    .encode_with_tag_and_constraints(encoder, tag, constraints)
+                    .encode_with_tag_and_constraints(encoder, tag, constraints, identifier)
             }
         }
         impl $crate::rasn::Decode for $name {
@@ -185,8 +186,8 @@ macro_rules! object_type {
         }
 
         impl $crate::rasn::Encode for $name {
-            fn encode_with_tag_and_constraints<'encoder, EN: $crate::rasn::Encoder<'encoder>>(&self, encoder: &mut EN, tag: $crate::rasn::types::Tag, constraints: $crate::rasn::types::Constraints,) -> Result<(), EN::Error> {
-                self.0.encode_with_tag_and_constraints(encoder, tag, constraints)
+            fn encode_with_tag_and_constraints<'encoder, EN: $crate::rasn::Encoder<'encoder>>(&self, encoder: &mut EN, tag: $crate::rasn::types::Tag, constraints: $crate::rasn::types::Constraints, identifier: Option<&'static str>) -> Result<(), EN::Error> {
+                self.0.encode_with_tag_and_constraints(encoder, tag, constraints, identifier)
             }
         }
 

--- a/standards/smi/src/macros.rs
+++ b/standards/smi/src/macros.rs
@@ -16,7 +16,8 @@ macro_rules! common_impls {
     ($name:ident, $network_type:ty, $access_variant:ident, $status_variant:ident, $const_oid:expr) => {
         impl $crate::rasn::AsnType for $name {
             const TAG: $crate::rasn::types::Tag = <$network_type as $crate::rasn::AsnType>::TAG;
-            const IDENTIFIER: $crate::rasn::types::Identifier = <$network_type as $crate::rasn::AsnType>::IDENTIFIER;
+            const IDENTIFIER: $crate::rasn::types::Identifier =
+                <$network_type as $crate::rasn::AsnType>::IDENTIFIER;
         }
 
         impl $crate::ObjectType for $name {

--- a/standards/smi/src/macros.rs
+++ b/standards/smi/src/macros.rs
@@ -16,6 +16,7 @@ macro_rules! common_impls {
     ($name:ident, $network_type:ty, $access_variant:ident, $status_variant:ident, $const_oid:expr) => {
         impl $crate::rasn::AsnType for $name {
             const TAG: $crate::rasn::types::Tag = <$network_type as $crate::rasn::AsnType>::TAG;
+            const IDENTIFIER: $crate::rasn::types::Identifier = <$network_type as $crate::rasn::AsnType>::IDENTIFIER;
         }
 
         impl $crate::ObjectType for $name {
@@ -88,7 +89,7 @@ macro_rules! opaque_impls {
                 encoder: &mut EN,
                 tag: $crate::rasn::types::Tag,
                 constraints: $crate::rasn::types::Constraints,
-                identifier: Option<&'static str>,
+                identifier: Identifier,
             ) -> Result<(), EN::Error> {
                 self.to_opaque()
                     .map_err(|e| $crate::rasn::error::EncodeError::opaque_conversion_failed(e.to_string(), encoder.codec()))?
@@ -186,7 +187,7 @@ macro_rules! object_type {
         }
 
         impl $crate::rasn::Encode for $name {
-            fn encode_with_tag_and_constraints<'encoder, EN: $crate::rasn::Encoder<'encoder>>(&self, encoder: &mut EN, tag: $crate::rasn::types::Tag, constraints: $crate::rasn::types::Constraints, identifier: Option<&'static str>) -> Result<(), EN::Error> {
+            fn encode_with_tag_and_constraints<'encoder, EN: $crate::rasn::Encoder<'encoder>>(&self, encoder: &mut EN, tag: $crate::rasn::types::Tag, constraints: $crate::rasn::types::Constraints, identifier: $crate::rasn::types::Identifier) -> Result<(), EN::Error> {
                 self.0.encode_with_tag_and_constraints(encoder, tag, constraints, identifier)
             }
         }

--- a/standards/smi/src/v1.rs
+++ b/standards/smi/src/v1.rs
@@ -104,9 +104,10 @@ impl Encode for Opaque {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), EN::Error> {
         encoder
-            .encode_octet_string(tag, constraints, &self.0)
+            .encode_octet_string(tag, constraints, &self.0, identifier)
             .map(drop)
     }
 }

--- a/standards/smi/src/v1.rs
+++ b/standards/smi/src/v1.rs
@@ -2,7 +2,9 @@
 
 use rasn::{
     error::EncodeError,
-    types::{Constraints, FixedOctetString, Integer, ObjectIdentifier, OctetString, Oid, Tag, Identifier},
+    types::{
+        Constraints, FixedOctetString, Identifier, Integer, ObjectIdentifier, OctetString, Oid, Tag,
+    },
     AsnType, Decode, Encode,
 };
 

--- a/standards/smi/src/v1.rs
+++ b/standards/smi/src/v1.rs
@@ -2,7 +2,7 @@
 
 use rasn::{
     error::EncodeError,
-    types::{Constraints, FixedOctetString, Integer, ObjectIdentifier, OctetString, Oid, Tag},
+    types::{Constraints, FixedOctetString, Integer, ObjectIdentifier, OctetString, Oid, Tag, Identifier},
     AsnType, Decode, Encode,
 };
 
@@ -104,7 +104,7 @@ impl Encode for Opaque {
         encoder: &mut EN,
         tag: Tag,
         constraints: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         encoder
             .encode_octet_string(tag, constraints, &self.0, identifier)

--- a/standards/smi/src/v2.rs
+++ b/standards/smi/src/v2.rs
@@ -76,6 +76,7 @@ impl Encode for ExtUtcTime {
         encoder: &mut EN,
         tag: Tag,
         _: Constraints,
+        identifier: Option<&'static str>,
     ) -> Result<(), EN::Error> {
         const CONSTRAINT_1: constraints::Constraints = constraints!(value_constraint!(13));
         encoder
@@ -83,6 +84,7 @@ impl Encode for ExtUtcTime {
                 tag,
                 CONSTRAINT_1,
                 self.0.format(FULL_DATE_FORMAT).to_string().as_bytes(),
+                identifier,
             )
             .map(drop)
     }

--- a/standards/smi/src/v2.rs
+++ b/standards/smi/src/v2.rs
@@ -76,7 +76,7 @@ impl Encode for ExtUtcTime {
         encoder: &mut EN,
         tag: Tag,
         _: Constraints,
-        identifier: Option<&'static str>,
+        identifier: Identifier,
     ) -> Result<(), EN::Error> {
         const CONSTRAINT_1: constraints::Constraints = constraints!(value_constraint!(13));
         encoder

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -244,14 +244,14 @@ fn explicit_identifiers() {
     #[rasn(identifier = "my-delegate")]
     struct MyDelegate(());
 
-    assert_eq!(MyEnum::IDENTIFIER, Some("my-enum"));
+    assert_eq!(MyEnum::IDENTIFIER, Identifier(Some("my-enum")));
     assert_eq!(MyEnum::IDENTIFIERS, ["has-alt-ident"]);
-    assert_eq!(MyChoice::IDENTIFIER, Some("my-choice"));
+    assert_eq!(MyChoice::IDENTIFIER, Identifier(Some("my-choice")));
     assert_eq!(MyChoice::IDENTIFIERS, ["has-alt-ident"]);
-    assert_eq!(MyStruct::IDENTIFIER, Some("my-struct"));
+    assert_eq!(MyStruct::IDENTIFIER, Identifier(Some("my-struct")));
     assert_eq!(
         MyStruct::FIELDS.identifiers().collect::<Vec<_>>(),
         vec!["has-alt-ident"]
     );
-    assert_eq!(MyDelegate::IDENTIFIER, Some("my-delegate"));
+    assert_eq!(MyDelegate::IDENTIFIER, Identifier(Some("my-delegate")));
 }

--- a/tests/issue286.rs
+++ b/tests/issue286.rs
@@ -1,8 +1,4 @@
-use rasn::error::EncodeErrorKind;
-use rasn::uper;
-use rasn::AsnType;
-use rasn::Decode;
-use rasn::Encode;
+use rasn::{error::EncodeErrorKind, prelude::*, uper};
 
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[rasn(delegate, value("-500..=504"))]

--- a/tests/personnel.rs
+++ b/tests/personnel.rs
@@ -37,32 +37,36 @@ impl rasn::Encode for PersonnelRecord {
         #[allow(unused)]
         let children = &self.children;
         encoder
-            .encode_set::<6, 0, Self, _>(tag, |encoder| {
-                self.name.encode(encoder)?;
-                encoder.encode_explicit_prefix(
-                    rasn::types::Tag::new(rasn::types::Class::Context, 0),
-                    &self.title,
-                    None,
-                )?;
-                self.number.encode(encoder)?;
-                encoder.encode_explicit_prefix(
-                    rasn::types::Tag::new(rasn::types::Class::Context, 1),
-                    &self.date_of_hire,
-                    None,
-                )?;
-                encoder.encode_explicit_prefix(
-                    rasn::types::Tag::new(rasn::types::Class::Context, 2),
-                    &self.name_of_spouse,
-                    None,
-                )?;
-                encoder.encode_default_with_tag(
-                    rasn::types::Tag::new(rasn::types::Class::Context, 3),
-                    &self.children,
-                    <Vec<ChildInformation>>::default,
-                    None,
-                )?;
-                Ok(())
-            }, None)
+            .encode_set::<6, 0, Self, _>(
+                tag,
+                |encoder| {
+                    self.name.encode(encoder)?;
+                    encoder.encode_explicit_prefix(
+                        rasn::types::Tag::new(rasn::types::Class::Context, 0),
+                        &self.title,
+                        None,
+                    )?;
+                    self.number.encode(encoder)?;
+                    encoder.encode_explicit_prefix(
+                        rasn::types::Tag::new(rasn::types::Class::Context, 1),
+                        &self.date_of_hire,
+                        None,
+                    )?;
+                    encoder.encode_explicit_prefix(
+                        rasn::types::Tag::new(rasn::types::Class::Context, 2),
+                        &self.name_of_spouse,
+                        None,
+                    )?;
+                    encoder.encode_default_with_tag(
+                        rasn::types::Tag::new(rasn::types::Class::Context, 3),
+                        &self.children,
+                        <Vec<ChildInformation>>::default,
+                        None,
+                    )?;
+                    Ok(())
+                },
+                None,
+            )
             .map(drop)
     }
 }

--- a/tests/personnel.rs
+++ b/tests/personnel.rs
@@ -22,6 +22,7 @@ impl rasn::Encode for PersonnelRecord {
         encoder: &mut EN,
         tag: rasn::types::Tag,
         _: rasn::types::Constraints,
+        _: Option<&'static str>,
     ) -> core::result::Result<(), EN::Error> {
         #[allow(unused)]
         let name = &self.name;
@@ -41,23 +42,27 @@ impl rasn::Encode for PersonnelRecord {
                 encoder.encode_explicit_prefix(
                     rasn::types::Tag::new(rasn::types::Class::Context, 0),
                     &self.title,
+                    None,
                 )?;
                 self.number.encode(encoder)?;
                 encoder.encode_explicit_prefix(
                     rasn::types::Tag::new(rasn::types::Class::Context, 1),
                     &self.date_of_hire,
+                    None,
                 )?;
                 encoder.encode_explicit_prefix(
                     rasn::types::Tag::new(rasn::types::Class::Context, 2),
                     &self.name_of_spouse,
+                    None,
                 )?;
                 encoder.encode_default_with_tag(
                     rasn::types::Tag::new(rasn::types::Class::Context, 3),
                     &self.children,
                     <Vec<ChildInformation>>::default,
+                    None,
                 )?;
                 Ok(())
-            })
+            }, None)
             .map(drop)
     }
 }

--- a/tests/personnel.rs
+++ b/tests/personnel.rs
@@ -22,7 +22,7 @@ impl rasn::Encode for PersonnelRecord {
         encoder: &mut EN,
         tag: rasn::types::Tag,
         _: rasn::types::Constraints,
-        _: Option<&'static str>,
+        _: Identifier,
     ) -> core::result::Result<(), EN::Error> {
         #[allow(unused)]
         let name = &self.name;
@@ -44,28 +44,28 @@ impl rasn::Encode for PersonnelRecord {
                     encoder.encode_explicit_prefix(
                         rasn::types::Tag::new(rasn::types::Class::Context, 0),
                         &self.title,
-                        None,
+                        rasn::types::Identifier::EMPTY,
                     )?;
                     self.number.encode(encoder)?;
                     encoder.encode_explicit_prefix(
                         rasn::types::Tag::new(rasn::types::Class::Context, 1),
                         &self.date_of_hire,
-                        None,
+                        rasn::types::Identifier::EMPTY,
                     )?;
                     encoder.encode_explicit_prefix(
                         rasn::types::Tag::new(rasn::types::Class::Context, 2),
                         &self.name_of_spouse,
-                        None,
+                        rasn::types::Identifier::EMPTY,
                     )?;
                     encoder.encode_default_with_tag(
                         rasn::types::Tag::new(rasn::types::Class::Context, 3),
                         &self.children,
                         <Vec<ChildInformation>>::default,
-                        None,
+                        rasn::types::Identifier::EMPTY,
                     )?;
                     Ok(())
                 },
-                None,
+                rasn::types::Identifier::EMPTY,
             )
             .map(drop)
     }


### PR DESCRIPTION
## Support for XML Encoding Rules
This PR adds basic support for XML Encoding Rules.
#109 

### Added Dependencies
- `xml-no-std`, a `no_std` fork of [xml-rs](https://github.com/kornelski/xml-rs)

### Changes to the Existing Codebase
- adds an associated item ~`IDENTIFIER: Option<&'static str>`~ `IDENTIFIER: crate::types::Identifier` to the `AsnType` trait, which is necessary for determining XML tag names
- adds an ~`identifier: Option<&'static str>`~ `identifier: crate::types::Identifier` argument to all encoding methods of the `Encoder` trait in order to pass tag names from parent to child structure in nested items
- adds further methods, such as`encode_with_identifier`, to the `Encode` traits, that complement the existing `encode_with_*` methods 

### Fixes Along the Way
- replaces two uncaught `rasn` references in the decode macro with `#crate_root`

### Misc
- added a link to `rasn` compiler in README