### PR TITLE
Fixes librasn/rasn#418. Add support for explict tags and default values to encode correctly

### DIFF
--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -859,13 +859,11 @@ impl<'a> FieldConfig<'a> {
             if self.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
                 if self.default.is_some() {
                     // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-                    quote!(encoder.encode_default_with_explicit_prefix(#tag, &self.#field,  #default_fn)?;)
+                    quote!(encoder.encode_default_with_explicit_prefix(#tag, &self.#field, #default_fn #identifier)?;)
                 } else {
                     // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-                    quote!(encoder.encode_explicit_prefix(#tag, &self.#field)?;)
+                    quote!(encoder.encode_explicit_prefix(#tag, &self.#field, #identifier)?;)
                 }
-                // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-                quote!(encoder.encode_explicit_prefix(#tag, &self.#field, #identifier)?;)
             } else if self.extension_addition {
                 quote!(
                     #constraint_def

--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -857,6 +857,13 @@ impl<'a> FieldConfig<'a> {
 
         let encode = if self.tag.is_some() || self.container_config.automatic_tags {
             if self.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
+                if self.default.is_some() {
+                    // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
+                    quote!(encoder.encode_default_with_explicit_prefix(#tag, &self.#field,  #default_fn)?;)
+                } else {
+                    // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
+                    quote!(encoder.encode_explicit_prefix(#tag, &self.#field)?;)
+                }
                 // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
                 quote!(encoder.encode_explicit_prefix(#tag, &self.#field, #identifier)?;)
             } else if self.extension_addition {

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -461,11 +461,11 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         tag: Tag,
         value: &E,
         default: impl FnOnce() -> E,
+        identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         match (*value != (default)()).then_some(value) {
-            Some(value) => self.encode_explicit_prefix(tag, value),
-            // TODO: We need to figure out why this is putting a NULL in when it should just be skipping
-            None => self.encode_none_with_tag(tag),
+            Some(value) => self.encode_explicit_prefix(tag, value, identifier),
+            None => self.encode_none_with_tag(tag, identifier),
         }
     }
 

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -455,6 +455,20 @@ pub trait Encoder<'encoder, const RCL: usize = 0, const ECL: usize = 0> {
         }
     }
 
+    /// Encode the preset value of an optional field using Explicit Tags
+    fn encode_default_with_explicit_prefix<E: Encode + PartialEq>(
+        &mut self,
+        tag: Tag,
+        value: &E,
+        default: impl FnOnce() -> E,
+    ) -> Result<Self::Ok, Self::Error> {
+        match (*value != (default)()).then_some(value) {
+            Some(value) => self.encode_explicit_prefix(tag, value),
+            // TODO: We need to figure out why this is putting a NULL in when it should just be skipping
+            None => self.encode_none_with_tag(tag),
+        }
+    }
+
     /// Encode the present value of an optional field.
     fn encode_default_with_tag_and_constraints<E: Encode + PartialEq>(
         &mut self,

--- a/tests/explicit.rs
+++ b/tests/explicit.rs
@@ -131,7 +131,7 @@ fn works() {
     );
     assert_eq!(
         sequence_multi_default,
-        rasn::der::decode(&EXPECTED_MULTI_DEFAULT_FIELD_ENCODED).unwrap()
+        rasn::der::decode(EXPECTED_MULTI_DEFAULT_FIELD_ENCODED).unwrap()
     );
     assert_eq!(delegate_seq_enc, EXPECTED);
     assert_eq!(inline_seq_enc, EXPECTED);

--- a/tests/explicit.rs
+++ b/tests/explicit.rs
@@ -90,6 +90,10 @@ fn works() {
     const EXPECTED_NOT_DEFAULT: &[u8] = &[0x30, 0x05, 0x61, 0x03, 0x01, 0x01, 0x00];
     // NOTE: The explicit tag number is just different
     const EXPECTED_MULTI_DEFAULT: &[u8] = &[0x30, 0x05, 0x62, 0x03, 0x01, 0x01, 0x00];
+    // This version of the output is what would be generated without a default check.
+    // Using this for backward compat. verification
+    const EXPECTED_MULTI_DEFAULT_FIELD_ENCODED: &[u8] = &[
+        0x30,0x0a,0x61,0x03,0x01,0x01,0xff,0x62,0x03,0x01,0x01,0x00];
 
     let delegate_seq = DelegateSequence(Sequence { b: true });
     let inline_seq = InlineSequence { b: true };
@@ -120,6 +124,8 @@ fn works() {
     assert_eq!(sequence_non_default_enc, EXPECTED_NOT_DEFAULT);
     assert_eq!(sequence_default_enc, EXPECTED_DEFAULT);
     assert_eq!(sequence_multi_default_enc, EXPECTED_MULTI_DEFAULT);
+    assert_eq!(sequence_multi_default, rasn::der::decode(&sequence_multi_default_enc).unwrap());
+    assert_eq!(sequence_multi_default, rasn::der::decode(&EXPECTED_MULTI_DEFAULT_FIELD_ENCODED).unwrap());
 
     assert_eq!(delegate_seq_enc, EXPECTED);
     assert_eq!(inline_seq_enc, EXPECTED);

--- a/tests/explicit.rs
+++ b/tests/explicit.rs
@@ -93,7 +93,8 @@ fn works() {
     // This version of the output is what would be generated without a default check.
     // Using this for backward compat. verification
     const EXPECTED_MULTI_DEFAULT_FIELD_ENCODED: &[u8] = &[
-        0x30,0x0a,0x61,0x03,0x01,0x01,0xff,0x62,0x03,0x01,0x01,0x00];
+        0x30, 0x0a, 0x61, 0x03, 0x01, 0x01, 0xff, 0x62, 0x03, 0x01, 0x01, 0x00,
+    ];
 
     let delegate_seq = DelegateSequence(Sequence { b: true });
     let inline_seq = InlineSequence { b: true };
@@ -124,9 +125,14 @@ fn works() {
     assert_eq!(sequence_non_default_enc, EXPECTED_NOT_DEFAULT);
     assert_eq!(sequence_default_enc, EXPECTED_DEFAULT);
     assert_eq!(sequence_multi_default_enc, EXPECTED_MULTI_DEFAULT);
-    assert_eq!(sequence_multi_default, rasn::der::decode(&sequence_multi_default_enc).unwrap());
-    assert_eq!(sequence_multi_default, rasn::der::decode(&EXPECTED_MULTI_DEFAULT_FIELD_ENCODED).unwrap());
-
+    assert_eq!(
+        sequence_multi_default,
+        rasn::der::decode(&sequence_multi_default_enc).unwrap()
+    );
+    assert_eq!(
+        sequence_multi_default,
+        rasn::der::decode(&EXPECTED_MULTI_DEFAULT_FIELD_ENCODED).unwrap()
+    );
     assert_eq!(delegate_seq_enc, EXPECTED);
     assert_eq!(inline_seq_enc, EXPECTED);
     assert_eq!(field_seq_enc, EXPECTED);

--- a/tests/explicit.rs
+++ b/tests/explicit.rs
@@ -10,6 +10,23 @@ pub struct Sequence {
 }
 
 #[derive(AsnType, Decode, Debug, Encode, PartialEq)]
+pub struct SequenceWithDefault {
+    #[rasn(tag(explicit(application, 1)), default = "default_bool")]
+    b: bool,
+}
+
+#[derive(AsnType, Decode, Debug, Encode, PartialEq)]
+pub struct SequenceWithMultiDefault {
+    #[rasn(tag(explicit(application, 1)), default = "default_bool")]
+    b: bool,
+    #[rasn(tag(explicit(application, 2)), default = "default_bool")]
+    b2: bool,
+}
+pub fn default_bool() -> bool {
+    true
+}
+
+#[derive(AsnType, Decode, Debug, Encode, PartialEq)]
 #[rasn(tag(explicit(application, 1)))]
 pub struct InlineSequence {
     b: bool,
@@ -67,6 +84,13 @@ const _: () = assert!(Tag::const_eq(DelegateSequence::TAG, &InlineSet::TAG,));
 #[test]
 fn works() {
     const EXPECTED: &[u8] = &[0x61, 0x5, 0x30, 0x3, 0x01, 0x1, 0xFF];
+    // Note that the explicitly tagged field is dropped.
+    // This makes it a sequence with 0 elements
+    const EXPECTED_DEFAULT: &[u8] = &[0x30, 0x00];
+    const EXPECTED_NOT_DEFAULT: &[u8] = &[0x30, 0x05, 0x61, 0x03, 0x01, 0x01, 0x00];
+    // NOTE: The explicit tag number is just different
+    const EXPECTED_MULTI_DEFAULT: &[u8] = &[0x30, 0x05, 0x62, 0x03, 0x01, 0x01, 0x00];
+
     let delegate_seq = DelegateSequence(Sequence { b: true });
     let inline_seq = InlineSequence { b: true };
     let field_seq = SequenceField { b: true };
@@ -83,6 +107,19 @@ fn works() {
     let delegate_choice_enc = rasn::der::encode(&delegate_choice).unwrap();
     let inline_choice_enc = rasn::der::encode(&inline_choice).unwrap();
     let wrapped_choice_enc = rasn::der::encode(&wrapped_choice).unwrap();
+
+    // Set the field to match the default value to have it dropped
+    let sequence_default = SequenceWithDefault { b: true };
+    let sequence_non_default = SequenceWithDefault { b: false };
+    let sequence_default_enc = rasn::der::encode(&sequence_default).unwrap();
+    let sequence_non_default_enc = rasn::der::encode(&sequence_non_default).unwrap();
+    // Verify it correctly includes encoded fields
+    let sequence_multi_default = SequenceWithMultiDefault { b: true, b2: false };
+    let sequence_multi_default_enc = rasn::der::encode(&sequence_multi_default).unwrap();
+
+    assert_eq!(sequence_non_default_enc, EXPECTED_NOT_DEFAULT);
+    assert_eq!(sequence_default_enc, EXPECTED_DEFAULT);
+    assert_eq!(sequence_multi_default_enc, EXPECTED_MULTI_DEFAULT);
 
     assert_eq!(delegate_seq_enc, EXPECTED);
     assert_eq!(inline_seq_enc, EXPECTED);


### PR DESCRIPTION
Currently, when using an explicit tag default values are not considered and only a code path of adding that value to the encoded output is followed.

This change adds support to check if the default value matches and, if so, does not encode it. This will have no impact on the decode path.