### PR TITLE
chore(xer): update xml-no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "xml-no-std"
-version = "0.8.19"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4f451c779ea0b57e28c106c0fdafe9290038c97d26364aeb87617d2b78f698"
+checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ snafu = { version = "0.8.5", default-features = false, features = [
   "rust_1_81",
 ] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
-xml-no-std = "0.8.19"
+xml-no-std = "0.8.26"
 
 [dev-dependencies]
 asn1 = "=0.20.0"


### PR DESCRIPTION
Closes #445

Updates `xml-no-std` to `v0.8.26`, which adopted a fix by kornelski for a decoding panic.