### PR TITLE
Clarify error message for UnexpectedEmptyInput

### DIFF
--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -686,7 +686,9 @@ pub enum DecodeErrorKind {
         tag: Tag,
     },
     /// An error when there should be more data but it is not present.
-    #[snafu(display("SEQUENCE has at least one required field, but no input provided"))]
+    #[snafu(display(
+        "No input was provided where expected in the given SEQUENCE or INTEGER type"
+    ))]
     UnexpectedEmptyInput,
 }
 


### PR DESCRIPTION
Currently, the `UnexpectedEmptyInput` error prints out the following message:

```
SEQUENCE has at least one required field, but no input provided
```

However, not all instances of this error are within SEQUENCE types; some may occur within INTEGER types as well:

https://github.com/librasn/rasn/blob/3e8e3a26048c229b32a66a48362ea476a2ddd92d/src/types/integer.rs#L519-L527

https://github.com/librasn/rasn/blob/3e8e3a26048c229b32a66a48362ea476a2ddd92d/src/types/integer.rs#L637-L645

https://github.com/librasn/rasn/blob/3e8e3a26048c229b32a66a48362ea476a2ddd92d/src/types/integer.rs#L730-L743

(the unexpected_empty_input() function maps to the UnexpectedEmptyInput error):

https://github.com/librasn/rasn/blob/3e8e3a26048c229b32a66a48362ea476a2ddd92d/src/error/decode.rs#L348

This PR simply changes the phrasing of this error message to include INTEGER types as potential causes of the error.