### PR TITLE
feat: inner subtype constraint

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 //! Backtraces are enabled by default with `backtraces` feature.
 //! See submodules for other error types.
 #![allow(clippy::module_name_repetitions)]
+mod components;
 mod decode;
 mod encode;
 mod string;
@@ -27,3 +28,5 @@ pub use encode::JerEncodeErrorKind;
 pub use encode::{
     BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError, XerEncodeErrorKind,
 };
+
+pub use components::InnerSubtypeConstraintError;

--- a/src/error/components.rs
+++ b/src/error/components.rs
@@ -1,0 +1,91 @@
+use snafu::Snafu;
+
+/// Error types for inner subtype constraints
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum InnerSubtypeConstraintError {
+    /// General error for subtype constraint violation: invalid inner component combination in a newtype.
+    /// Mostly useful when there are specific variants for a base type, e.g. implicit or explicit variants.
+    /// Other use discouraged.
+    #[snafu(display("Invalid component combination in {component_path}: {details}"))]
+    SubtypeConstraintViolation {
+        /// The path to the component where the invalid component combination was found.
+        component_path: &'static str,
+        /// Detailed information about the invalid component combination.
+        details: &'static str,
+    },
+
+    /// A required component is missing. All components stated in `components` must be present.
+    #[snafu(display(
+        "Missing required components in {component_path}: the following must be present:"
+    ))]
+    MissingRequiredComponent {
+        /// The path to the component where the required component is missing.
+        component_path: &'static str,
+        /// List of required components that are missing.
+        components: &'static [&'static str],
+    },
+
+    /// Subtype constraint violation: mutually exclusive components are present
+    #[snafu(display("Mutually exclusive components present in {component_path}: {components:?}"))]
+    MutuallyExclusiveViolation {
+        /// The path to the componenent where the mutually exclusive components are present.
+        component_path: &'static str,
+        /// List of mutually exclusive components that are present.
+        components: &'static [&'static str],
+    },
+    /// Invalid value for a component
+    #[snafu(display(
+        "Invalid value for component {component_path} in {component_name}: {details}"
+    ))]
+    InvalidComponentValue {
+        /// The path to the component where the invalid component value was found.
+        component_path: &'static str,
+        /// The name of the component type or field with the invalid value.
+        component_name: &'static str,
+        /// Detailed information about the invalid component value.
+        details: alloc::string::String,
+    },
+    /// Invalid component variant (applies to enums and choice types)
+    #[snafu(display(
+        "Invalid variant for component {component_type} in {component_path}: {details}"
+    ))]
+    InvalidComponentVariant {
+        /// The path to the component where the invalid component variant was found.
+        component_path: &'static str,
+        /// The name of the component type with the invalid variant.
+        component_type: &'static str,
+        /// Detailed information about the invalid component variant.
+        details: alloc::string::String,
+    },
+    /// Invalid size constraint for a component
+    #[snafu(display(
+        "Invalid size constraint for component {component_name} in {component_path}: {details}"
+    ))]
+    InvalidComponentSize {
+        /// The name of the type where the invalid component value was found.
+        component_path: &'static str,
+        /// The name of the component type or field with the invalid size.
+        component_name: &'static str,
+        /// Detailed information about the inner error.
+        details: alloc::string::String,
+    },
+    /// A field that should be absent is present
+    #[snafu(display(
+        "Component that should be absent is present in {component_path}: {component_name}"
+    ))]
+    UnexpectedComponentPresent {
+        /// The name of the type where the absent component is present.
+        component_path: &'static str,
+        /// The name of the absent component that is present.
+        component_name: &'static str,
+    },
+    /// An error if inner `CONTAINING` constraint is not satisfied.
+    #[snafu(display("CONTAINING does not contain the expected component {expected}: {err}"))]
+    InvalidInnerContaining {
+        /// The name of the expected value in CONTAINING constraint.
+        expected: &'static str,
+        /// Inner decode error
+        err: alloc::string::String,
+    },
+}

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -189,6 +189,18 @@ impl DecodeError {
             codec,
         )
     }
