### PR TITLE
Change from TagTree in choice for Tag array

### DIFF
--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 use snafu::{Backtrace, GenerateImplicitData};
 
 use crate::de::Error;
-use crate::types::{constraints::Bounded, variants::Variants, Tag};
+use crate::types::{constraints::Bounded, Tag};
 use crate::Codec;
 use num_bigint::BigInt;
 
@@ -340,7 +340,11 @@ impl DecodeError {
 
     /// Creates a wrapper around a missing choice index error from a given codec.
     #[must_use]
-    pub fn choice_index_not_found(index: usize, variants: Variants, codec: Codec) -> Self {
+    pub fn choice_index_not_found(
+        index: usize,
+        variants: alloc::vec::Vec<Tag>,
+        codec: Codec,
+    ) -> Self {
         Self::from_kind(
             DecodeErrorKind::ChoiceIndexNotFound { index, variants },
             codec,
@@ -498,7 +502,7 @@ pub enum DecodeErrorKind {
         /// The found index of the choice variant.
         index: usize,
         /// The variants checked for presence.
-        variants: Variants,
+        variants: alloc::vec::Vec<Tag>,
     },
 
     /// Choice index exceeds maximum possible address width.

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -6,10 +6,10 @@ use crate::{
     de::Error,
     error::{DecodeError, JerDecodeErrorKind},
     types::{
-        variants, Any, BitString, BmpString, Constraints, Constructed, Date, DecodeChoice,
-        Enumerated, GeneralString, GeneralizedTime, GraphicString, Ia5String, NumericString,
-        ObjectIdentifier, Oid, PrintableString, SequenceOf, SetOf, Tag, TeletexString, UtcTime,
-        Utf8String, VisibleString,
+        Any, BitString, BmpString, Constraints, Constructed, Date, DecodeChoice, Enumerated,
+        GeneralString, GeneralizedTime, GraphicString, Ia5String, NumericString, ObjectIdentifier,
+        Oid, PrintableString, SequenceOf, SetOf, Tag, TeletexString, UtcTime, Utf8String,
+        VisibleString,
     },
     Decode,
 };
@@ -660,14 +660,13 @@ impl Decoder {
                     .map(|(i, _)| (i, v))
             })
             .map_or(Tag::EOC, |(i, v)| {
-                match variants::Variants::from_slice(
-                    &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
-                )
-                .get(i)
+                match &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])]
+                    .concat()
+                    .get(i)
                 {
                     Some(t) => {
                         self.stack.push(v.clone());
-                        *t
+                        **t
                     }
                     None => Tag::EOC,
                 }

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -8,7 +8,7 @@ type ValueMap = Map<alloc::string::String, Value>;
 
 use crate::{
     error::{EncodeError, JerEncodeErrorKind},
-    types::{variants, Constraints, Identifier, IntegerType, Tag},
+    types::{Constraints, Identifier, IntegerType, Tag},
 };
 
 use crate::types::RealType;
@@ -487,9 +487,7 @@ impl crate::Encoder<'_> for Encoder {
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
         _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        let variants = variants::Variants::from_slice(
-            &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
-        );
+        let variants = &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat();
 
         let identifier = variants
             .iter()

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -894,12 +894,12 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
     {
         let is_extensible = constraints.extensible();
         let tag: Tag = self.parse_tag()?;
-        let is_root_extension = crate::types::TagTree::tag_contains(&tag, D::VARIANTS);
-        let is_extended_extension =
-            crate::types::TagTree::tag_contains(&tag, D::EXTENDED_VARIANTS.unwrap_or(&[]));
+        let is_root_extension = D::VARIANTS.contains(&tag);
         if is_root_extension {
-            D::from_tag(self, tag)
-        } else if is_extensible && is_extended_extension {
+            return D::from_tag(self, tag);
+        }
+        let is_extended_extension = D::EXTENDED_VARIANTS.unwrap_or(&[]).contains(&tag);
+        if is_extensible && is_extended_extension {
             let options = self.options;
             let length = self.decode_length()?;
             let bytes = self.extract_data_by_length(length)?;

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -1048,11 +1048,11 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
         D: crate::types::DecodeChoice,
     {
         let is_extensible = self.parse_extensible_bit(&constraints)?;
-        let variants = crate::types::variants::Variants::from_static(if is_extensible {
+        let variants = if is_extensible {
             D::EXTENDED_VARIANTS.unwrap_or(&[])
         } else {
             D::VARIANTS
-        });
+        };
 
         let index = if variants.len() != 1 || is_extensible {
             if is_extensible {
@@ -1080,7 +1080,7 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
         };
 
         let tag = variants.get(index).ok_or_else(|| {
-            DecodeError::choice_index_not_found(index, variants.clone(), self.codec())
+            DecodeError::choice_index_not_found(index, variants.to_vec(), self.codec())
         })?;
 
         if is_extensible {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1234,22 +1234,22 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
     ) -> Result<Self::Ok, Self::Error> {
         let mut buffer = BitString::new();
 
-        let is_root_extension = crate::types::TagTree::tag_contains(&tag, E::VARIANTS);
+        let is_root_extension = E::VARIANTS.contains(&tag);
         self.encode_extensible_bit(&constraints, &mut buffer, || is_root_extension);
-        let variants = crate::types::variants::Variants::from_static(if is_root_extension {
+        let tags = if is_root_extension {
             E::VARIANTS
         } else {
             E::EXTENDED_VARIANTS.unwrap_or(&[])
-        });
+        };
 
-        let index = variants
+        let index = tags
             .iter()
             .enumerate()
             .find_map(|(i, &variant_tag)| (tag == variant_tag).then_some(i))
             .ok_or_else(|| Error::variant_not_in_choice(self.codec()))?;
 
         let bounds = if is_root_extension {
-            let variance = variants.len();
+            let variance = tags.len();
             debug_assert!(variance > 0);
             if variance == 1 {
                 None

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,6 @@ mod tag;
 
 pub mod constraints;
 pub mod fields;
-pub mod variants;
 
 pub(crate) mod constructed;
 pub(crate) mod date;
@@ -91,11 +90,11 @@ pub trait AsnType {
 /// A `CHOICE` value.
 pub trait Choice: Sized {
     /// Variants contained in the "root component list".
-    const VARIANTS: &'static [TagTree];
+    const VARIANTS: &'static [Tag];
     /// Constraint for the choice type, based on the number of root components. Used for PER encoding.
     const VARIANCE_CONSTRAINT: Constraints;
     /// Variants contained in the list of extensions.
-    const EXTENDED_VARIANTS: Option<&'static [TagTree]> = None;
+    const EXTENDED_VARIANTS: Option<&'static [Tag]> = None;
     /// Variant identifiers for text-based encoding rules
     const IDENTIFIERS: &'static [&'static str];
 }

--- a/src/types/variants.rs
+++ b/src/types/variants.rs
@@ -1,71 +1,67 @@
-//! Representing all possible variants for a `CHOICE` type.
+// //! Representing all possible variants for a `CHOICE` type.
 
-use alloc::{borrow::Cow, vec, vec::Vec};
+// use alloc::{borrow::Cow, vec, vec::Vec};
 
-use crate::types::{Tag, TagTree};
+// use crate::types::{Tag, TagTree};
 
-/// A set of tags which represents all possible tags used in this field.
-#[derive(Debug, Clone)]
-pub struct Variants {
-    fields: Vec<Tag>,
-}
+// /// A set of tags which represents all possible tags used in this field.
+// #[derive(Debug, Clone)]
+// pub struct Variants {
+//     fields: Vec<Tag>,
+// }
 
-impl Variants {
-    /// Creates a new set of variants from a given set of tag trees.
-    #[must_use]
-    pub fn new(fields: Cow<'static, [TagTree]>) -> Self {
-        Self::flatten_tree((*fields).iter())
-    }
+// impl Variants {
+//     /// Creates a new set of variants from a given set of tag trees.
+//     pub fn new(fields: Cow<'static, [TagTree]>) -> Self {
+//         Self::flatten_tree((*fields).iter())
+//     }
 
-    /// Returns an empty set of variants.
-    #[must_use]
-    pub const fn empty() -> Self {
-        Self { fields: Vec::new() }
-    }
+//     /// Returns an empty set of variants.
+//     pub const fn empty() -> Self {
+//         Self { fields: Vec::new() }
+//     }
 
-    /// Creates a new set of variants from a static set of tag trees.
-    #[must_use]
-    pub fn from_static(fields: &'static [TagTree]) -> Self {
-        Self::new(Cow::Borrowed(fields))
-    }
+//     /// Creates a new set of variants from a static set of tag trees.
+//     pub fn from_static(fields: &'static [TagTree]) -> Self {
+//         Self::new(Cow::Borrowed(fields))
+//     }
 
-    /// Creates a new set of variants a static set of tag trees.
-    #[must_use]
-    pub fn from_slice(fields: &[TagTree]) -> Self {
-        Self::flatten_tree(fields.iter())
-    }
+//     /// Creates a new set of variants a static set of tag trees.
+//     pub fn from_slice(fields: &[TagTree]) -> Self {
+//         Self::flatten_tree(fields.iter())
+//     }
 
-    fn flatten_tree<'a, I>(field_iter: I) -> Self
-    where
-        I: Iterator<Item = &'a TagTree>,
-    {
-        let fields = field_iter
-            .flat_map(|tree| {
-                fn flatten_tree(tree: &TagTree) -> Vec<Tag> {
-                    match tree {
-                        TagTree::Leaf(tag) => vec![*tag],
-                        TagTree::Choice(tree) => tree.iter().flat_map(flatten_tree).collect(),
-                    }
-                }
+//     fn flatten_tree<'a, I>(field_iter: I) -> Self
+//     where
+//         I: Iterator<Item = &'a TagTree>,
+//     {
+//         let fields = field_iter
+//             .flat_map(|tree| {
+//                 fn flatten_tree(tree: &TagTree) -> Vec<Tag> {
+//                     match tree {
+//                         TagTree::Leaf(tag) => vec![*tag],
+//                         TagTree::Choice(tree) => tree.iter().flat_map(flatten_tree).collect(),
+//                     }
+//                 }
 
-                flatten_tree(tree)
-            })
-            .collect();
+//                 flatten_tree(tree)
+//             })
+//             .collect();
 
-        Self { fields }
-    }
-}
+//         Self { fields }
+//     }
+// }
 
-impl From<Cow<'static, [TagTree]>> for Variants {
-    fn from(fields: Cow<'static, [TagTree]>) -> Self {
-        Self::new(fields)
-    }
-}
+// impl From<Cow<'static, [TagTree]>> for Variants {
+//     fn from(fields: Cow<'static, [TagTree]>) -> Self {
+//         Self::new(fields)
+//     }
+// }
 
-impl core::ops::Deref for Variants {
-    type Target = [Tag];
+// impl core::ops::Deref for Variants {
+//     type Target = [Tag];
 
-    fn deref(&self) -> &Self::Target {
-        &self.fields
-    }
-}
+//     fn deref(&self) -> &Self::Target {
+//         &self.fields
+//     }
+// }

--- a/src/xer/de.rs
+++ b/src/xer/de.rs
@@ -819,11 +819,10 @@ impl crate::Decoder for Decoder {
                     .enumerate()
                     .find(|(_, id)| id.eq_ignore_ascii_case(&name.local_name))
                     .and_then(|(i, _)| {
-                        variants::Variants::from_slice(
-                            &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
-                        )
-                        .get(i)
-                        .cloned()
+                        [D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])]
+                            .concat()
+                            .get(i)
+                            .copied()
                     })
                     .unwrap_or(Tag::EOC);
                 let events = self


### PR DESCRIPTION
I am still doing some benchmarking and optimizations, and it seems that `TagTree::tag_contains` takes a lot time when there are many `Choice` types in the overall type.

It seems to call itself recursively at least once no matter what it contains.
This adds ups since when especially decoding `Choice` variant that is the last in order, `tag_contains` can be called 1 + amount of variants or even more.  

So I have tried to replace `TagTree` with simple `&'static [Tag]` whenever possible, including in Choice trait, and there is a pretty significant performance boost available.

I still have to test if there are some side effects what current tests are not showing. 

![image](https://github.com/user-attachments/assets/f1ce7776-55bf-4dab-94ab-795cfaa0d4b0)

At least current codec implementations just want to know whether tag exists with VARIANTS/EXTENDED_VARIANTS so maybe this can be changed.