### PR TITLE
CI: allow nightly workflows to fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    continue-on-error: ${{ matrix.channel == 'nightly' }}
     # Windows technically doesn't need this, but if we don't block windows on it
     # some of the windows jobs could fill up the concurrent job queue before
     # one of the install-cross jobs has started, so this makes sure all
@@ -70,6 +71,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    continue-on-error: ${{ matrix.channel == 'nightly' }}
     needs: install-cross
     steps:
       - uses: actions/checkout@v4
@@ -115,6 +117,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.channel == 'nightly' }}
     needs: install-cross
     steps:
       - uses: actions/checkout@v4

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -724,7 +724,7 @@ impl Decoder {
 
 /// Parses a hex string into bytes.
 fn bytes_from_hexstring(hex_string: &str) -> Option<alloc::vec::Vec<u8>> {
-    if hex_string.len() % 2 != 0 {
+    if !hex_string.len().is_multiple_of(2) {
         return None;
     }
     let mut bytes = alloc::vec::Vec::<u8>::with_capacity(hex_string.len() / 2);

--- a/src/oer/enc.rs
+++ b/src/oer/enc.rs
@@ -78,13 +78,14 @@ impl<const RC: usize, const EC: usize> ConstructedCursor<RC, EC> {
         let preamble_missing_bits =
             (8 - ((is_extensible as usize + number_optional_default) & 7)) & 7;
         debug_assert!(
-            (preamble_missing_bits + is_extensible as usize + number_optional_default) % 8 == 0
+            (preamble_missing_bits + is_extensible as usize + number_optional_default)
+                .is_multiple_of(8)
         );
         let preamble_width =
             (number_optional_default + is_extensible as usize + preamble_missing_bits) / 8;
         let extension_missing_bits: u8 =
             ((EC > 0) as u8).wrapping_neg() & ((8 - (EC & 7) as u8) & 7);
-        debug_assert!((EC + extension_missing_bits as usize) % 8 == 0);
+        debug_assert!((EC + extension_missing_bits as usize).is_multiple_of(8));
         let extension_bitfield_width = (EC + extension_missing_bits as usize) / 8;
         let extension_bitmap_width = 1 + extension_bitfield_width;
         let extension_bitmap_width_length = if extension_bitmap_width <= 127 {

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -135,7 +135,7 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
     }
 
     fn force_parse_padding(&self, input: InputSlice<'input>) -> Result<InputSlice<'input>> {
-        if input.len() % 8 == 0 {
+        if input.len().is_multiple_of(8) {
             Ok(input)
         } else {
             let (input, _) = nom::bytes::streaming::take(input.len() % 8)(input)

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -187,7 +187,7 @@ impl<const RCL: usize, const ECL: usize> Encoder<RCL, ECL> {
         if self.options.aligned {
             let mut output_length = self.output_length();
             output_length += buffer.len();
-            if output_length % 8 != 0 {
+            if !output_length.is_multiple_of(8) {
                 for _ in 0..(8 - output_length % 8) {
                     buffer.push(false);
                 }
@@ -197,7 +197,7 @@ impl<const RCL: usize, const ECL: usize> Encoder<RCL, ECL> {
 
     fn force_pad_to_alignment(buffer: &mut BitString) {
         const BYTE_WIDTH: usize = 8;
-        if buffer.len() % BYTE_WIDTH != 0 {
+        if !buffer.len().is_multiple_of(BYTE_WIDTH) {
             let mut string = BitString::new();
             for _ in 0..BYTE_WIDTH - (buffer.len() % 8) {
                 string.push(false);

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -244,7 +244,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         character_width: usize,
     ) -> Result<Self, PermittedAlphabetError> {
         let mut string = Self::default();
-        if character_width == 0 || bits.len() % character_width != 0 {
+        if character_width == 0 || !bits.len().is_multiple_of(character_width) {
             return Err(PermittedAlphabetError::InvalidData {
                 length: bits.len(),
                 width: character_width,


### PR DESCRIPTION
It might be possible that `rust-toolchain` file has prevented us from actually running nightly builds and we haven't seen many issues because of that. PR attempts to allow nightly builds to fail without failing the whole pipeline. Also fixes some nightly lint issues. 