### PR TITLE
fix: use full paths for field encode/decode, remove nightly CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: [stable, beta, nightly]
+        channel: [stable, beta]
         target:
           # MSVC
           - i686-pc-windows-msvc
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: [stable, beta, nightly]
+        channel: [stable, beta]
         target:
           # macOS
           - x86_64-apple-darwin
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: [stable, beta, nightly]
+        channel: [stable, beta]
         target:
           # WASM, off by default as most rust projects aren't compatible yet.
           # - wasm32-unknown-emscripten

--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -986,7 +986,9 @@ impl<'a> FieldConfig<'a> {
                 (false, true) => {
                     quote!(encoder.encode_default(&#this #field, #default_fn #identifier)?;)
                 }
-                (false, false) => quote!(#this #field.encode(encoder)?;),
+                (false, false) => {
+                    quote!(< #ty as #crate_root::Encode>::encode(&#this #field, encoder)?;)
+                }
             }
         };
 
@@ -1134,7 +1136,7 @@ impl<'a> FieldConfig<'a> {
                     )
                 }
                 (None, None, false) => {
-                    quote!(<_>::decode(decoder) #or_else)
+                    quote!(< #ty as #crate_root::Decode>::decode(decoder) #or_else)
                 }
             }
         };

--- a/macros/macros_impl/src/decode.rs
+++ b/macros/macros_impl/src/decode.rs
@@ -281,7 +281,7 @@ pub fn derive_struct_impl(
 
     Ok(quote! {
         impl #impl_generics #crate_root::Decode for #name #ty_generics #where_clause {
-            fn decode_with_tag_and_constraints<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints) -> core::result::Result<Self, D::Error> {
+            fn decode_with_tag_and_constraints<_DECODER: #crate_root::Decoder>(decoder: &mut _DECODER, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints) -> core::result::Result<Self, _DECODER::Error> {
                 #decode_impl
             }
         }

--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -108,7 +108,7 @@ pub fn derive_struct_impl(
     Ok(quote! {
         #[allow(clippy::mutable_key_type)]
         impl #impl_generics  #crate_root::Encode for #name #ty_generics #where_clause {
-            fn encode_with_tag_and_constraints<'encoder, EN: #crate_root::Encoder<'encoder>>(&self, encoder: &mut EN, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints, identifier: #crate_root::types::Identifier) -> core::result::Result<(), EN::Error> {
+            fn encode_with_tag_and_constraints<'encoder, _ENCODER: #crate_root::Encoder<'encoder>>(&self, encoder: &mut _ENCODER, tag: #crate_root::types::Tag, constraints: #crate_root::types::Constraints, identifier: #crate_root::types::Identifier) -> core::result::Result<(), _ENCODER::Error> {
                 #(#vars)*
 
                 #encode_impl


### PR DESCRIPTION
Fixes #486

Removes nightly CI.

Also changes some generic names for something rarer to avoid conflicts. 