### PR TITLE
fix(OER/PER): detect choice type always correctly on explicit prefix

### DIFF
--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -175,6 +175,11 @@ impl Enum<'_> {
             quote!(const IDENTIFIER: #crate_root::types::Identifier = #crate_root::types::Identifier(Some(#name_literal));),
             |id| quote!(const IDENTIFIER: #crate_root::types::Identifier = #crate_root::types::Identifier(Some(#id));),
         );
+        let is_choice = if self.config.choice {
+            quote!(true)
+        } else {
+            quote!(false)
+        };
 
         Ok(quote! {
             impl #impl_generics #crate_root::AsnType for #name #ty_generics #where_clause {
@@ -191,6 +196,8 @@ impl Enum<'_> {
                 };
                 #alt_identifier
                 #constraints_def
+                const IS_CHOICE: bool = #is_choice;
+
             }
 
             #choice_impl

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -777,7 +777,7 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
 
     fn decode_explicit_prefix<D: Decode>(&mut self, tag: Tag) -> Result<D, Self::Error> {
         // Whether we have a choice here
-        if D::TAG == Tag::EOC {
+        if D::IS_CHOICE {
             D::decode(self)
         } else {
             D::decode_with_tag(self, tag)

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -950,7 +950,7 @@ impl<'buffer, const RFC: usize, const EFC: usize> crate::Encoder<'buffer>
         _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
         // Whether we have a choice type being encoded
-        if V::TAG == Tag::EOC {
+        if V::IS_CHOICE {
             value.encode(self)
         } else {
             value.encode_with_tag(self, tag)

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -923,7 +923,7 @@ impl<'input, const RFC: usize, const EFC: usize> crate::Decoder for Decoder<'inp
 
     fn decode_explicit_prefix<D: Decode>(&mut self, tag: Tag) -> Result<D> {
         // Whether we have a choice here
-        if D::TAG == Tag::EOC {
+        if D::IS_CHOICE {
             D::decode(self)
         } else {
             D::decode_with_tag(self, tag)

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1143,7 +1143,7 @@ impl<const RFC: usize, const EFC: usize> crate::Encoder<'_> for Encoder<RFC, EFC
         value: &V,
         _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        if V::TAG == Tag::EOC {
+        if V::IS_CHOICE {
             value.encode(self)
         } else {
             value.encode_with_tag(self, tag)

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,9 @@ pub trait AsnType {
     /// if not identical with the identifier of `Self`
     const IDENTIFIER: Identifier = Identifier::EMPTY;
 
+    /// Whether the type is choice type. PER/OER encoding rules require this knowledge.
+    const IS_CHOICE: bool = false;
+
     /// Whether the type is present with value. `OPTIONAL` fields are common in `SEQUENCE` or `SET`.
     ///
     /// Custom implementation is only used for `OPTIONAL` type.

--- a/src/uper.rs
+++ b/src/uper.rs
@@ -1249,4 +1249,36 @@ mod tests {
             &[]
         );
     }
+    #[test]
+    // https://github.com/librasn/rasn/issues/478
+    fn test_explicit_tagged_null_choice() {
+        use crate as rasn;
+        use rasn::prelude::*;
+
+        #[doc = " Inner type "]
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(choice, tag(explicit(context, 123)))]
+        pub enum FizzBuzz {
+            #[rasn(tag(context, 456))]
+            Foo(()),
+            #[rasn(tag(context, 789))]
+            Bar(()),
+        }
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        pub struct Fizz {
+            #[rasn(tag(explicit(context, 123)))]
+            pub buzz: FizzBuzz,
+        }
+        let encoded = rasn::uper::encode(&Fizz {
+            buzz: FizzBuzz::Foo(()),
+        })
+        .unwrap();
+        let decoded: Fizz = rasn::uper::decode(&encoded).unwrap();
+        assert_eq!(
+            decoded,
+            Fizz {
+                buzz: FizzBuzz::Foo(())
+            }
+        );
+    }
 }


### PR DESCRIPTION
Adds proper detection for choice type. 
Fixes #478  