### PR TITLE
Fix invalid mapping of PKIStatus in TSP. 

### DIFF
--- a/standards/cms/src/tsp.rs
+++ b/standards/cms/src/tsp.rs
@@ -122,20 +122,7 @@ pub struct PkiStatusInfo {
        -- notification that a revocation has occurred  }
 ```
 */
-#[derive(AsnType, Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[rasn(enumerated)]
-pub enum PkiStatus {
-    /// A TimeStampToken, as requested, is present.
-    Granted = 0,
-    /// A TimeStampToken, with modifications, is present.
-    GrantedWithMods = 1,
-    Rejection = 2,
-    Waiting = 3,
-    /// This message contains a warning that a revocation is imminent.
-    RevocationWarning = 4,
-    /// Notification that a revocation has occurred.
-    RevocationNotification = 5,
-}
+pub type PkiStatus = Integer;
 
 /** Time-stamp response status free text.
 

--- a/standards/cms/src/tsp.rs
+++ b/standards/cms/src/tsp.rs
@@ -1,6 +1,7 @@
 //! [RFC 3161](https://www.rfc-editor.org/rfc/rfc3161) Time Stamp Protocol (TSP).
 
 use crate::ContentInfo;
+use rasn::error::DecodeError;
 use rasn::prelude::*;
 use rasn::types::OctetString;
 use rasn::{AsnType, Decode, Encode};
@@ -122,7 +123,47 @@ pub struct PkiStatusInfo {
        -- notification that a revocation has occurred  }
 ```
 */
-pub type PkiStatus = Integer;
+#[derive(AsnType, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[rasn(enumerated)]
+pub enum PkiStatus {
+    /// A TimeStampToken, as requested, is present.
+    Granted = 0,
+    /// A TimeStampToken, with modifications, is present.
+    GrantedWithMods = 1,
+    Rejection = 2,
+    Waiting = 3,
+    /// This message contains a warning that a revocation is imminent.
+    RevocationWarning = 4,
+    /// Notification that a revocation has occurred.
+    RevocationNotification = 5,
+}
+
+impl Decode for PkiStatus {
+    fn decode_with_tag_and_constraints<D: Decoder>(
+        decoder: &mut D,
+        _tag: Tag,
+        constraints: Constraints,
+    ) -> Result<Self, D::Error> {
+        let discriminant = decoder.decode_integer::<isize>(Tag::INTEGER, constraints)?;
+        let pki_status = PkiStatus::from_discriminant(discriminant).ok_or_else(|| {
+            DecodeError::discriminant_value_not_found(discriminant, decoder.codec())
+        })?;
+        Ok(pki_status)
+    }
+}
+
+impl Encode for PkiStatus {
+    fn encode_with_tag_and_constraints<'b, E: Encoder<'b>>(
+        &self,
+        encoder: &mut E,
+        _tag: Tag,
+        constraints: Constraints,
+        identifier: Identifier,
+    ) -> Result<(), <E as Encoder<'b>>::Error> {
+        encoder.encode_integer(Tag::INTEGER, constraints, &self.discriminant(), identifier)?;
+        Ok(())
+    }
+}
 
 /** Time-stamp response status free text.
 


### PR DESCRIPTION
Contributed under SPDX "MIT OR Apache-2.0" licenses.

Mapping PKIStatus to an enum didn't work out as expected in https://github.com/librasn/rasn/pull/451 when doing interoperability tests:

```text
"Error while decoding data. kind: 'FieldError { name: \"TimeStampResp.status\", nested: DecodeError { kind: FieldError { name: \"PkiStatusInfo.status\", nested: DecodeError { kind: CodecSpecific { inner: Ber(MismatchedTag { expected: Tag { class: Universal, value: 10 }, actual: Tag { class: Universal, value: 2 } }) }, codec: Ber } }, codec: Der } }', codec: 'Der'"
```

Revert to using the one-to-one mapping from [RFC 3161 2.4.2](https://www.rfc-editor.org/rfc/rfc3161#section-2.4.2) :

```text
   PKIStatus ::= INTEGER {
      ...
```
