### PR TITLE
Fix UPER encoding and parsing of extensible CHOICE

### DIFF
--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -102,10 +102,10 @@ impl Enum<'_> {
         // Check count of the root components in the choice
         // https://github.com/XAMPPRocky/rasn/issues/168
         // Choice index starts from zero, so we need to reduce variance by one
-        let variant_count = if self.variants.is_empty() {
+        let variant_count = if base_variants.is_empty() {
             0
         } else {
-            self.variants.len() - 1
+            base_variants.len() - 1
         };
 
         let variance_constraint = Constraints {

--- a/src/uper.rs
+++ b/src/uper.rs
@@ -271,6 +271,50 @@ mod tests {
         round_trip!(uper, Choice, Choice::Normal, &[0]);
         round_trip!(uper, Choice, Choice::Medium, &[0x80, 1, 0]);
         round_trip!(aper, Choice, Choice::Medium, &[0x80, 1, 0]);
+
+        #[derive(AsnType, Decode, Debug, Encode, PartialEq)]
+        #[rasn(choice, automatic_tags)]
+        #[non_exhaustive]
+        enum ChoiceWithData {
+            Normal(u8),
+            High(u8),
+        }
+
+        round_trip!(
+            uper,
+            ChoiceWithData,
+            ChoiceWithData::Normal(0xaf),
+            &[0b0010_1011, 0b1100_0000]
+        );
+        round_trip!(
+            uper,
+            ChoiceWithData,
+            ChoiceWithData::High(0xaf),
+            &[0b0110_1011, 0b1100_0000]
+        );
+
+        #[derive(AsnType, Decode, Debug, Encode, PartialEq)]
+        #[rasn(choice, automatic_tags)]
+        #[non_exhaustive]
+        enum ExtendedChoiceWithData {
+            Normal(u8),
+            High(u8),
+            #[rasn(extension_addition)]
+            Medium(u8),
+        }
+
+        round_trip!(
+            uper,
+            ExtendedChoiceWithData,
+            ExtendedChoiceWithData::Normal(0xaf),
+            &[0b0010_1011, 0b1100_0000]
+        );
+        round_trip!(
+            uper,
+            ExtendedChoiceWithData,
+            ExtendedChoiceWithData::Medium(0x42),
+            &[0x80, 1, 0x42]
+        );
     }
 
     #[test]


### PR DESCRIPTION
A CHOICE with extensions shall use the number or root variants for the constraints when encoding the index integer. This was already in a comment, but the code below it used the number of all variants instead of the `base_variants` which were already created earlier.

This PR also adds some more test cases for this condition. The existing tests couldn't differentiate the variant index from the padding, so I added some data to each variant.

Fixes #528 