### PR TITLE
Fix BER encoding of tagged CHOICE

### DIFF
--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -49,10 +49,11 @@ pub fn derive_struct_impl(
     let encode_impl = if config.delegate {
         let ty = &container.fields.iter().next().unwrap().ty;
 
-        if let Some(tag) = config.tag.as_ref().filter(|tag| tag.is_explicit()) {
-            let tag = tag.to_tokens(crate_root);
+        if config.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
             // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-            quote!(encoder.encode_explicit_prefix(#tag, &self.0, identifier.or(Self::IDENTIFIER)).map(drop))
+            quote!(encoder
+                .encode_explicit_prefix(tag, &self.0, identifier.or(Self::IDENTIFIER))
+                .map(drop))
         } else {
             // NOTE: AsnType trait already implements correct delegate constraints, and those are passed here
             // We don't need to do double intersection here!

--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -272,11 +272,18 @@ impl Enum<'_> {
                 quote!(#inner_name::#ident #fields => #name::#ident #fields)
             });
 
+            let automatic_tags_attr = if self.config.automatic_tags {
+                quote!(#[rasn(automatic_tags)])
+            } else {
+                quote!()
+            };
+
             quote! {
                 fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> core::result::Result<Self, D::Error> {
 
                     #[derive(#crate_root::AsnType, #crate_root::Decode)]
                     #[rasn(choice)]
+                    #automatic_tags_attr
                     #inner_type
 
                     let value = decoder.decode_explicit_prefix::<#inner_name>(<Self as #crate_root::AsnType>::TAG)?;
@@ -549,11 +556,17 @@ impl Enum<'_> {
 
                 quote!(Self::#ident { #(#def_fields),* } => #inner_name::#ident { #(#init_fields),* })
             });
+            let automatic_tags_attr = if self.config.automatic_tags {
+                quote!(#[rasn(automatic_tags)])
+            } else {
+                quote!()
+            };
 
             let name = &self.name;
             quote! {
                 #[derive(#crate_root::AsnType, #crate_root::Encode)]
                 #[rasn(choice)]
+                #automatic_tags_attr
                 #inner_enum
 
                 let value = match &self {

--- a/tests/prefixed_type.rs
+++ b/tests/prefixed_type.rs
@@ -60,3 +60,61 @@ fn test_ber_encoding_of_tagged_type_round_trip() {
     assert_eq!(type4, rasn::ber::decode::<Type4>(&type4_ber).unwrap());
     assert_eq!(type5, rasn::ber::decode::<Type5>(&type5_ber).unwrap());
 }
+
+#[test]
+fn test_issue_519_automatic_tagging_for_tagged_choice_round_trip() {
+    // https://github.com/librasn/rasn/issues/519
+
+    /*
+        With following ASN.1 definitions, BER encoding of TC1 and TC2 should be identical,
+        and alternatives in a choice (`a` and `b`) are automatically tagged.
+
+        TestModuleA DEFINITIONS AUTOMATIC TAGS::= BEGIN
+            --untagged choice
+            C1 ::= CHOICE { a INTEGER, b BOOLEAN }
+
+            --tagged choice. This is explicit tagging. (see ITU-T X.680 section 31.2.7 clause c)
+            TC1  ::= [4] C1
+            --another form of tagged choice
+            TC2  ::= [4] CHOICE { a INTEGER, b BOOLEAN }
+        END
+    */
+
+    use rasn::prelude::*;
+
+    #[doc = "untagged choice"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum C1 {
+        A(Integer),
+        B(bool),
+    }
+    #[doc = "tagged choice. This is explicit tagging. (see ITU-T X.680 section 31.2.7 clause c)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(explicit(context, 4)))]
+    pub struct TC1(pub C1);
+    #[doc = "another form of tagged choice"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, tag(explicit(context, 4)), automatic_tags)]
+    pub enum TC2 {
+        A(Integer),
+        B(bool),
+    }
+
+    let choice = C1::A(0x55.into());
+    let tc1 = TC1(choice.clone());
+    let tc2 = TC2::A(0x55.into());
+
+    let choice_enc = rasn::ber::encode(&choice).unwrap();
+    let tc1_enc = rasn::ber::encode(&tc1).unwrap();
+    let tc2_enc = rasn::ber::encode(&tc2).unwrap();
+
+    assert_eq!(choice_enc, vec![0x80, 0x01, 0x55]);
+    assert_eq!(tc1_enc, vec![0xa4, 0x03, 0x80, 0x01, 0x55]);
+    assert_eq!(tc2_enc, tc1_enc); // should be identical to tc1_enc
+
+    let tc1_de = rasn::ber::decode::<TC1>(&tc1_enc).unwrap();
+    let tc2_de = rasn::ber::decode::<TC2>(&tc2_enc).unwrap();
+    assert_eq!(tc1, tc1_de);
+    assert_eq!(tc2, tc2_de);
+}

--- a/tests/prefixed_type.rs
+++ b/tests/prefixed_type.rs
@@ -1,0 +1,62 @@
+#[test]
+fn test_ber_encoding_of_tagged_type_round_trip() {
+    //  -- BER encoding example from ITU-T X.690 clause 8.14:
+    //
+    //  With ASN.1 type definitions (in an explicit tagging environment) of:
+    //  TestModule DEFINITIONS EXPLICIT TAGS::= BEGIN
+    //      Type1 ::= VisibleString
+    //      Type2 ::= [APPLICATION 3] IMPLICIT Type1
+    //      Type3 ::= [2] Type2
+    //      Type4 ::= [APPLICATION 7] IMPLICIT Type3
+    //      Type5 ::= [2] IMPLICIT Type2
+    //  END
+    //  a value of "Jones" is encoded as follows ...
+
+    use rasn::prelude::*;
+
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct Type1(pub VisibleString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(application, 3))]
+    pub struct Type2(pub Type1);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(explicit(context, 2)))]
+    pub struct Type3(pub Type2);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(application, 7))]
+    pub struct Type4(pub Type3);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(context, 2))]
+    pub struct Type5(pub Type2);
+
+    let type1 = Type1(VisibleString::from_iso646_bytes(b"Jones").unwrap());
+    let type2 = Type2(type1.clone());
+    let type3 = Type3(type2.clone());
+    let type4 = Type4(type3.clone());
+    let type5 = Type5(type2.clone());
+
+    let type1_ber = rasn::ber::encode(&type1).unwrap();
+    let type2_ber = rasn::ber::encode(&type2).unwrap();
+    let type3_ber = rasn::ber::encode(&type3).unwrap();
+    let type4_ber = rasn::ber::encode(&type4).unwrap();
+    let type5_ber = rasn::ber::encode(&type5).unwrap();
+
+    assert_eq!(type1_ber, vec![0x1A, 0x05, 0x4A, 0x6F, 0x6E, 0x65, 0x73_u8]);
+    assert_eq!(type2_ber, vec![0x43, 0x05, 0x4A, 0x6F, 0x6E, 0x65, 0x73_u8]);
+    assert_eq!(
+        type3_ber,
+        vec![0xa2, 0x07, 0x43, 0x05, 0x4A, 0x6F, 0x6E, 0x65, 0x73_u8]
+    );
+    assert_eq!(
+        type4_ber,
+        vec![0x67, 0x07, 0x43, 0x05, 0x4A, 0x6F, 0x6E, 0x65, 0x73_u8]
+    );
+    assert_eq!(type5_ber, vec![0x82, 0x05, 0x4A, 0x6F, 0x6E, 0x65, 0x73_u8]);
+
+    assert_eq!(type1, rasn::ber::decode::<Type1>(&type1_ber).unwrap());
+    assert_eq!(type2, rasn::ber::decode::<Type2>(&type2_ber).unwrap());
+    assert_eq!(type3, rasn::ber::decode::<Type3>(&type3_ber).unwrap());
+    assert_eq!(type4, rasn::ber::decode::<Type4>(&type4_ber).unwrap());
+    assert_eq!(type5, rasn::ber::decode::<Type5>(&type5_ber).unwrap());
+}


### PR DESCRIPTION
This PR fixes #518, #519, and #520.

Fixes for #518 and #519 are trivial.

As for #520, this PR fixes so that `encode()` method of `rasn::Encode` trait is only derived for untagged CHOICE type.
For tagged CHOICE type,  `encode_with_tag_and_constraint()` is derived instead of  `encode()` so that it will handle implicity tagging in the same way where `#[rasn(delegate)]` on `struct Foo(enum)` does.

Decoding is also fixed in the same way.