### PR TITLE
implement std::ops::Not for ldap Filters

### DIFF
--- a/standards/ldap/src/lib.rs
+++ b/standards/ldap/src/lib.rs
@@ -78,7 +78,10 @@ impl rasn::Decode for LdapString {
     ) -> core::result::Result<Self, D::Error> {
         String::from_utf8(decoder.decode_octet_string(tag, constraints)?)
             .map_err(|error| {
-                rasn::de::Error::custom(alloc::format!("LdapString not valid UTF-8: {error}"), decoder.codec())
+                rasn::de::Error::custom(
+                    alloc::format!("LdapString not valid UTF-8: {error}"),
+                    decoder.codec(),
+                )
             })
             .map(Self::from)
     }
@@ -225,7 +228,11 @@ pub struct LdapResult {
 
 impl LdapResult {
     /// LdapResult constructor
-    pub fn new(result_code: ResultCode, matched_dn: LdapDn, diagnostic_message: LdapString) -> Self {
+    pub fn new(
+        result_code: ResultCode,
+        matched_dn: LdapDn,
+        diagnostic_message: LdapString,
+    ) -> Self {
         Self {
             result_code,
             matched_dn,
@@ -291,7 +298,11 @@ pub struct Control {
 
 impl Control {
     /// Control constructor
-    pub fn new(control_type: LdapOid, criticality: bool, control_value: Option<OctetString>) -> Self {
+    pub fn new(
+        control_type: LdapOid,
+        criticality: bool,
+        control_value: Option<OctetString>,
+    ) -> Self {
         Self {
             control_type,
             criticality,
@@ -364,7 +375,10 @@ pub struct SaslCredentials {
 impl SaslCredentials {
     /// SaslCredentials constructor
     pub fn new(mechanism: LdapString, credentials: Option<OctetString>) -> Self {
-        Self { mechanism, credentials }
+        Self {
+            mechanism,
+            credentials,
+        }
     }
 }
 


### PR DESCRIPTION
This allows a "Filter::not(other_filter)" or !other_filter syntax. Maybe worth considering