### PR TITLE
fix(uper): empty outer encoding

### DIFF
--- a/src/uper.rs
+++ b/src/uper.rs
@@ -27,7 +27,12 @@ pub fn decode_with_remainder<T: crate::Decode>(
 pub fn encode<T: crate::Encode>(
     value: &T,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::EncodeError> {
-    crate::per::encode(enc::EncoderOptions::unaligned(), value)
+    let result = crate::per::encode(enc::EncoderOptions::unaligned(), value)?;
+    if result.is_empty() {
+        Ok(alloc::vec![0x00])
+    } else {
+        Ok(result)
+    }
 }
 
 /// Attempts to decode `T` from `input` using UPER-BASIC.
@@ -43,7 +48,13 @@ pub fn encode_with_constraints<T: crate::Encode>(
     constraints: Constraints,
     value: &T,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::EncodeError> {
-    crate::per::encode_with_constraints(enc::EncoderOptions::unaligned(), constraints, value)
+    let result =
+        crate::per::encode_with_constraints(enc::EncoderOptions::unaligned(), constraints, value)?;
+    if result.is_empty() {
+        Ok(alloc::vec![0x00])
+    } else {
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -91,7 +102,7 @@ mod tests {
         round_trip!(uper, C, C::new(1), &[0x58]);
         round_trip!(uper, C, C::new(10), &[0xa0]);
         // round_trip!(uper, D, 99, &[0x5e]);
-        round_trip!(uper, E, E::new(1000), &[]);
+        round_trip!(uper, E, E::new(1000), &[0x00]);
     }
 
     #[test]
@@ -1246,7 +1257,7 @@ mod tests {
             AlignedZeroLength {
                 the_string: OctetString::from_static(&[])
             },
-            &[]
+            &[0x00]
         );
     }
     #[test]


### PR DESCRIPTION
Returns a single zero-octet for empty outermost encodings.

11.1.3.1	(The result of the encoding is not contained in an ASN.1 bitstring) If the result of encoding the outermost value is an empty bit string, the bit string shall be replaced with a single octet with all bits set to 0. If it is a non-empty bit string and it is not a multiple of eight bits, (one to seven) zero bits shall be appended to it to produce a multiple of eight bits.

Technically, there's also the following paragraph to consider, but given that we `rasn::uper::encode` always returns a byte vector that may be padded it does not apply.

11.1.3.2	(The result of the encoding is contained in an ASN.1 bitstring) If the result of encoding the outermost value is an empty bit string, the bit string shall be replaced with a single bit set to 0. No padding bits shall be appended.

