### PR TITLE
Fix field tag stack for XER encoding 

### DIFF
--- a/src/xer.rs
+++ b/src/xer.rs
@@ -126,6 +126,26 @@ mod tests {
         recursion: Vec<DefaultSequence>,
     }
 
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    pub struct SequenceWithSequenceOf {
+        ids: SequenceOfIntegers,
+        flag: bool,
+        int: Integer,
+        enum_val: EnumType,
+    }
+
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    pub struct SequenceWithSetOf {
+        ids: SetOfIntegers,
+        flag: bool,
+        int: Integer,
+        enum_val: EnumType,
+    }
+
     fn bool_default() -> bool {
         bool::default()
     }
@@ -497,6 +517,30 @@ mod tests {
         },
         "SequenceWithChoice",
         "<recursion><Leaf /></recursion><nested><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid></nested>"
+    );
+    round_trip!(
+        sequence_with_element_after_sequence_of,
+        SequenceWithSequenceOf,
+        SequenceWithSequenceOf {
+            ids: vec![42, 13],
+            flag: false,
+            int: Integer::from(12),
+            enum_val: EnumType::First
+        },
+        "SequenceWithSequenceOf",
+        "<ids><INTEGER>42</INTEGER><INTEGER>13</INTEGER></ids><flag><false /></flag><int>12</int><enum_val><eins /></enum_val>"
+    );
+    round_trip!(
+        sequence_with_element_after_set_of,
+        SequenceWithSetOf,
+        SequenceWithSetOf {
+            ids: SetOf::from_vec(vec![42, 13]),
+            flag: false,
+            int: Integer::from(12),
+            enum_val: EnumType::First
+        },
+        "SequenceWithSetOf",
+        "<ids><INTEGER>42</INTEGER><INTEGER>13</INTEGER></ids><flag><false /></flag><int>12</int><enum_val><eins /></enum_val>"
     );
 
     #[test]

--- a/src/xer.rs
+++ b/src/xer.rs
@@ -84,6 +84,14 @@ mod tests {
         Recursion(Box<RecursiveChoice>),
     }
 
+    #[derive(AsnType, Debug, Encode, Decode, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct SequenceWithChoice {
+        recursion: RecursiveChoice,
+        nested: NestedTestA,
+    }
+
     #[derive(AsnType, Debug, Encode, Decode, PartialEq, Copy, Clone, Eq, Hash)]
     #[rasn(enumerated, automatic_tags)]
     #[rasn(crate_root = "crate")]
@@ -472,6 +480,23 @@ mod tests {
         }]),
         "SET_OF",
         "<Enum-Sequence><enum-field><zwei /></enum-field></Enum-Sequence>"
+    );
+    round_trip!(
+        sequence_with_element_after_choice,
+        SequenceWithChoice,
+        SequenceWithChoice {
+            recursion: RecursiveChoice::Leaf,
+            nested: NestedTestA {
+                wine: true,
+                grappa: vec![0, 1, 2, 3].into(),
+                inner: InnerTestA {
+                    hidden: Some(false),
+                },
+                oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1]))),
+            }
+        },
+        "SequenceWithChoice",
+        "<recursion><Leaf /></recursion><nested><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid></nested>"
     );
 
     #[test]

