### PR TITLE
feat: support multi-field tuple-structs with delegate if other types are PhantomData

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -51,7 +51,7 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 /// - `crate_root` The path to the `rasn` library to use in the macro.
 /// - `enumerated/choice` Use either `#[rasn(choice)]` or `#[rasn(enumerated)]`
 /// - `delegate` Only available for newtype wrappers (e.g. `struct Delegate(T)`);
-///   uses the inner `T` type for implementing the trait.
+///   uses the inner `T` type for implementing the trait. Tuple-struct can have more than one field if other fields are `PhantomData` types.
 #[proc_macro_derive(AsnType, attributes(rasn))]
 pub fn asn_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -70,3 +70,62 @@ fn test_sequence_with_generic_and_constraints() {
         Third(T),
     }
 }
+#[test]
+fn test_multi_field_tuple_structs_with_phantom_data() {
+    use core::marker::PhantomData;
+    // without phantom data
+    #[derive(AsnType, Debug, Encode, Decode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    pub struct TupleStruct(u8);
+
+    let encoded = rasn::oer::encode::<TupleStruct>(&TupleStruct(1)).unwrap();
+
+    #[derive(AsnType, Debug, Encode, Decode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    #[rasn(delegate, automatic_tags)]
+    pub struct TupleStructWithPhantomData<T: Ord>(u8, PhantomData<T>);
+    let encoded2 = rasn::oer::encode::<TupleStructWithPhantomData<u32>>(
+        &TupleStructWithPhantomData(1, PhantomData),
+    )
+    .unwrap();
+
+    #[derive(AsnType, Debug, Encode, Decode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    pub struct TupleStructWithTwoPhantomData<T: Ord>(u8, PhantomData<T>, PhantomData<T>);
+    let encoded3 = rasn::oer::encode::<TupleStructWithTwoPhantomData<u32>>(
+        &TupleStructWithTwoPhantomData(1, PhantomData, PhantomData),
+    )
+    .unwrap();
+
+    #[derive(AsnType, Debug, Encode, Decode, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    #[rasn(automatic_tags)]
+    #[rasn(delegate)]
+    pub struct TupleStructWithThreePhantomData<T: Ord>(
+        u8,
+        PhantomData<T>,
+        PhantomData<T>,
+        PhantomData<T>,
+    );
+    let encoded4 = rasn::oer::encode::<TupleStructWithThreePhantomData<u32>>(
+        &TupleStructWithThreePhantomData(1, PhantomData, PhantomData, PhantomData),
+    )
+    .unwrap();
+    assert_eq!(&encoded, &encoded2);
+    assert_eq!(&encoded, &encoded3);
+    assert_eq!(&encoded, &encoded4);
+    let decoded = rasn::oer::decode::<TupleStruct>(&encoded).unwrap();
+    assert_eq!(decoded, TupleStruct(1));
+    let decoded2 = rasn::oer::decode::<TupleStructWithPhantomData<u32>>(&encoded2).unwrap();
+    assert_eq!(decoded2, TupleStructWithPhantomData(1, PhantomData));
+    let decoded3 = rasn::oer::decode::<TupleStructWithTwoPhantomData<u32>>(&encoded3).unwrap();
+    assert_eq!(
+        decoded3,
+        TupleStructWithTwoPhantomData(1, PhantomData, PhantomData)
+    );
+    let decoded4 = rasn::oer::decode::<TupleStructWithThreePhantomData<u32>>(&encoded4).unwrap();
+    assert_eq!(
+        decoded4,
+        TupleStructWithThreePhantomData(1, PhantomData, PhantomData, PhantomData)
+    );
+}


### PR DESCRIPTION
Continues #433 .. Sometimes it can be useful to support newtype pattern and delegate with more than one field when other fields are `PhantomData` type. This allows the use of generics to apply inner constraints for the underlying type.  