### PR TITLE
fix: remove SetOf hashbrown dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,12 +25,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -472,16 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,7 +858,6 @@ dependencies = [
  "chrono",
  "criterion",
  "either",
- "hashbrown",
  "iai-callgrind",
  "nom",
  "num-bigint",
@@ -1389,12 +1360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,26 +1608,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ bitvec.workspace = true
 bytes = { version = "1.7.2", default-features = false }
 chrono.workspace = true
 either = { version = "1.13.0", default-features = false }
-hashbrown = "0.14.5"
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 nom-bitvec = { package = "bitvec-nom2", version = "0.2.1" }
 num-bigint = { version = "0.4.6", default-features = false }
@@ -117,5 +116,5 @@ x509-certificate = "0.23.1"
 x509-parser = "0.16"
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
-rasn-derive-impl = { path = "macros/macros_impl"}
-syn = {  version = "2.0.87", features = ["full"] }
+rasn-derive-impl = { path = "macros/macros_impl" }
+syn = { version = "2.0.87", features = ["full"] }


### PR DESCRIPTION
Okay, I am not sure what I was originally thinking, but we can just use `Vec<T>` internally here with `SetOf` and drop the `hashbrown` dependency.

It takes more space internally and equal check is significantly slower but it is likely reasonable trade-off. Not a common type in modern standards. 

Fixes #350 