--- a/src/xer/enc.rs
+++ b/src/xer/enc.rs
@@ -27,7 +27,10 @@ use super::{BOOLEAN_FALSE_TAG, BOOLEAN_TRUE_TAG, MINUS_INFINITY_TAG, NAN_TAG, PL
 
 macro_rules! wrap_in_tags {
     ($this:ident, $tag:expr, $inner:ident, $($args:expr)*) => {{
-        let xml_tag = $this.field_tag_stack.pop().unwrap_or($tag);
+        let xml_tag = match $this.entering_list_item_type {
+            true => $tag,
+            false => $this.field_tag_stack.pop().unwrap_or($tag),
+        };
         $this.write_start_element(&xml_tag)?;
         $this.$inner($($args),*)?;
         $this.write_end_element(&xml_tag)
@@ -464,9 +467,12 @@ impl crate::Encoder<'_> for Encoder {
         }
 
         // Read current xml tag
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
 
         if self.entering_list_item_type {
             // List items that are `CHOICE` delegate types are encoded without their outer tags
@@ -508,9 +514,12 @@ impl crate::Encoder<'_> for Encoder {
         C: crate::types::Constructed<RL, EL>,
         F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
     {
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
         self.write_start_element(&xml_tag)?;
 
         let mut ids = C::FIELDS
@@ -538,9 +547,12 @@ impl crate::Encoder<'_> for Encoder {
         _constraints: Constraints,
         identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
         self.write_start_element(&xml_tag)?;
         for elem in value {
             self.set_entering_list_item_type(true);
@@ -559,9 +571,12 @@ impl crate::Encoder<'_> for Encoder {
         C: crate::types::Constructed<RL, EL>,
         F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
     {
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
         self.write_start_element(&xml_tag)?;
 
         let mut ids = C::FIELDS
@@ -589,9 +604,12 @@ impl crate::Encoder<'_> for Encoder {
         _constraints: Constraints,
         identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
         self.write_start_element(&xml_tag)?;
         for elem in value.to_vec() {
             self.set_entering_list_item_type(true);
@@ -646,12 +664,12 @@ impl crate::Encoder<'_> for Encoder {
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
         identifier: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        let xml_tag = self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
-            identifier
-                .or(E::IDENTIFIER)
-                .0
-                .ok_or(XerEncodeErrorKind::MissingIdentifier)?,
-        ));
+        let xml_tag = match self.entering_list_item_type {
+            true => Cow::Borrowed(identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?),
+            false => self.field_tag_stack.pop().unwrap_or(Cow::Borrowed(
+                identifier.0.ok_or(XerEncodeErrorKind::MissingIdentifier)?,
+            )),
+        };
         if self.entering_list_item_type {
             self.set_entering_list_item_type(false);
             encode_fn(self)?;


### PR DESCRIPTION
# Fix `field_tag_stack` of the XER encoder

While integrating the rasn compiler into our project, I came across issues with the XER encoding of some values in special cases.
I found two special cases in which  the `field_tag_stack` of the XER encoder is not behaving as expected.

## CHOICE

When a `CHOICE` is encoded, it didn't remove the current tag from the `field_tag_stack` and thus all elements after the choice were offset by `-1` tag.

### Changes

I have removed the `match` from the `encode_explicit_prefix` function, because the xml_tag was one of the matching arguments, but we shall only pop an element of the `field_tag_stack` in the both Arms which match on `Tag::EOC`.

### Tests

I've added a test `sequence_with_element_after_choice` which shows the behavior. Here is the encoded xml before the changes:

```xml
<SequenceWithChoice>
  <recursion>
    <Leaf />
  </recursion>
  <recursion>
    <wine>
      <true />
    </wine>
    <grappa>00010203</grappa>
    <inner>
      <hidden>
        <false />
      </hidden>
    </inner>
    <oid>1.8270.4.1</oid>
  </recursion>
</SequenceWithChoice>
```

The expected xml would look like this:

```xml
<SequenceWithChoice>
  <recursion>
    <Leaf />
  </recursion>
  <nested>
    <wine>
      <true />
    </wine>
    <grappa>00010203</grappa>
    <inner>
      <hidden>
        <false />
      </hidden>
    </inner>
    <oid>1.8270.4.1</oid>
  </nested>
</SequenceWithChoice>
```

Where the `nested` element of the xml has been named `recursion` instead of `nested`.

## SET OF / SEQUENCE OF

When encoding a `SET OF` or `SEQUENCE OF` each element in the `SET OF / SEQUENCE OF` popped an element from the `field_tag_stack`, which lead to all elements after set `SET OF / SEQUENCE OF` been offset by `+X` tags (with X the number of elements in the `SET OF / SEQUENCE OF`).

### Changes

The `entering_list_item_type` is already set, when we are entering a `SET OF` or `SEQUENCE OF`, so I've made sure to not call `field_tag_stack.pop()` when this flag is set.

### Tests

I've also added two tests `sequence_with_element_after_sequence_of` and `sequence_with_element_after_set_of` which show the behavior. Here is the encoded xml before the changes for `sequence_with_element_after_sequence_of`:

```xml
<SequenceWithSequenceOf>
  <ids>
    <flag>42</flag>
    <int>13</int>
  </ids>
  <enum_val>
    <false />
  </enum_val>
  <int>12</int>
  <enum_val>
    <eins />
  </enum_val>
</SequenceWithSequenceOf>
```

The expected xml would look like this:

```xml
<SequenceWithSetOf>
  <ids>
    <INTEGER>42</INTEGER>
    <INTEGER>13</INTEGER>
  </ids>
  <flag>
    <false />
  </flag>
  <int>12</int>
  <enum_val>
    <eins />
  </enum_val>
</SequenceWithSetOf>
```

Here the elements in the SEQUENCE OF (`ids`) have been named by the tags following in the parent SEQUENCE (`SequenceWithSequenceOf`) after the SEQUENCE OF (so: `flag` and `int`).
Also the names of the elements afterwards are offset, so `flag` is named `enum_val`. The following elements are named correctly again, as the `tag_field_stack` is then completly empty and the identifier passed to the encode function is used as a fallback XML tag.
