### PR TITLE
Add feature: Implement Default trait for FixedOctetString

### DIFF
--- a/src/types/strings/octet.rs
+++ b/src/types/strings/octet.rs
@@ -118,6 +118,12 @@ impl PartialEq<Vec<u8>> for OctetString {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FixedOctetString<const N: usize>([u8; N]);
 
+impl<const N: usize> Default for FixedOctetString<N> {
+    fn default() -> Self {
+        Self([0u8; N])
+    }
+}
+
 impl<const N: usize> FixedOctetString<N> {
     /// Creates a new octet string from a given array.
     #[must_use]


### PR DESCRIPTION
Hi,

While using the library I discovered that _**FixedOctetString**_ does not implement **Default** trait. Thus, I decided to add a small change to implement **Default** trait for _**FixedOctetString**_ that makes the life a lot of easier since all other **ASN types** have **Default** trait.

//Ervins