+    /// Creates a wrapper around a inner subtype constraint error from a given codec.
+    /// This is mainly used by standards.
+    #[must_use]
+    pub fn inner_subtype_constraint_not_satisfied(
+        reason: super::InnerSubtypeConstraintError,
+        codec: Codec,
+    ) -> Self {
+        Self::from_kind(
+            DecodeErrorKind::InnerSubtypeConstraintNotSatisfied { reason },
+            codec,
+        )
+    }
 
     /// Creates a wrapper around a discriminant value error from a given codec.
     #[must_use]
@@ -442,6 +454,12 @@ pub enum DecodeErrorKind {
         value: BigInt,
         /// Expected value by the constraint
         expected: Bounded<i128>,
+    },
+    /// Inner subtype constraint not satisfied.
+    #[snafu(display("Inner subtype constraint not satisfied: {reason}"))]
+    InnerSubtypeConstraintNotSatisfied {
+        /// The reason the constraint wasn't satisfied.
+        reason: super::InnerSubtypeConstraintError,
     },
 
     /// Codec specific error.

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,7 @@ use alloc::boxed::Box;
 pub use {
     self::{
         any::Any,
-        constraints::{Constraint, Constraints, Extensible},
+        constraints::{Constraint, Constraints, Extensible, InnerSubtypeConstraint},
         constructed::{Constructed, SequenceOf, SetOf},
         identifier::Identifier,
         instance::InstanceOf,

--- a/src/types/constraints.rs
+++ b/src/types/constraints.rs
@@ -3,6 +3,25 @@
 use super::IntegerType;
 use num_bigint::BigInt;
 
+/// A marker trait with validation methods for types that have ASN.1 inner subtype constraints.
+pub trait InnerSubtypeConstraint: Sized {
+    /// Validates the inner subtype constraints and returns the type on success.
+    /// Does not attempt to decode internal ASN.1 `CONTAINING` constraints as a marked type. See `validate_and_decode_containing` for CONTAINING validation.
+    fn validate_components(self) -> Result<Self, crate::error::InnerSubtypeConstraintError> {
+        self.validate_and_decode_containing(None)
+    }
+
+    /// Validates the inner subtype constraints and attempts to decode internal ASN.1 `CONTAINING` constraints as a marked type.
+    /// Usually this means that some field has `OPAQUE` data, and we need to decode it further as a specific type, as defined in the inner subtype constraint.
+    /// Manual implementation of this function is required for all types that have inner subtype constraints.
+    /// # Arguments
+    /// * `decode_containing_with` - the codec to validate and decode the containing data with - ASN.1 type definiton has `CONTAINING.
+    fn validate_and_decode_containing(
+        self,
+        decode_containing_with: Option<crate::Codec>,
+    ) -> Result<Self, crate::error::InnerSubtypeConstraintError>;
+}
+
 /// A set of constraints for a given type on what kinds of values are allowed.
 /// Used in certain codecs to optimise encoding and decoding values.
 ///


### PR DESCRIPTION
Adds `InnerSubtypeConstraint` constraint trait and some relevant error messages. Mainly used in #389 

Usage requires implementing single method which should validate the inner constraints:

```rust
/// Validates the inner subtype constraints and attempts to decode internal ASN.1 `CONTAINING` constraints as a marked type.
/// Usually this means that some field has `OPAQUE` data, and we need to decode it further as a specific type, as defined in the inner subtype constraint.
/// Manual implementation of this function is required for all types that have inner subtype constraints.
/// # Arguments
/// * `decode_containing_with` - the codec to validate and decode the containing data with - ASN.1 type definiton has `CONTAINING.
fn validate_and_decode_containing(
    self,
    decode_containing_with: Option<crate::Codec>,
) -> Result<Self, crate::error::InnerSubtypeConstraintError>;
```