### PR TITLE
feat(avn): implement ASN.1 Value Notation codec

### DIFF
--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -51,9 +51,11 @@ pub fn derive_struct_impl(
 
         if config.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
             // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-            quote!(encoder
-                .encode_explicit_prefix(tag, &self.0, identifier.or(Self::IDENTIFIER))
-                .map(drop))
+            quote!(
+                encoder
+                    .encode_explicit_prefix(tag, &self.0, identifier.or(Self::IDENTIFIER))
+                    .map(drop)
+            )
         } else {
             // NOTE: AsnType trait already implements correct delegate constraints, and those are passed here
             // We don't need to do double intersection here!

--- a/src/avn.rs
+++ b/src/avn.rs
@@ -1,0 +1,257 @@
+//! ASN.1 Value Notation (AVN) encoding.
+
+pub mod de;
+pub mod enc;
+pub mod value;
+
+/// Attempts to encode `value` to AVN text format.
+///
+/// # Errors
+/// Returns an error specific to the AVN encoder if encoding is not possible.
+pub fn encode<T: crate::Encode>(
+    value: &T,
+) -> Result<alloc::string::String, crate::error::EncodeError> {
+    let mut encoder = enc::Encoder::new();
+    value.encode(&mut encoder)?;
+    Ok(encoder.to_string())
+}
+
+/// Attempts to decode `input` (AVN text) to type `T`.
+///
+/// # Errors
+/// Returns an error specific to the AVN decoder if decoding is not possible.
+pub fn decode<T: crate::Decode>(input: &str) -> Result<T, crate::error::DecodeError> {
+    T::decode(&mut de::Decoder::new(input)?)
+}
+
+#[cfg(test)]
+mod tests {
+    /// Encode `$value` as `$typ`, assert the output equals `$expected`, then decode
+    /// back and assert round-trip equality.
+    macro_rules! round_trip_avn {
+        ($typ:ty, $value:expr, $expected:expr) => {{
+            let value: $typ = $value;
+            let actual = crate::avn::encode(&value).unwrap();
+            pretty_assertions::assert_eq!($expected, actual.as_str());
+            let decoded: $typ = crate::avn::decode(&actual).unwrap();
+            pretty_assertions::assert_eq!(value, decoded);
+        }};
+    }
+
+    use crate::prelude::*;
+
+    // -----------------------------------------------------------------------
+    // Test types (shared with JER tests, adapted for AVN)
+    // -----------------------------------------------------------------------
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    #[non_exhaustive]
+    struct TestTypeA {
+        #[rasn(value("0..3", extensible))]
+        juice: Integer,
+        wine: Inner,
+        #[rasn(extension_addition)]
+        grappa: BitString,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(choice, automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    enum Inner {
+        #[rasn(value("0..3"))]
+        Wine(u8),
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, Clone, Copy, PartialEq)]
+    #[rasn(automatic_tags, enumerated)]
+    #[rasn(crate_root = "crate")]
+    enum SimpleEnum {
+        Test1 = 5,
+        Test2 = 2,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq, Ord, Eq, PartialOrd, Hash)]
+    #[rasn(automatic_tags, choice)]
+    #[rasn(crate_root = "crate")]
+    enum SimpleChoice {
+        Test1(u8),
+        #[rasn(size("0..3"))]
+        Test2(Utf8String),
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    #[non_exhaustive]
+    struct Very {
+        #[rasn(extension_addition)]
+        a: Option<Nested>,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct Nested {
+        very: Option<Struct>,
+        nested: Option<bool>,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct Struct {
+        strct: Option<u8>,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+    #[rasn(automatic_tags)]
+    #[rasn(crate_root = "crate")]
+    struct Renamed {
+        #[rasn(identifier = "so-very")]
+        very: Integer,
+        #[rasn(identifier = "re_named")]
+        renamed: Option<bool>,
+    }
+
+    #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
+    #[rasn(automatic_tags, choice)]
+    #[rasn(crate_root = "crate")]
+    enum Renumed {
+        #[rasn(identifier = "test-1")]
+        #[rasn(size("0..3"))]
+        Test1(Utf8String),
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bool_values() {
+        round_trip_avn!(bool, true, "TRUE");
+        round_trip_avn!(bool, false, "FALSE");
+    }
+
+    #[test]
+    fn integer_values() {
+        round_trip_avn!(u8, 42_u8, "42");
+        round_trip_avn!(u8, 1_u8, "1");
+        round_trip_avn!(i8, -1_i8, "-1");
+        round_trip_avn!(u16, 0_u16, "0");
+        round_trip_avn!(Integer, 1.into(), "1");
+        round_trip_avn!(Integer, (-1_235_352).into(), "-1235352");
+    }
+
+    #[test]
+    fn null_value() {
+        round_trip_avn!((), (), "NULL");
+    }
+
+    #[test]
+    fn octet_string_value() {
+        round_trip_avn!(
+            OctetString,
+            OctetString::from_static(&[0x01, 0xFF]),
+            "'01FF'H"
+        );
+        round_trip_avn!(OctetString, OctetString::from_static(&[]), "''H");
+    }
+
+    #[test]
+    fn bit_string_value() {
+        // Non-byte-aligned: 2 bits [1, 0] -> '10'B
+        round_trip_avn!(
+            BitString,
+            [true, false].into_iter().collect::<BitString>(),
+            "'10'B"
+        );
+        // Byte-aligned: 8 bits -> hex
+        round_trip_avn!(
+            BitString,
+            [true, false, true, false, false, false, false, false]
+                .into_iter()
+                .collect::<BitString>(),
+            "'A0'H"
+        );
+        // Empty
+        round_trip_avn!(BitString, BitString::default(), "''H");
+    }
+
+    #[test]
+    fn object_identifier_value() {
+        round_trip_avn!(
+            ObjectIdentifier,
+            ObjectIdentifier::from(Oid::JOINT_ISO_ITU_T_DS_NAME_FORM),
+            "{ 2 5 15 }"
+        );
+    }
+
+    #[test]
+    fn enumerated_value() {
+        round_trip_avn!(SimpleEnum, SimpleEnum::Test1, "Test1");
+        round_trip_avn!(SimpleEnum, SimpleEnum::Test2, "Test2");
+    }
+
+    #[test]
+    fn choice_value() {
+        round_trip_avn!(SimpleChoice, SimpleChoice::Test1(3), "Test1 : 3");
+        round_trip_avn!(
+            SimpleChoice,
+            SimpleChoice::Test2("foo".into()),
+            "Test2 : \"foo\""
+        );
+    }
+
+    #[test]
+    fn sequence_of_values() {
+        round_trip_avn!(
+            SequenceOf<u8>,
+            alloc::vec![1, 2, 3],
+            "{\n  1,\n  2,\n  3\n}"
+        );
+        round_trip_avn!(SequenceOf<bool>, alloc::vec![], "{}");
+    }
+
+    #[test]
+    fn sequence_with_optional() {
+        // Absent optional field is omitted
+        round_trip_avn!(
+            Very,
+            Very {
+                a: Some(Nested {
+                    very: Some(Struct { strct: None }),
+                    nested: Some(false)
+                })
+            },
+            "{\n  a {\n    very {},\n    nested FALSE\n  }\n}"
+        );
+    }
+
+    #[test]
+    fn sequence_value() {
+        round_trip_avn!(
+            TestTypeA,
+            TestTypeA {
+                juice: 0.into(),
+                wine: Inner::Wine(4),
+                grappa: [true, false].into_iter().collect::<BitString>()
+            },
+            "{\n  juice 0,\n  wine Wine : 4,\n  grappa '10'B\n}"
+        );
+    }
+
+    #[test]
+    fn with_identifier_annotation() {
+        round_trip_avn!(
+            Renamed,
+            Renamed {
+                very: 1.into(),
+                renamed: Some(true),
+            },
+            "{\n  so-very 1,\n  re_named TRUE\n}"
+        );
+        round_trip_avn!(Renumed, Renumed::Test1("hel".into()), "test-1 : \"hel\"");
+    }
+}

--- a/src/avn/de.rs
+++ b/src/avn/de.rs
@@ -1,0 +1,1166 @@
+//! Decoding ASN.1 Value Notation (AVN) text into Rust structures.
+//!
+//! Uses a two-phase approach:
+//! 1. **Lex + parse** the entire input string into an [`AvnValue`] tree.
+//! 2. **Type-directed decode** pops values from a stack and dispatches.
+
+use alloc::collections::BTreeMap;
+use core::str::FromStr;
+use num_bigint::BigInt;
+
+use crate::{
+    Decode,
+    de::Error,
+    error::{AvnDecodeErrorKind, DecodeError},
+    types::{
+        Any, BitString, BmpString, Constraints, Constructed, Date, DecodeChoice, Enumerated,
+        GeneralString, GeneralizedTime, GraphicString, Ia5String, NumericString, ObjectIdentifier,
+        Oid, PrintableString, SetOf, Tag, TeletexString, UtcTime, Utf8String, VisibleString,
+        variants,
+    },
+};
+
+use super::value::AvnValue;
+
+// ---------------------------------------------------------------------------
+// Lexer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum Token {
+    LBrace,
+    RBrace,
+    Colon,
+    Comma,
+    Identifier(alloc::string::String),
+    Number(alloc::string::String),
+    /// Content of `'...'H` (between the quotes, before the `H`)
+    HexString(alloc::string::String),
+    /// Content of `'...'B` (between the quotes, before the `B`)
+    BinString(alloc::string::String),
+    /// Already-unescaped content of `"..."` string
+    QuotedString(alloc::string::String),
+    True,
+    False,
+    Null,
+}
+
+fn lex(input: &str) -> Result<alloc::vec::Vec<Token>, DecodeError> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    let mut tokens = alloc::vec::Vec::new();
+
+    while i < len {
+        match bytes[i] {
+            // skip whitespace
+            b' ' | b'\t' | b'\n' | b'\r' => i += 1,
+
+            b'{' => {
+                tokens.push(Token::LBrace);
+                i += 1;
+            }
+            b'}' => {
+                tokens.push(Token::RBrace);
+                i += 1;
+            }
+            b':' => {
+                tokens.push(Token::Colon);
+                i += 1;
+            }
+            b',' => {
+                tokens.push(Token::Comma);
+                i += 1;
+            }
+
+            // Quoted string "..." with "" → " escaping
+            b'"' => {
+                i += 1; // skip opening "
+                let mut s = alloc::string::String::new();
+                loop {
+                    if i >= len {
+                        return Err(DecodeError::from(AvnDecodeErrorKind::UnterminatedString));
+                    }
+                    if bytes[i] == b'"' {
+                        i += 1;
+                        if i < len && bytes[i] == b'"' {
+                            s.push('"');
+                            i += 1;
+                        } else {
+                            break; // end of string
+                        }
+                    } else {
+                        // For simplicity, treat each byte as a char (ASCII-safe for AVN identifiers)
+                        s.push(bytes[i] as char);
+                        i += 1;
+                    }
+                }
+                tokens.push(Token::QuotedString(s));
+            }
+
+            // Hex or binary string: '...'H or '...'B
+            b'\'' => {
+                i += 1; // skip opening '
+                let start = i;
+                while i < len && bytes[i] != b'\'' {
+                    i += 1;
+                }
+                if i >= len {
+                    return Err(DecodeError::from(AvnDecodeErrorKind::UnterminatedString));
+                }
+                // Collect content (strip internal whitespace allowed in AVN hex strings)
+                let raw = &input[start..i];
+                let content: alloc::string::String =
+                    raw.chars().filter(|c| !c.is_whitespace()).collect();
+                i += 1; // skip closing '
+                // Check for H or B suffix
+                if i < len && bytes[i] == b'H' {
+                    tokens.push(Token::HexString(content));
+                    i += 1;
+                } else if i < len && bytes[i] == b'B' {
+                    tokens.push(Token::BinString(content));
+                    i += 1;
+                } else {
+                    return Err(DecodeError::from(AvnDecodeErrorKind::InvalidHexString));
+                }
+            }
+
+            // Number (possibly negative)
+            b'-' | b'0'..=b'9' => {
+                let start = i;
+                if bytes[i] == b'-' {
+                    i += 1;
+                }
+                while i < len && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i < len && bytes[i] == b'.' {
+                    i += 1;
+                    while i < len && bytes[i].is_ascii_digit() {
+                        i += 1;
+                    }
+                }
+                let s =
+                    alloc::string::String::from_utf8(bytes[start..i].to_vec()).unwrap_or_default();
+                tokens.push(Token::Number(s));
+            }
+
+            // Identifier or keyword: [a-zA-Z][a-zA-Z0-9-_]*
+            b if b.is_ascii_alphabetic() => {
+                let start = i;
+                while i < len
+                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-' || bytes[i] == b'_')
+                {
+                    i += 1;
+                }
+                let s =
+                    alloc::string::String::from_utf8(bytes[start..i].to_vec()).unwrap_or_default();
+                match s.as_str() {
+                    "TRUE" => tokens.push(Token::True),
+                    "FALSE" => tokens.push(Token::False),
+                    "NULL" => tokens.push(Token::Null),
+                    _ => tokens.push(Token::Identifier(s)),
+                }
+            }
+
+            b => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                    found: alloc::format!("byte 0x{b:02X} at position {i}"),
+                }));
+            }
+        }
+    }
+    Ok(tokens)
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+struct Parser {
+    tokens: alloc::vec::Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(tokens: alloc::vec::Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn consume(&mut self) -> Option<Token> {
+        if self.pos < self.tokens.len() {
+            let t = self.tokens[self.pos].clone();
+            self.pos += 1;
+            Some(t)
+        } else {
+            None
+        }
+    }
+
+    fn parse_value(&mut self, depth: usize) -> Result<AvnValue, DecodeError> {
+        if depth > 64 {
+            return Err(DecodeError::from_kind(
+                crate::error::DecodeErrorKind::ExceedsMaxParseDepth,
+                crate::Codec::Avn,
+            ));
+        }
+        match self.peek() {
+            None => Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
+
+            Some(Token::True) => {
+                self.consume();
+                Ok(AvnValue::Boolean(true))
+            }
+            Some(Token::False) => {
+                self.consume();
+                Ok(AvnValue::Boolean(false))
+            }
+            Some(Token::Null) => {
+                self.consume();
+                Ok(AvnValue::Null)
+            }
+
+            Some(Token::Number(_)) => {
+                if let Some(Token::Number(s)) = self.consume() {
+                    if s.contains('.') {
+                        Ok(AvnValue::Real(s))
+                    } else {
+                        Ok(AvnValue::Integer(s))
+                    }
+                } else {
+                    unreachable!()
+                }
+            }
+
+            Some(Token::HexString(_)) => {
+                if let Some(Token::HexString(hex)) = self.consume() {
+                    parse_hex_bytes(&hex)
+                        .map(AvnValue::OctetString)
+                        .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::InvalidHexString))
+                } else {
+                    unreachable!()
+                }
+            }
+
+            Some(Token::BinString(_)) => {
+                if let Some(Token::BinString(bin)) = self.consume() {
+                    parse_bin_bits(&bin)
+                        .map(|(bytes, bit_length)| AvnValue::BitString { bytes, bit_length })
+                        .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::InvalidBinString))
+                } else {
+                    unreachable!()
+                }
+            }
+
+            Some(Token::QuotedString(_)) => {
+                if let Some(Token::QuotedString(s)) = self.consume() {
+                    Ok(AvnValue::CharString(s))
+                } else {
+                    unreachable!()
+                }
+            }
+
+            Some(Token::LBrace) => {
+                self.consume(); // consume '{'
+                self.parse_brace_contents(depth + 1)
+            }
+
+            Some(Token::Identifier(_)) => {
+                if let Some(Token::Identifier(id)) = self.consume() {
+                    // Special real keywords encoded as identifiers by the encoder
+                    match id.as_str() {
+                        "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => {
+                            return Ok(AvnValue::Real(id));
+                        }
+                        _ => {}
+                    }
+                    // Check for CHOICE: identifier : value
+                    if matches!(self.peek(), Some(Token::Colon)) {
+                        self.consume(); // consume ':'
+                        let inner = self.parse_value(depth + 1)?;
+                        Ok(AvnValue::Choice {
+                            identifier: id,
+                            value: alloc::boxed::Box::new(inner),
+                        })
+                    } else {
+                        Ok(AvnValue::Enumerated(id))
+                    }
+                } else {
+                    unreachable!()
+                }
+            }
+
+            Some(t) => Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                found: alloc::format!("{t:?}"),
+            })),
+        }
+    }
+
+    /// Parse contents after `{` has been consumed.
+    /// Returns `AvnValue::Sequence`, `AvnValue::SequenceOf`, or empty `SequenceOf([])`.
+    fn parse_brace_contents(&mut self, depth: usize) -> Result<AvnValue, DecodeError> {
+        // Empty braces
+        if matches!(self.peek(), Some(Token::RBrace)) {
+            self.consume();
+            return Ok(AvnValue::SequenceOf(alloc::vec![]));
+        }
+
+        enum BraceItem {
+            Named(alloc::string::String, AvnValue),
+            Bare(AvnValue),
+        }
+
+        let mut items: alloc::vec::Vec<BraceItem> = alloc::vec![];
+
+        loop {
+            match self.peek() {
+                None => return Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
+                Some(Token::RBrace) => {
+                    self.consume();
+                    break;
+                }
+                Some(Token::Identifier(_)) => {
+                    let id = if let Some(Token::Identifier(s)) = self.consume() {
+                        s
+                    } else {
+                        unreachable!()
+                    };
+
+                    match self.peek() {
+                        // id : value → CHOICE element (bare)
+                        Some(Token::Colon) => {
+                            self.consume();
+                            let val = self.parse_value(depth)?;
+                            items.push(BraceItem::Bare(AvnValue::Choice {
+                                identifier: id,
+                                value: alloc::boxed::Box::new(val),
+                            }));
+                        }
+                        // id alone (comma or closing brace) → bare enumerated or real keyword
+                        Some(Token::Comma) | Some(Token::RBrace) => match id.as_str() {
+                            "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => {
+                                items.push(BraceItem::Bare(AvnValue::Real(id)));
+                            }
+                            _ => items.push(BraceItem::Bare(AvnValue::Enumerated(id))),
+                        },
+                        // id value → named SEQUENCE field
+                        _ => {
+                            let val = self.parse_value(depth)?;
+                            items.push(BraceItem::Named(id, val));
+                        }
+                    }
+                }
+                _ => {
+                    // Non-identifier: bare SEQUENCE OF element
+                    let val = self.parse_value(depth)?;
+                    items.push(BraceItem::Bare(val));
+                }
+            }
+
+            // Consume separator: comma, or allow space-separated integers (OID notation).
+            match self.peek() {
+                Some(Token::Comma) => {
+                    self.consume();
+                }
+                Some(Token::RBrace) => {}
+                None => return Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
+                // OID-style space-separated arcs: all items so far must be bare integers
+                Some(Token::Number(_))
+                    if items
+                        .iter()
+                        .all(|i| matches!(i, BraceItem::Bare(AvnValue::Integer(_)))) =>
+                {
+                    // No comma needed — continue to parse next arc in next loop iteration
+                }
+                Some(t) => {
+                    return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                        found: alloc::format!("{t:?}"),
+                    }));
+                }
+            }
+        }
+
+        let has_named = items.iter().any(|i| matches!(i, BraceItem::Named(..)));
+        let has_bare = items.iter().any(|i| matches!(i, BraceItem::Bare(..)));
+
+        if has_named && has_bare {
+            return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                found: "mixed named and bare items inside braces".into(),
+            }));
+        }
+
+        if has_named {
+            Ok(AvnValue::Sequence(
+                items
+                    .into_iter()
+                    .map(|item| {
+                        if let BraceItem::Named(name, val) = item {
+                            (name, val)
+                        } else {
+                            unreachable!()
+                        }
+                    })
+                    .collect(),
+            ))
+        } else {
+            Ok(AvnValue::SequenceOf(
+                items
+                    .into_iter()
+                    .map(|item| {
+                        if let BraceItem::Bare(val) = item {
+                            val
+                        } else {
+                            unreachable!()
+                        }
+                    })
+                    .collect(),
+            ))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level string helpers
+// ---------------------------------------------------------------------------
+
+fn parse_hex_bytes(hex: &str) -> Option<alloc::vec::Vec<u8>> {
+    if hex.is_empty() {
+        return Some(alloc::vec![]);
+    }
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+    let b = hex.as_bytes();
+    let mut out = alloc::vec::Vec::with_capacity(hex.len() / 2);
+    for chunk in b.chunks(2) {
+        let hi = nibble(chunk[0])?;
+        let lo = nibble(chunk[1])?;
+        out.push((hi << 4) | lo);
+    }
+    Some(out)
+}
+
+fn nibble(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_bin_bits(bin: &str) -> Option<(alloc::vec::Vec<u8>, usize)> {
+    if bin.is_empty() {
+        return Some((alloc::vec![], 0));
+    }
+    let bit_length = bin.len();
+    let mut bytes: alloc::vec::Vec<u8> = alloc::vec![];
+    let mut current: u8 = 0;
+    for (i, c) in bin.chars().enumerate() {
+        let bit: u8 = match c {
+            '0' => 0,
+            '1' => 1,
+            _ => return None,
+        };
+        current |= bit << (7 - (i % 8));
+        if i % 8 == 7 {
+            bytes.push(current);
+            current = 0;
+        }
+    }
+    if !bit_length.is_multiple_of(8) {
+        bytes.push(current);
+    }
+    Some((bytes, bit_length))
+}
+
+// ---------------------------------------------------------------------------
+// Decoder struct
+// ---------------------------------------------------------------------------
+
+macro_rules! decode_avn_value {
+    ($decoder_fn:expr, $stack:expr) => {
+        $stack
+            .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))
+            .and_then($decoder_fn)
+    };
+}
+
+/// Decodes ASN.1 Value Notation text into Rust structures.
+pub struct Decoder {
+    stack: alloc::vec::Vec<AvnValue>,
+}
+
+impl Decoder {
+    /// Create a new decoder by parsing the entire input string.
+    pub fn new(input: &str) -> Result<Self, DecodeError> {
+        let tokens = lex(input)?;
+        let mut parser = Parser::new(tokens);
+        let root = parser.parse_value(0)?;
+        Ok(Self {
+            stack: alloc::vec![root],
+        })
+    }
+}
+
+impl From<AvnValue> for Decoder {
+    fn from(value: AvnValue) -> Self {
+        Self {
+            stack: alloc::vec![value],
+        }
+    }
+}
+
+impl crate::Decoder for Decoder {
+    type Ok = ();
+    type Error = DecodeError;
+    type AnyDecoder<const R: usize, const E: usize> = Self;
+
+    fn codec(&self) -> crate::Codec {
+        crate::Codec::Avn
+    }
+
+    fn decode_any(&mut self, _tag: Tag) -> Result<Any, Self::Error> {
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
+        Ok(Any::new(alloc::format!("{value}").into_bytes()))
+    }
+
+    fn decode_bool(&mut self, _t: Tag) -> Result<bool, Self::Error> {
+        decode_avn_value!(Self::boolean_from_value, self.stack)
+    }
+
+    fn decode_enumerated<E: Enumerated>(&mut self, _t: Tag) -> Result<E, Self::Error> {
+        decode_avn_value!(Self::enumerated_from_value::<E>, self.stack)
+    }
+
+    fn decode_integer<I: crate::types::IntegerType>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<I, Self::Error> {
+        decode_avn_value!(Self::integer_from_value::<I>, self.stack)
+    }
+
+    fn decode_real<R: crate::types::RealType>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<R, Self::Error> {
+        decode_avn_value!(Self::real_from_value::<R>, self.stack)
+    }
+
+    fn decode_null(&mut self, _t: Tag) -> Result<(), Self::Error> {
+        decode_avn_value!(Self::null_from_value, self.stack)
+    }
+
+    fn decode_object_identifier(&mut self, _t: Tag) -> Result<ObjectIdentifier, Self::Error> {
+        decode_avn_value!(Self::oid_from_value, self.stack)
+    }
+
+    fn decode_bit_string(&mut self, _t: Tag, _c: Constraints) -> Result<BitString, Self::Error> {
+        decode_avn_value!(Self::bit_string_from_value, self.stack)
+    }
+
+    fn decode_octet_string<'buf, T>(
+        &'buf mut self,
+        _: Tag,
+        _c: Constraints,
+    ) -> Result<T, Self::Error>
+    where
+        T: From<alloc::vec::Vec<u8>> + From<&'buf [u8]>,
+    {
+        decode_avn_value!(Self::octet_string_from_value, self.stack).map(T::from)
+    }
+
+    fn decode_utf8_string(&mut self, _t: Tag, _c: Constraints) -> Result<Utf8String, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)
+    }
+
+    fn decode_visible_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<VisibleString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::VISIBLE_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_general_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<GeneralString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::GENERAL_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_graphic_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<GraphicString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::GRAPHIC_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_ia5_string(&mut self, _t: Tag, _c: Constraints) -> Result<Ia5String, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::IA5_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_printable_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<PrintableString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::PRINTABLE_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_numeric_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<NumericString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::NUMERIC_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_teletex_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<TeletexString, Self::Error> {
+        todo!()
+    }
+
+    fn decode_bmp_string(&mut self, _t: Tag, _c: Constraints) -> Result<BmpString, Self::Error> {
+        decode_avn_value!(Self::char_string_from_value, self.stack)?
+            .try_into()
+            .map_err(|e| {
+                DecodeError::string_conversion_failed(
+                    Tag::BMP_STRING,
+                    alloc::format!("{e:?}"),
+                    crate::Codec::Avn,
+                )
+            })
+    }
+
+    fn decode_explicit_prefix<D: Decode>(&mut self, _t: Tag) -> Result<D, Self::Error> {
+        D::decode(self)
+    }
+
+    fn decode_optional_with_explicit_prefix<D: Decode>(
+        &mut self,
+        _: Tag,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_utc_time(&mut self, _t: Tag) -> Result<UtcTime, Self::Error> {
+        decode_avn_value!(Self::utc_time_from_value, self.stack)
+    }
+
+    fn decode_generalized_time(&mut self, _t: Tag) -> Result<GeneralizedTime, Self::Error> {
+        decode_avn_value!(Self::generalized_time_from_value, self.stack)
+    }
+
+    fn decode_date(&mut self, _t: Tag) -> Result<Date, Self::Error> {
+        decode_avn_value!(Self::date_from_value, self.stack)
+    }
+
+    fn decode_sequence<const RC: usize, const EC: usize, D, DF, F>(
+        &mut self,
+        _: Tag,
+        _: Option<DF>,
+        decode_fn: F,
+    ) -> Result<D, Self::Error>
+    where
+        D: Constructed<RC, EC>,
+        DF: FnOnce() -> D,
+        F: FnOnce(&mut Self::AnyDecoder<RC, EC>) -> Result<D, Self::Error>,
+    {
+        let last = self
+            .stack
+            .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
+
+        let mut field_map: BTreeMap<alloc::string::String, AvnValue> = match last {
+            AvnValue::Sequence(fields) => fields.into_iter().collect(),
+            AvnValue::SequenceOf(items) if items.is_empty() => BTreeMap::new(),
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "sequence",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+
+        // Push field values in reverse order so pop() yields them in declaration order.
+        let mut field_names: alloc::vec::Vec<&str> = D::FIELDS.iter().map(|f| f.name).collect();
+        if let Some(extended_fields) = D::EXTENDED_FIELDS {
+            field_names.extend(extended_fields.iter().map(|f| f.name));
+        }
+        field_names.reverse();
+        for name in field_names {
+            self.stack
+                .push(field_map.remove(name).unwrap_or(AvnValue::Absent));
+        }
+        (decode_fn)(self)
+    }
+
+    fn decode_sequence_of<D: Decode>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<alloc::vec::Vec<D>, Self::Error> {
+        decode_avn_value!(|v| self.sequence_of_from_value(v), self.stack)
+    }
+
+    fn decode_set_of<D: Decode + Eq + core::hash::Hash>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<SetOf<D>, Self::Error> {
+        decode_avn_value!(|v| self.set_of_from_value(v), self.stack)
+    }
+
+    fn decode_set<const RC: usize, const EC: usize, FIELDS, SET, D, F>(
+        &mut self,
+        _t: Tag,
+        decode_fn: D,
+        field_fn: F,
+    ) -> Result<SET, Self::Error>
+    where
+        SET: Decode + Constructed<RC, EC>,
+        FIELDS: Decode,
+        D: Fn(&mut Self::AnyDecoder<RC, EC>, usize, Tag) -> Result<FIELDS, Self::Error>,
+        F: FnOnce(alloc::vec::Vec<FIELDS>) -> Result<SET, Self::Error>,
+    {
+        let last = self
+            .stack
+            .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
+
+        let mut field_map: BTreeMap<alloc::string::String, AvnValue> = match last {
+            AvnValue::Sequence(fields) => fields.into_iter().collect(),
+            AvnValue::SequenceOf(items) if items.is_empty() => BTreeMap::new(),
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "set",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+
+        let mut fields_out = alloc::vec![];
+
+        let mut field_indices: alloc::vec::Vec<(usize, _)> =
+            SET::FIELDS.iter().enumerate().collect();
+        field_indices
+            .sort_by(|(_, a), (_, b)| a.tag_tree.smallest_tag().cmp(&b.tag_tree.smallest_tag()));
+        for (index, field) in field_indices {
+            self.stack
+                .push(field_map.remove(field.name).unwrap_or(AvnValue::Absent));
+            fields_out.push((decode_fn)(self, index, field.tag)?);
+        }
+        for (index, field) in SET::EXTENDED_FIELDS
+            .iter()
+            .flat_map(|fields| fields.iter())
+            .enumerate()
+        {
+            self.stack
+                .push(field_map.remove(field.name).unwrap_or(AvnValue::Absent));
+            fields_out.push((decode_fn)(self, index + SET::FIELDS.len(), field.tag)?);
+        }
+        (field_fn)(fields_out)
+    }
+
+    fn decode_choice<D>(&mut self, _c: Constraints) -> Result<D, Self::Error>
+    where
+        D: DecodeChoice,
+    {
+        decode_avn_value!(|v| self.choice_from_value::<D>(v), self.stack)
+    }
+
+    fn decode_optional<D: Decode>(&mut self) -> Result<Option<D>, Self::Error> {
+        let last = self
+            .stack
+            .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
+        match last {
+            AvnValue::Absent => Ok(None),
+            v => {
+                self.stack.push(v);
+                Some(D::decode(self)).transpose()
+            }
+        }
+    }
+
+    fn decode_optional_with_tag<D: Decode>(&mut self, _: Tag) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_optional_with_constraints<D: Decode>(
+        &mut self,
+        _: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_optional_with_tag_and_constraints<D: Decode>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_extension_addition_with_explicit_tag_and_constraints<D: Decode>(
+        &mut self,
+        tag: Tag,
+        constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_extension_addition_with_tag_and_constraints::<D>(tag, constraints)
+    }
+
+    fn decode_extension_addition_with_tag_and_constraints<D: Decode>(
+        &mut self,
+        _: Tag,
+        _: Constraints,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+
+    fn decode_extension_addition_group<
+        const RC: usize,
+        const EC: usize,
+        D: Decode + Constructed<RC, EC>,
+    >(
+        &mut self,
+    ) -> Result<Option<D>, Self::Error> {
+        self.decode_optional()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper methods on Decoder
+// ---------------------------------------------------------------------------
+
+impl Decoder {
+    fn boolean_from_value(value: AvnValue) -> Result<bool, DecodeError> {
+        match value {
+            AvnValue::Boolean(b) => Ok(b),
+            other => Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                needed: "boolean",
+                found: alloc::format!("{other:?}"),
+            })),
+        }
+    }
+
+    fn enumerated_from_value<E: Enumerated>(value: AvnValue) -> Result<E, DecodeError> {
+        let id = match value {
+            AvnValue::Enumerated(id) => id,
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "enumerated identifier",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        E::from_identifier(&id).ok_or_else(|| {
+            DecodeError::from(AvnDecodeErrorKind::AvnInvalidEnumDiscriminant { discriminant: id })
+        })
+    }
+
+    fn integer_from_value<I: crate::types::IntegerType>(value: AvnValue) -> Result<I, DecodeError> {
+        let s = match value {
+            AvnValue::Integer(s) => s,
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "integer",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        let bigint = BigInt::from_str(&s).map_err(|e| {
+            DecodeError::from(AvnDecodeErrorKind::IntegerParseError {
+                msg: alloc::format!("{e}"),
+            })
+        })?;
+        I::try_from(bigint).map_err(|_| DecodeError::integer_overflow(I::WIDTH, crate::Codec::Avn))
+    }
+
+    fn real_from_value<R: crate::types::RealType>(value: AvnValue) -> Result<R, DecodeError> {
+        let s: alloc::string::String = match value {
+            AvnValue::Real(s) => s,
+            AvnValue::Integer(s) => s, // handles "-0" which lexes as Number("-0")
+            AvnValue::Enumerated(s) => s, // handles PLUS-INFINITY etc. if missed as Identifier
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "real",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+
+        let real_err = || {
+            DecodeError::from_kind(
+                crate::error::DecodeErrorKind::InvalidRealEncoding,
+                crate::Codec::Avn,
+            )
+        };
+
+        match s.as_str() {
+            "PLUS-INFINITY" => {
+                return R::try_from_float(f64::INFINITY).ok_or_else(real_err);
+            }
+            "MINUS-INFINITY" => {
+                return R::try_from_float(f64::NEG_INFINITY).ok_or_else(real_err);
+            }
+            "NOT-A-NUMBER" => {
+                return R::try_from_float(f64::NAN).ok_or_else(real_err);
+            }
+            "-0" => {
+                return R::try_from_float(-0.0_f64).ok_or_else(real_err);
+            }
+            _ => {}
+        }
+
+        let f: f64 = s.parse().map_err(|_| real_err())?;
+        R::try_from_float(f).ok_or_else(real_err)
+    }
+
+    fn null_from_value(value: AvnValue) -> Result<(), DecodeError> {
+        match value {
+            AvnValue::Null => Ok(()),
+            other => Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                needed: "null",
+                found: alloc::format!("{other:?}"),
+            })),
+        }
+    }
+
+    fn oid_from_value(value: AvnValue) -> Result<ObjectIdentifier, DecodeError> {
+        // OID is encoded as { arc1 arc2 ... } which parses as SequenceOf([Integer, ...])
+        let arcs: alloc::vec::Vec<u32> = match value {
+            AvnValue::Oid(arcs) => arcs,
+            AvnValue::SequenceOf(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    AvnValue::Integer(s) => s.parse::<u32>().map_err(|_| {
+                        DecodeError::from(AvnDecodeErrorKind::InvalidOid { value: s })
+                    }),
+                    other => Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                        needed: "OID arc (integer)",
+                        found: alloc::format!("{other:?}"),
+                    })),
+                })
+                .collect::<Result<_, _>>()?,
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "OID as { arc... }",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        Oid::new(&arcs).map(ObjectIdentifier::from).ok_or_else(|| {
+            DecodeError::from(AvnDecodeErrorKind::InvalidOid {
+                value: alloc::format!("{arcs:?}"),
+            })
+        })
+    }
+
+    fn bit_string_from_value(value: AvnValue) -> Result<BitString, DecodeError> {
+        let (bytes, bit_length) = match value {
+            AvnValue::BitString { bytes, bit_length } => (bytes, bit_length),
+            // Hex notation '...'H also used for byte-aligned bit strings
+            AvnValue::OctetString(bytes) => {
+                let bl = bytes.len() * 8;
+                (bytes, bl)
+            }
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "bit string ('...'H or '...'B)",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        // Build BitVec from raw bytes and trim to exact bit_length
+        let mut bv = BitString::try_from_vec(bytes).map_err(|e| {
+            DecodeError::custom(
+                alloc::format!("Failed to create BitString: {e:02x?}"),
+                crate::Codec::Avn,
+            )
+        })?;
+        while bv.len() > bit_length {
+            bv.pop();
+        }
+        Ok(bv)
+    }
+
+    fn octet_string_from_value(value: AvnValue) -> Result<alloc::vec::Vec<u8>, DecodeError> {
+        match value {
+            AvnValue::OctetString(bytes) => Ok(bytes),
+            other => Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                needed: "octet string ('...'H)",
+                found: alloc::format!("{other:?}"),
+            })),
+        }
+    }
+
+    fn char_string_from_value(value: AvnValue) -> Result<alloc::string::String, DecodeError> {
+        match value {
+            AvnValue::CharString(s) => Ok(s),
+            AvnValue::OctetString(bytes) => alloc::string::String::from_utf8(bytes).map_err(|e| {
+                DecodeError::custom(
+                    alloc::format!("Invalid UTF-8 in AVN string: {e}"),
+                    crate::Codec::Avn,
+                )
+            }),
+            other => Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                needed: "character string",
+                found: alloc::format!("{other:?}"),
+            })),
+        }
+    }
+
+    fn sequence_of_from_value<D: Decode>(
+        &mut self,
+        value: AvnValue,
+    ) -> Result<alloc::vec::Vec<D>, DecodeError> {
+        let items = match value {
+            AvnValue::SequenceOf(items) => items,
+            AvnValue::Sequence(fields) if fields.is_empty() => alloc::vec![],
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "sequence of",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        items
+            .into_iter()
+            .map(|v| {
+                self.stack.push(v);
+                D::decode(self)
+            })
+            .collect()
+    }
+
+    fn set_of_from_value<D: Decode + Eq + core::hash::Hash>(
+        &mut self,
+        value: AvnValue,
+    ) -> Result<SetOf<D>, DecodeError> {
+        let items = match value {
+            AvnValue::SequenceOf(items) => items,
+            AvnValue::Sequence(fields) if fields.is_empty() => alloc::vec![],
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "set of",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+        items.into_iter().try_fold(SetOf::new(), |mut acc, v| {
+            self.stack.push(v);
+            acc.insert(D::decode(self)?);
+            Ok(acc)
+        })
+    }
+
+    fn choice_from_value<D: DecodeChoice>(&mut self, value: AvnValue) -> Result<D, DecodeError> {
+        let (identifier, inner_value) = match value {
+            AvnValue::Choice { identifier, value } => (identifier, value),
+            other => {
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "choice (identifier : value)",
+                    found: alloc::format!("{other:?}"),
+                }));
+            }
+        };
+
+        let all_variants = variants::Variants::from_slice(
+            &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
+        );
+        let tag = all_variants
+            .iter()
+            .enumerate()
+            .find_map(|(i, t)| {
+                D::IDENTIFIERS
+                    .get(i)
+                    .filter(|&&id| id.eq_ignore_ascii_case(&identifier))
+                    .map(|_| *t)
+            })
+            .unwrap_or(Tag::EOC);
+
+        if tag != Tag::EOC {
+            self.stack.push(*inner_value);
+        }
+        D::from_tag(self, tag)
+    }
+
+    fn utc_time_from_value(value: AvnValue) -> Result<UtcTime, DecodeError> {
+        crate::ber::de::Decoder::parse_any_utc_time_string(Self::char_string_from_value(value)?)
+    }
+
+    fn generalized_time_from_value(value: AvnValue) -> Result<GeneralizedTime, DecodeError> {
+        crate::ber::de::Decoder::parse_any_generalized_time_string(Self::char_string_from_value(
+            value,
+        )?)
+    }
+
+    fn date_from_value(value: AvnValue) -> Result<Date, DecodeError> {
+        crate::ber::de::Decoder::parse_date_string(&Self::char_string_from_value(value)?)
+    }
+}

--- a/src/avn/de.rs
+++ b/src/avn/de.rs
@@ -399,7 +399,7 @@ impl Parser {
                     .into_iter()
                     .map(|item| {
                         if let BraceItem::Named(name, val) = item {
-                            (name, val)
+                            (name, Some(val))
                         } else {
                             unreachable!()
                         }
@@ -487,13 +487,14 @@ macro_rules! decode_avn_value {
         $stack
             .pop()
             .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))
+            .and_then(|v| v.ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi())))
             .and_then($decoder_fn)
     };
 }
 
 /// Decodes ASN.1 Value Notation text into Rust structures.
 pub struct Decoder {
-    stack: alloc::vec::Vec<AvnValue>,
+    stack: alloc::vec::Vec<Option<AvnValue>>,
 }
 
 impl Decoder {
@@ -503,7 +504,7 @@ impl Decoder {
         let mut parser = Parser::new(tokens);
         let root = parser.parse_value(0)?;
         Ok(Self {
-            stack: alloc::vec![root],
+            stack: alloc::vec![Some(root)],
         })
     }
 }
@@ -511,7 +512,7 @@ impl Decoder {
 impl From<AvnValue> for Decoder {
     fn from(value: AvnValue) -> Self {
         Self {
-            stack: alloc::vec![value],
+            stack: alloc::vec![Some(value)],
         }
     }
 }
@@ -529,6 +530,7 @@ impl crate::Decoder for Decoder {
         let value = self
             .stack
             .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?
             .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
         Ok(Any::new(alloc::format!("{value}").into_bytes()))
     }
@@ -733,10 +735,14 @@ impl crate::Decoder for Decoder {
         let last = self
             .stack
             .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?
             .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
 
         let mut field_map: BTreeMap<alloc::string::String, AvnValue> = match last {
-            AvnValue::Sequence(fields) => fields.into_iter().collect(),
+            AvnValue::Sequence(fields) => fields
+                .into_iter()
+                .filter_map(|(k, v)| v.map(|v| (k, v)))
+                .collect(),
             AvnValue::SequenceOf(items) if items.is_empty() => BTreeMap::new(),
             other => {
                 return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
@@ -753,8 +759,7 @@ impl crate::Decoder for Decoder {
         }
         field_names.reverse();
         for name in field_names {
-            self.stack
-                .push(field_map.remove(name).unwrap_or(AvnValue::Absent));
+            self.stack.push(field_map.remove(name));
         }
         (decode_fn)(self)
     }
@@ -790,10 +795,14 @@ impl crate::Decoder for Decoder {
         let last = self
             .stack
             .pop()
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?
             .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
 
         let mut field_map: BTreeMap<alloc::string::String, AvnValue> = match last {
-            AvnValue::Sequence(fields) => fields.into_iter().collect(),
+            AvnValue::Sequence(fields) => fields
+                .into_iter()
+                .filter_map(|(k, v)| v.map(|v| (k, v)))
+                .collect(),
             AvnValue::SequenceOf(items) if items.is_empty() => BTreeMap::new(),
             other => {
                 return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
@@ -810,8 +819,7 @@ impl crate::Decoder for Decoder {
         field_indices
             .sort_by(|(_, a), (_, b)| a.tag_tree.smallest_tag().cmp(&b.tag_tree.smallest_tag()));
         for (index, field) in field_indices {
-            self.stack
-                .push(field_map.remove(field.name).unwrap_or(AvnValue::Absent));
+            self.stack.push(field_map.remove(field.name));
             fields_out.push((decode_fn)(self, index, field.tag)?);
         }
         for (index, field) in SET::EXTENDED_FIELDS
@@ -819,8 +827,7 @@ impl crate::Decoder for Decoder {
             .flat_map(|fields| fields.iter())
             .enumerate()
         {
-            self.stack
-                .push(field_map.remove(field.name).unwrap_or(AvnValue::Absent));
+            self.stack.push(field_map.remove(field.name));
             fields_out.push((decode_fn)(self, index + SET::FIELDS.len(), field.tag)?);
         }
         (field_fn)(fields_out)
@@ -834,14 +841,14 @@ impl crate::Decoder for Decoder {
     }
 
     fn decode_optional<D: Decode>(&mut self) -> Result<Option<D>, Self::Error> {
-        let last = self
+        match self
             .stack
             .pop()
-            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?;
-        match last {
-            AvnValue::Absent => Ok(None),
-            v => {
-                self.stack.push(v);
+            .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::eoi()))?
+        {
+            None => Ok(None),
+            Some(v) => {
+                self.stack.push(Some(v));
                 Some(D::decode(self)).transpose()
             }
         }
@@ -1092,7 +1099,7 @@ impl Decoder {
         items
             .into_iter()
             .map(|v| {
-                self.stack.push(v);
+                self.stack.push(Some(v));
                 D::decode(self)
             })
             .collect()
@@ -1113,7 +1120,7 @@ impl Decoder {
             }
         };
         items.into_iter().try_fold(SetOf::new(), |mut acc, v| {
-            self.stack.push(v);
+            self.stack.push(Some(v));
             acc.insert(D::decode(self)?);
             Ok(acc)
         })
@@ -1145,7 +1152,7 @@ impl Decoder {
             .unwrap_or(Tag::EOC);
 
         if tag != Tag::EOC {
-            self.stack.push(*inner_value);
+            self.stack.push(Some(*inner_value));
         }
         D::from_tag(self, tag)
     }

--- a/src/avn/de.rs
+++ b/src/avn/de.rs
@@ -6,6 +6,14 @@
 
 use alloc::collections::BTreeMap;
 use core::str::FromStr;
+use nom::{
+    IResult,
+    branch::alt,
+    bytes::complete::{take_while, take_while1},
+    character::complete::{char, digit1, multispace0},
+    combinator::{map, opt, recognize},
+    sequence::{pair, preceded},
+};
 use num_bigint::BigInt;
 
 use crate::{
@@ -23,378 +31,223 @@ use crate::{
 use super::value::AvnValue;
 
 // ---------------------------------------------------------------------------
-// Lexer
+// nom-based parser
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
-enum Token {
-    LBrace,
-    RBrace,
-    Colon,
-    Comma,
-    Identifier(alloc::string::String),
-    Number(alloc::string::String),
-    /// Content of `'...'H` (between the quotes, before the `H`)
-    HexString(alloc::string::String),
-    /// Content of `'...'B` (between the quotes, before the `B`)
-    BinString(alloc::string::String),
-    /// Already-unescaped content of `"..."` string
-    QuotedString(alloc::string::String),
-    True,
-    False,
-    Null,
+fn parse_identifier_str(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        take_while1(|c: char| c.is_ascii_alphabetic()),
+        take_while(|c: char| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+    ))(input)
 }
 
-fn lex(input: &str) -> Result<alloc::vec::Vec<Token>, DecodeError> {
-    let bytes = input.as_bytes();
-    let len = bytes.len();
-    let mut i = 0;
-    let mut tokens = alloc::vec::Vec::new();
-
-    while i < len {
-        match bytes[i] {
-            // skip whitespace
-            b' ' | b'\t' | b'\n' | b'\r' => i += 1,
-
-            b'{' => {
-                tokens.push(Token::LBrace);
-                i += 1;
-            }
-            b'}' => {
-                tokens.push(Token::RBrace);
-                i += 1;
-            }
-            b':' => {
-                tokens.push(Token::Colon);
-                i += 1;
-            }
-            b',' => {
-                tokens.push(Token::Comma);
-                i += 1;
-            }
-
-            // Quoted string "..." with "" → " escaping
-            b'"' => {
-                i += 1; // skip opening "
-                let mut s = alloc::string::String::new();
-                loop {
-                    if i >= len {
-                        return Err(DecodeError::from(AvnDecodeErrorKind::UnterminatedString));
-                    }
-                    if bytes[i] == b'"' {
-                        i += 1;
-                        if i < len && bytes[i] == b'"' {
-                            s.push('"');
-                            i += 1;
-                        } else {
-                            break; // end of string
-                        }
-                    } else {
-                        // For simplicity, treat each byte as a char (ASCII-safe for AVN identifiers)
-                        s.push(bytes[i] as char);
-                        i += 1;
-                    }
-                }
-                tokens.push(Token::QuotedString(s));
-            }
-
-            // Hex or binary string: '...'H or '...'B
-            b'\'' => {
-                i += 1; // skip opening '
-                let start = i;
-                while i < len && bytes[i] != b'\'' {
-                    i += 1;
-                }
-                if i >= len {
-                    return Err(DecodeError::from(AvnDecodeErrorKind::UnterminatedString));
-                }
-                // Collect content (strip internal whitespace allowed in AVN hex strings)
-                let raw = &input[start..i];
-                let content: alloc::string::String =
-                    raw.chars().filter(|c| !c.is_whitespace()).collect();
-                i += 1; // skip closing '
-                // Check for H or B suffix
-                if i < len && bytes[i] == b'H' {
-                    tokens.push(Token::HexString(content));
-                    i += 1;
-                } else if i < len && bytes[i] == b'B' {
-                    tokens.push(Token::BinString(content));
-                    i += 1;
-                } else {
-                    return Err(DecodeError::from(AvnDecodeErrorKind::InvalidHexString));
-                }
-            }
-
-            // Number (possibly negative)
-            b'-' | b'0'..=b'9' => {
-                let start = i;
-                if bytes[i] == b'-' {
-                    i += 1;
-                }
-                while i < len && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                if i < len && bytes[i] == b'.' {
-                    i += 1;
-                    while i < len && bytes[i].is_ascii_digit() {
-                        i += 1;
-                    }
-                }
-                let s =
-                    alloc::string::String::from_utf8(bytes[start..i].to_vec()).unwrap_or_default();
-                tokens.push(Token::Number(s));
-            }
-
-            // Identifier or keyword: [a-zA-Z][a-zA-Z0-9-_]*
-            b if b.is_ascii_alphabetic() => {
-                let start = i;
-                while i < len
-                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-' || bytes[i] == b'_')
-                {
-                    i += 1;
-                }
-                let s =
-                    alloc::string::String::from_utf8(bytes[start..i].to_vec()).unwrap_or_default();
-                match s.as_str() {
-                    "TRUE" => tokens.push(Token::True),
-                    "FALSE" => tokens.push(Token::False),
-                    "NULL" => tokens.push(Token::Null),
-                    _ => tokens.push(Token::Identifier(s)),
-                }
-            }
-
-            b => {
-                return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
-                    found: alloc::format!("byte 0x{b:02X} at position {i}"),
-                }));
-            }
-        }
+fn parse_hex_or_bin_string(input: &str) -> IResult<&str, AvnValue> {
+    let (input, _) = char('\'')(input)?;
+    let (input, raw) = take_while(|c: char| c != '\'')(input)?;
+    let (input, _) = char('\'')(input)?;
+    let content: alloc::string::String = raw.chars().filter(|c| !c.is_whitespace()).collect();
+    let (input, suffix) = alt((char('H'), char('B')))(input)?;
+    if suffix == 'H' {
+        parse_hex_bytes(&content)
+            .map(|bytes| (input, AvnValue::OctetString(bytes)))
+            .ok_or_else(|| {
+                nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::HexDigit,
+                ))
+            })
+    } else {
+        parse_bin_bits(&content)
+            .map(|(bytes, bit_length)| (input, AvnValue::BitString { bytes, bit_length }))
+            .ok_or_else(|| {
+                nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+            })
     }
-    Ok(tokens)
 }
 
-// ---------------------------------------------------------------------------
-// Parser
-// ---------------------------------------------------------------------------
-
-struct Parser {
-    tokens: alloc::vec::Vec<Token>,
-    pos: usize,
-}
-
-impl Parser {
-    fn new(tokens: alloc::vec::Vec<Token>) -> Self {
-        Self { tokens, pos: 0 }
-    }
-
-    fn peek(&self) -> Option<&Token> {
-        self.tokens.get(self.pos)
-    }
-
-    fn consume(&mut self) -> Option<Token> {
-        if self.pos < self.tokens.len() {
-            let t = self.tokens[self.pos].clone();
-            self.pos += 1;
-            Some(t)
-        } else {
-            None
-        }
-    }
-
-    fn parse_value(&mut self, depth: usize) -> Result<AvnValue, DecodeError> {
-        if depth > 64 {
-            return Err(DecodeError::from_kind(
-                crate::error::DecodeErrorKind::ExceedsMaxParseDepth,
-                crate::Codec::Avn,
-            ));
-        }
-        match self.peek() {
-            None => Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
-
-            Some(Token::True) => {
-                self.consume();
-                Ok(AvnValue::Boolean(true))
+fn parse_quoted_string(input: &str) -> IResult<&str, AvnValue> {
+    let (input, _) = char('"')(input)?;
+    let mut s = alloc::string::String::new();
+    let mut rest = input;
+    loop {
+        match rest.chars().next() {
+            None => {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    rest,
+                    nom::error::ErrorKind::Eof,
+                )));
             }
-            Some(Token::False) => {
-                self.consume();
-                Ok(AvnValue::Boolean(false))
-            }
-            Some(Token::Null) => {
-                self.consume();
-                Ok(AvnValue::Null)
-            }
-
-            Some(Token::Number(_)) => {
-                if let Some(Token::Number(s)) = self.consume() {
-                    if s.contains('.') {
-                        Ok(AvnValue::Real(s))
-                    } else {
-                        Ok(AvnValue::Integer(s))
-                    }
+            Some('"') => {
+                rest = &rest[1..];
+                if rest.starts_with('"') {
+                    s.push('"');
+                    rest = &rest[1..];
                 } else {
-                    unreachable!()
-                }
-            }
-
-            Some(Token::HexString(_)) => {
-                if let Some(Token::HexString(hex)) = self.consume() {
-                    parse_hex_bytes(&hex)
-                        .map(AvnValue::OctetString)
-                        .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::InvalidHexString))
-                } else {
-                    unreachable!()
-                }
-            }
-
-            Some(Token::BinString(_)) => {
-                if let Some(Token::BinString(bin)) = self.consume() {
-                    parse_bin_bits(&bin)
-                        .map(|(bytes, bit_length)| AvnValue::BitString { bytes, bit_length })
-                        .ok_or_else(|| DecodeError::from(AvnDecodeErrorKind::InvalidBinString))
-                } else {
-                    unreachable!()
-                }
-            }
-
-            Some(Token::QuotedString(_)) => {
-                if let Some(Token::QuotedString(s)) = self.consume() {
-                    Ok(AvnValue::CharString(s))
-                } else {
-                    unreachable!()
-                }
-            }
-
-            Some(Token::LBrace) => {
-                self.consume(); // consume '{'
-                self.parse_brace_contents(depth + 1)
-            }
-
-            Some(Token::Identifier(_)) => {
-                if let Some(Token::Identifier(id)) = self.consume() {
-                    // Special real keywords encoded as identifiers by the encoder
-                    match id.as_str() {
-                        "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => {
-                            return Ok(AvnValue::Real(id));
-                        }
-                        _ => {}
-                    }
-                    // Check for CHOICE: identifier : value
-                    if matches!(self.peek(), Some(Token::Colon)) {
-                        self.consume(); // consume ':'
-                        let inner = self.parse_value(depth + 1)?;
-                        Ok(AvnValue::Choice {
-                            identifier: id,
-                            value: alloc::boxed::Box::new(inner),
-                        })
-                    } else {
-                        Ok(AvnValue::Enumerated(id))
-                    }
-                } else {
-                    unreachable!()
-                }
-            }
-
-            Some(t) => Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
-                found: alloc::format!("{t:?}"),
-            })),
-        }
-    }
-
-    /// Parse contents after `{` has been consumed.
-    /// Returns `AvnValue::Sequence`, `AvnValue::SequenceOf`, or empty `SequenceOf([])`.
-    fn parse_brace_contents(&mut self, depth: usize) -> Result<AvnValue, DecodeError> {
-        // Empty braces
-        if matches!(self.peek(), Some(Token::RBrace)) {
-            self.consume();
-            return Ok(AvnValue::SequenceOf(alloc::vec![]));
-        }
-
-        enum BraceItem {
-            Named(alloc::string::String, AvnValue),
-            Bare(AvnValue),
-        }
-
-        let mut items: alloc::vec::Vec<BraceItem> = alloc::vec![];
-
-        loop {
-            match self.peek() {
-                None => return Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
-                Some(Token::RBrace) => {
-                    self.consume();
                     break;
                 }
-                Some(Token::Identifier(_)) => {
-                    let id = if let Some(Token::Identifier(s)) = self.consume() {
-                        s
-                    } else {
-                        unreachable!()
-                    };
+            }
+            Some(c) => {
+                s.push(c);
+                rest = &rest[c.len_utf8()..];
+            }
+        }
+    }
+    Ok((rest, AvnValue::CharString(s)))
+}
 
-                    match self.peek() {
-                        // id : value → CHOICE element (bare)
-                        Some(Token::Colon) => {
-                            self.consume();
-                            let val = self.parse_value(depth)?;
-                            items.push(BraceItem::Bare(AvnValue::Choice {
-                                identifier: id,
-                                value: alloc::boxed::Box::new(val),
-                            }));
-                        }
-                        // id alone (comma or closing brace) → bare enumerated or real keyword
-                        Some(Token::Comma) | Some(Token::RBrace) => match id.as_str() {
-                            "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => {
-                                items.push(BraceItem::Bare(AvnValue::Real(id)));
-                            }
-                            _ => items.push(BraceItem::Bare(AvnValue::Enumerated(id))),
-                        },
-                        // id value → named SEQUENCE field
-                        _ => {
-                            let val = self.parse_value(depth)?;
-                            items.push(BraceItem::Named(id, val));
-                        }
+fn parse_number(input: &str) -> IResult<&str, AvnValue> {
+    map(
+        recognize(pair(
+            opt(char('-')),
+            pair(digit1, opt(preceded(char('.'), digit1))),
+        )),
+        |s: &str| {
+            if s.contains('.') {
+                AvnValue::Real(s.into())
+            } else {
+                AvnValue::Integer(s.into())
+            }
+        },
+    )(input)
+}
+
+fn parse_value(input: &str) -> IResult<&str, AvnValue> {
+    parse_value_depth(input, 0)
+}
+
+fn parse_value_depth(input: &str, depth: usize) -> IResult<&str, AvnValue> {
+    if depth > 64 {
+        return Err(nom::Err::Failure(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::TooLarge,
+        )));
+    }
+    let (input, _) = multispace0(input)?;
+    alt((
+        parse_hex_or_bin_string,
+        parse_quoted_string,
+        parse_number,
+        move |i| parse_brace(i, depth + 1),
+        move |i| parse_identifier_or_choice(i, depth),
+    ))(input)
+}
+
+fn parse_identifier_or_choice(input: &str, depth: usize) -> IResult<&str, AvnValue> {
+    let (after_id, id) = parse_identifier_str(input)?;
+    let (after_ws, _) = multispace0(after_id)?;
+    if after_ws.starts_with(':') {
+        let rest = &after_ws[1..];
+        let (rest, inner) = parse_value_depth(rest, depth + 1)?;
+        return Ok((
+            rest,
+            AvnValue::Choice {
+                identifier: id.into(),
+                value: alloc::boxed::Box::new(inner),
+            },
+        ));
+    }
+    let val = match id {
+        "TRUE" => AvnValue::Boolean(true),
+        "FALSE" => AvnValue::Boolean(false),
+        "NULL" => AvnValue::Null,
+        "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => AvnValue::Real(id.into()),
+        _ => AvnValue::Enumerated(id.into()),
+    };
+    Ok((after_id, val))
+}
+
+fn parse_brace(input: &str, depth: usize) -> IResult<&str, AvnValue> {
+    let (input, _) = char('{')(input)?;
+    let (input, _) = multispace0(input)?;
+
+    if let Ok((rest, _)) = char::<_, nom::error::Error<&str>>('}')(input) {
+        return Ok((rest, AvnValue::SequenceOf(alloc::vec![])));
+    }
+
+    enum BraceItem {
+        Named(alloc::string::String, AvnValue),
+        Bare(AvnValue),
+    }
+
+    let mut items: alloc::vec::Vec<BraceItem> = alloc::vec![];
+    let mut current = input;
+
+    loop {
+        let (after_ws, _) = multispace0(current)?;
+        current = after_ws;
+
+        if let Ok((after_id, id)) = parse_identifier_str(current) {
+            let (after_ws2, _) = multispace0(after_id)?;
+            if after_ws2.starts_with(':') {
+                // CHOICE element inside braces: id : value
+                let (rest, val) = parse_value_depth(&after_ws2[1..], depth)?;
+                items.push(BraceItem::Bare(AvnValue::Choice {
+                    identifier: id.into(),
+                    value: alloc::boxed::Box::new(val),
+                }));
+                current = rest;
+            } else if after_ws2.starts_with(',') || after_ws2.starts_with('}') {
+                // Bare identifier: enumerated or real keyword
+                let val = match id {
+                    "PLUS-INFINITY" | "MINUS-INFINITY" | "NOT-A-NUMBER" => {
+                        AvnValue::Real(id.into())
                     }
-                }
-                _ => {
-                    // Non-identifier: bare SEQUENCE OF element
-                    let val = self.parse_value(depth)?;
-                    items.push(BraceItem::Bare(val));
-                }
+                    _ => AvnValue::Enumerated(id.into()),
+                };
+                items.push(BraceItem::Bare(val));
+                current = after_id;
+            } else {
+                // Named SEQUENCE field: id value
+                let (rest, val) = parse_value_depth(after_ws2, depth)?;
+                items.push(BraceItem::Named(id.into(), val));
+                current = rest;
             }
-
-            // Consume separator: comma, or allow space-separated integers (OID notation).
-            match self.peek() {
-                Some(Token::Comma) => {
-                    self.consume();
-                }
-                Some(Token::RBrace) => {}
-                None => return Err(DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {})),
-                // OID-style space-separated arcs: all items so far must be bare integers
-                Some(Token::Number(_))
-                    if items
-                        .iter()
-                        .all(|i| matches!(i, BraceItem::Bare(AvnValue::Integer(_)))) =>
-                {
-                    // No comma needed — continue to parse next arc in next loop iteration
-                }
-                Some(t) => {
-                    return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
-                        found: alloc::format!("{t:?}"),
-                    }));
-                }
-            }
+        } else {
+            // Non-identifier bare value (number, hex/bin string, nested brace, …)
+            let (rest, val) = parse_value_depth(current, depth)?;
+            items.push(BraceItem::Bare(val));
+            current = rest;
         }
 
-        let has_named = items.iter().any(|i| matches!(i, BraceItem::Named(..)));
-        let has_bare = items.iter().any(|i| matches!(i, BraceItem::Bare(..)));
+        let (after_sep, _) = multispace0(current)?;
+        current = after_sep;
 
-        if has_named && has_bare {
-            return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
-                found: "mixed named and bare items inside braces".into(),
-            }));
+        if current.starts_with('}') {
+            current = &current[1..];
+            break;
+        } else if current.starts_with(',') {
+            current = &current[1..];
+        } else if current
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_ascii_digit() || c == '-')
+            && items
+                .iter()
+                .all(|i| matches!(i, BraceItem::Bare(AvnValue::Integer(_))))
+        {
+            // OID-style space-separated arcs — no comma needed, continue
+        } else {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                current,
+                nom::error::ErrorKind::Char,
+            )));
         }
+    }
 
-        if has_named {
-            Ok(AvnValue::Sequence(
+    let has_named = items.iter().any(|i| matches!(i, BraceItem::Named(..)));
+    let has_bare = items.iter().any(|i| matches!(i, BraceItem::Bare(..)));
+
+    if has_named && has_bare {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            current,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    if has_named {
+        Ok((
+            current,
+            AvnValue::Sequence(
                 items
                     .into_iter()
                     .map(|item| {
@@ -405,9 +258,12 @@ impl Parser {
                         }
                     })
                     .collect(),
-            ))
-        } else {
-            Ok(AvnValue::SequenceOf(
+            ),
+        ))
+    } else {
+        Ok((
+            current,
+            AvnValue::SequenceOf(
                 items
                     .into_iter()
                     .map(|item| {
@@ -418,8 +274,8 @@ impl Parser {
                         }
                     })
                     .collect(),
-            ))
-        }
+            ),
+        ))
     }
 }
 
@@ -500,9 +356,26 @@ pub struct Decoder {
 impl Decoder {
     /// Create a new decoder by parsing the entire input string.
     pub fn new(input: &str) -> Result<Self, DecodeError> {
-        let tokens = lex(input)?;
-        let mut parser = Parser::new(tokens);
-        let root = parser.parse_value(0)?;
+        let (rest, root) = parse_value(input).map_err(|e| match e {
+            nom::Err::Incomplete(_) => DecodeError::from(AvnDecodeErrorKind::AvnEndOfInput {}),
+            nom::Err::Error(e) | nom::Err::Failure(e) => {
+                if e.code == nom::error::ErrorKind::TooLarge {
+                    DecodeError::from_kind(
+                        crate::error::DecodeErrorKind::ExceedsMaxParseDepth,
+                        crate::Codec::Avn,
+                    )
+                } else {
+                    DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                        found: e.input.chars().take(20).collect(),
+                    })
+                }
+            }
+        })?;
+        if !rest.trim().is_empty() {
+            return Err(DecodeError::from(AvnDecodeErrorKind::UnexpectedToken {
+                found: rest.into(),
+            }));
+        }
         Ok(Self {
             stack: alloc::vec![Some(root)],
         })

--- a/src/avn/de.rs
+++ b/src/avn/de.rs
@@ -1,8 +1,9 @@
 //! Decoding ASN.1 Value Notation (AVN) text into Rust structures.
 //!
-//! Uses a two-phase approach:
-//! 1. **Lex + parse** the entire input string into an [`AvnValue`] tree.
+//! 1. **Parse** the entire input string into an [`AvnValue`] tree using nom combinators.
 //! 2. **Type-directed decode** pops values from a stack and dispatches.
+
+#![deny(clippy::all)]
 
 use alloc::collections::BTreeMap;
 use core::str::FromStr;
@@ -135,8 +136,7 @@ fn parse_value_depth(input: &str, depth: usize) -> IResult<&str, AvnValue> {
 fn parse_identifier_or_choice(input: &str, depth: usize) -> IResult<&str, AvnValue> {
     let (after_id, id) = parse_identifier_str(input)?;
     let (after_ws, _) = multispace0(after_id)?;
-    if after_ws.starts_with(':') {
-        let rest = &after_ws[1..];
+    if let Some(rest) = after_ws.strip_prefix(':') {
         let (rest, inner) = parse_value_depth(rest, depth + 1)?;
         return Ok((
             rest,
@@ -178,9 +178,9 @@ fn parse_brace(input: &str, depth: usize) -> IResult<&str, AvnValue> {
 
         if let Ok((after_id, id)) = parse_identifier_str(current) {
             let (after_ws2, _) = multispace0(after_id)?;
-            if after_ws2.starts_with(':') {
+            if let Some(after_colon) = after_ws2.strip_prefix(':') {
                 // CHOICE element inside braces: id : value
-                let (rest, val) = parse_value_depth(&after_ws2[1..], depth)?;
+                let (rest, val) = parse_value_depth(after_colon, depth)?;
                 items.push(BraceItem::Bare(AvnValue::Choice {
                     identifier: id.into(),
                     value: alloc::boxed::Box::new(val),
@@ -220,7 +220,7 @@ fn parse_brace(input: &str, depth: usize) -> IResult<&str, AvnValue> {
         } else if current
             .chars()
             .next()
-            .map_or(false, |c| c.is_ascii_digit() || c == '-')
+            .is_some_and(|c| c.is_ascii_digit() || c == '-')
             && items
                 .iter()
                 .all(|i| matches!(i, BraceItem::Bare(AvnValue::Integer(_))))

--- a/src/avn/enc.rs
+++ b/src/avn/enc.rs
@@ -14,7 +14,7 @@ pub struct Encoder {
     /// Stack of field names waiting to be consumed by the next `update_root_or_constructed` call.
     stack: alloc::vec::Vec<&'static str>,
     /// Stack of in-progress SEQUENCE / SET / CHOICE constructed values.
-    constructed_stack: alloc::vec::Vec<alloc::vec::Vec<(alloc::string::String, AvnValue)>>,
+    constructed_stack: alloc::vec::Vec<alloc::vec::Vec<(alloc::string::String, Option<AvnValue>)>>,
     /// The completed root value (set once encoding is done).
     root_value: Option<AvnValue>,
 }
@@ -61,7 +61,7 @@ impl Encoder {
                     .ok_or_else(|| AvnEncodeErrorKind::AvnEncoder {
                         msg: "Internal stack mismatch!".into(),
                     })?
-                    .push((id.to_string(), value));
+                    .push((id.to_string(), Some(value)));
             }
             None => {
                 self.root_value = Some(value);
@@ -472,17 +472,15 @@ impl crate::Encoder<'_> for Encoder {
     }
 
     fn encode_none<E: crate::Encode>(&mut self, _: Identifier) -> Result<Self::Ok, Self::Error> {
-        // Pop the field name from the stack and push an Absent sentinel so the
-        // SEQUENCE encoder can filter it out.
         if let (Some(id), Some(top)) = (self.stack.pop(), self.constructed_stack.last_mut()) {
-            top.push((id.to_string(), AvnValue::Absent));
+            top.push((id.to_string(), None));
         }
         Ok(())
     }
 
     fn encode_none_with_tag(&mut self, _t: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
         if let (Some(id), Some(top)) = (self.stack.pop(), self.constructed_stack.last_mut()) {
-            top.push((id.to_string(), AvnValue::Absent));
+            top.push((id.to_string(), None));
         }
         Ok(())
     }
@@ -526,7 +524,7 @@ impl crate::Encoder<'_> for Encoder {
             let inner_value = fields
                 .into_iter()
                 .next()
-                .map(|(_, v)| v)
+                .and_then(|(_, v)| v)
                 .unwrap_or(AvnValue::Null);
             self.update_root_or_constructed(AvnValue::Choice {
                 identifier: identifier.to_string(),

--- a/src/avn/enc.rs
+++ b/src/avn/enc.rs
@@ -1,0 +1,617 @@
+//! Encoding Rust structures into ASN.1 Value Notation (AVN) text format.
+
+use alloc::string::ToString;
+
+use super::value::AvnValue;
+use crate::types::RealType;
+use crate::{
+    error::{AvnEncodeErrorKind, EncodeError},
+    types::{Constraints, Identifier, IntegerType, Tag, variants},
+};
+
+/// Encodes Rust structures into ASN.1 Value Notation text.
+pub struct Encoder {
+    /// Stack of field names waiting to be consumed by the next `update_root_or_constructed` call.
+    stack: alloc::vec::Vec<&'static str>,
+    /// Stack of in-progress SEQUENCE / SET / CHOICE constructed values.
+    constructed_stack: alloc::vec::Vec<alloc::vec::Vec<(alloc::string::String, AvnValue)>>,
+    /// The completed root value (set once encoding is done).
+    root_value: Option<AvnValue>,
+}
+
+impl Default for Encoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Encoder {
+    /// Creates a new default encoder.
+    pub fn new() -> Self {
+        Self {
+            stack: alloc::vec![],
+            constructed_stack: alloc::vec![],
+            root_value: None,
+        }
+    }
+
+    /// Returns the complete encoded AVN value, consuming the encoder.
+    pub fn to_avn(self) -> Result<AvnValue, EncodeError> {
+        self.root_value
+            .ok_or_else(|| AvnEncodeErrorKind::AvnNoRootValueFound.into())
+    }
+
+    /// Returns the encoded AVN value formatted as a string, consuming the encoder.
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(self) -> alloc::string::String {
+        self.to_avn()
+            .ok()
+            .map(|v| v.to_string())
+            .unwrap_or_default()
+    }
+
+    /// Places `value` into the top of the constructed stack (keyed by the
+    /// name popped from `self.stack`), or sets the root value when the stack
+    /// is empty.
+    fn update_root_or_constructed(&mut self, value: AvnValue) -> Result<(), EncodeError> {
+        match self.stack.pop() {
+            Some(id) => {
+                self.constructed_stack
+                    .last_mut()
+                    .ok_or_else(|| AvnEncodeErrorKind::AvnEncoder {
+                        msg: "Internal stack mismatch!".into(),
+                    })?
+                    .push((id.to_string(), value));
+            }
+            None => {
+                self.root_value = Some(value);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl crate::Encoder<'_> for Encoder {
+    type Ok = ();
+    type Error = EncodeError;
+    type AnyEncoder<'this, const R: usize, const E: usize> = Encoder;
+
+    fn encode_any(
+        &mut self,
+        t: crate::types::Tag,
+        value: &crate::types::Any,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.encode_octet_string(
+            t,
+            Constraints::default(),
+            value.as_bytes(),
+            Identifier::EMPTY,
+        )
+    }
+
+    fn encode_bool(&mut self, _: Tag, value: bool, _: Identifier) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::Boolean(value))
+    }
+
+    fn encode_bit_string(
+        &mut self,
+        _t: Tag,
+        _constraints: Constraints,
+        value: &crate::types::BitStr,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let bit_length = value.len();
+        let mut bitvec = value.to_bitvec();
+        // Force-align so that `into_vec()` gives us whole bytes.
+        bitvec.force_align();
+        let bytes = bitvec.into_vec();
+        self.update_root_or_constructed(AvnValue::BitString { bytes, bit_length })
+    }
+
+    fn encode_enumerated<E: crate::types::Enumerated>(
+        &mut self,
+        _: Tag,
+        value: &E,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::Enumerated(alloc::string::String::from(
+            value.identifier(),
+        )))
+    }
+
+    fn encode_object_identifier(
+        &mut self,
+        _t: Tag,
+        value: &[u32],
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::Oid(value.to_vec()))
+    }
+
+    fn encode_integer<I: IntegerType>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &I,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        // BigInt always works — no i64 limitation unlike JER.
+        let s = value.to_bigint().unwrap_or_default().to_string();
+        self.update_root_or_constructed(AvnValue::Integer(s))
+    }
+
+    fn encode_real<R: RealType>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &R,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        use num_traits::{ToPrimitive, Zero, float::FloatCore};
+
+        let as_float = value
+            .try_to_float()
+            .ok_or(AvnEncodeErrorKind::AvnExceedsSupportedRealRange)?;
+
+        let avn_val = if as_float.is_infinite() {
+            if as_float.is_sign_positive() {
+                AvnValue::Real("PLUS-INFINITY".into())
+            } else {
+                AvnValue::Real("MINUS-INFINITY".into())
+            }
+        } else if as_float.is_nan() {
+            AvnValue::Real("NOT-A-NUMBER".into())
+        } else if as_float.is_zero() && as_float.is_sign_negative() {
+            AvnValue::Real("-0".into())
+        } else {
+            let f64_val = as_float
+                .to_f64()
+                .ok_or(AvnEncodeErrorKind::AvnExceedsSupportedRealRange)?;
+            AvnValue::Real(alloc::format!("{f64_val}"))
+        };
+        self.update_root_or_constructed(avn_val)
+    }
+
+    fn encode_null(&mut self, _: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::Null)
+    }
+
+    fn encode_octet_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &[u8],
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::OctetString(value.to_vec()))
+    }
+
+    fn encode_general_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::GeneralString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(value.to_vec()).map_err(|e| {
+            AvnEncodeErrorKind::AvnEncoder {
+                msg: alloc::format!("Invalid UTF-8: {e}"),
+            }
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_graphic_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::GraphicString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(value.to_vec()).map_err(|e| {
+            AvnEncodeErrorKind::AvnEncoder {
+                msg: alloc::format!("Invalid UTF-8: {e}"),
+            }
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_utf8_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &str,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.update_root_or_constructed(AvnValue::CharString(value.into()))
+    }
+
+    fn encode_visible_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::VisibleString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s =
+            alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec()).map_err(|e| {
+                AvnEncodeErrorKind::AvnEncoder {
+                    msg: alloc::format!("Invalid UTF-8: {e}"),
+                }
+            })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_ia5_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::Ia5String,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s =
+            alloc::string::String::from_utf8(value.as_iso646_bytes().to_vec()).map_err(|e| {
+                AvnEncodeErrorKind::AvnEncoder {
+                    msg: alloc::format!("Invalid UTF-8: {e}"),
+                }
+            })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_printable_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::PrintableString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(value.as_bytes().to_vec()).map_err(|e| {
+            AvnEncodeErrorKind::AvnEncoder {
+                msg: alloc::format!("Invalid UTF-8: {e}"),
+            }
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_numeric_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::NumericString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(value.as_bytes().to_vec()).map_err(|e| {
+            AvnEncodeErrorKind::AvnEncoder {
+                msg: alloc::format!("Invalid UTF-8: {e}"),
+            }
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_teletex_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        _value: &crate::types::TeletexString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn encode_bmp_string(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &crate::types::BmpString,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(value.to_bytes()).map_err(|e| {
+            AvnEncodeErrorKind::AvnEncoder {
+                msg: alloc::format!("Invalid UTF-8: {e}"),
+            }
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_generalized_time(
+        &mut self,
+        _t: Tag,
+        value: &crate::types::GeneralizedTime,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(
+            crate::ber::enc::Encoder::datetime_to_canonical_generalized_time_bytes(value),
+        )
+        .map_err(|e| AvnEncodeErrorKind::AvnEncoder {
+            msg: alloc::format!("Invalid UTF-8: {e}"),
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_utc_time(
+        &mut self,
+        _t: Tag,
+        value: &crate::types::UtcTime,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(
+            crate::ber::enc::Encoder::datetime_to_canonical_utc_time_bytes(value),
+        )
+        .map_err(|e| AvnEncodeErrorKind::AvnEncoder {
+            msg: alloc::format!("Invalid UTF-8: {e}"),
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_date(
+        &mut self,
+        _t: Tag,
+        value: &crate::types::Date,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let s = alloc::string::String::from_utf8(
+            crate::ber::enc::Encoder::naivedate_to_date_bytes(value),
+        )
+        .map_err(|e| AvnEncodeErrorKind::AvnEncoder {
+            msg: alloc::format!("Invalid UTF-8: {e}"),
+        })?;
+        self.update_root_or_constructed(AvnValue::CharString(s))
+    }
+
+    fn encode_explicit_prefix<V: crate::Encode>(
+        &mut self,
+        _: Tag,
+        value: &V,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self)
+    }
+
+    fn encode_sequence<'b, const RL: usize, const EL: usize, C, F>(
+        &'b mut self,
+        _t: Tag,
+        encoder_scope: F,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        C: crate::types::Constructed<RL, EL>,
+        F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
+    {
+        // Push field names in reverse so that `pop()` yields them in definition order.
+        let mut field_names = C::FIELDS
+            .iter()
+            .map(|f| f.name)
+            .collect::<alloc::vec::Vec<&str>>();
+        if let Some(extended_fields) = C::EXTENDED_FIELDS {
+            field_names.extend(extended_fields.iter().map(|f| f.name));
+        }
+        field_names.reverse();
+        for name in field_names {
+            self.stack.push(name);
+        }
+        self.constructed_stack.push(alloc::vec![]);
+        (encoder_scope)(self)?;
+        let fields =
+            self.constructed_stack
+                .pop()
+                .ok_or_else(|| AvnEncodeErrorKind::AvnEncoder {
+                    msg: "Internal stack mismatch!".into(),
+                })?;
+        self.update_root_or_constructed(AvnValue::Sequence(fields))
+    }
+
+    fn encode_sequence_of<E: crate::Encode>(
+        &mut self,
+        _t: Tag,
+        value: &[E],
+        _c: Constraints,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let items = value
+            .iter()
+            .try_fold(alloc::vec::Vec::<AvnValue>::new(), |mut acc, v| {
+                let mut item_encoder = Self::new();
+                v.encode(&mut item_encoder)?;
+                acc.push(item_encoder.to_avn()?);
+                Ok::<_, EncodeError>(acc)
+            })?;
+        self.update_root_or_constructed(AvnValue::SequenceOf(items))
+    }
+
+    fn encode_set<'b, const RL: usize, const EL: usize, C, F>(
+        &'b mut self,
+        tag: Tag,
+        value: F,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        C: crate::types::Constructed<RL, EL>,
+        F: FnOnce(&mut Self::AnyEncoder<'b, RL, EL>) -> Result<(), Self::Error>,
+    {
+        // Treat SET identically to SEQUENCE in AVN output.
+        self.encode_sequence::<RL, EL, C, F>(tag, value, Identifier::EMPTY)
+    }
+
+    fn encode_set_of<E: crate::Encode + Eq + core::hash::Hash>(
+        &mut self,
+        _t: Tag,
+        value: &crate::types::SetOf<E>,
+        _c: Constraints,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let items =
+            value
+                .to_vec()
+                .iter()
+                .try_fold(alloc::vec::Vec::<AvnValue>::new(), |mut acc, v| {
+                    let mut item_encoder = Self::new();
+                    v.encode(&mut item_encoder)?;
+                    acc.push(item_encoder.to_avn()?);
+                    Ok::<_, EncodeError>(acc)
+                })?;
+        self.update_root_or_constructed(AvnValue::SequenceOf(items))
+    }
+
+    fn encode_some<E: crate::Encode>(
+        &mut self,
+        value: &E,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self)
+    }
+
+    fn encode_some_with_tag_and_constraints<E: crate::Encode>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: &E,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self)
+    }
+
+    fn encode_none<E: crate::Encode>(&mut self, _: Identifier) -> Result<Self::Ok, Self::Error> {
+        // Pop the field name from the stack and push an Absent sentinel so the
+        // SEQUENCE encoder can filter it out.
+        if let (Some(id), Some(top)) = (self.stack.pop(), self.constructed_stack.last_mut()) {
+            top.push((id.to_string(), AvnValue::Absent));
+        }
+        Ok(())
+    }
+
+    fn encode_none_with_tag(&mut self, _t: Tag, _: Identifier) -> Result<Self::Ok, Self::Error> {
+        if let (Some(id), Some(top)) = (self.stack.pop(), self.constructed_stack.last_mut()) {
+            top.push((id.to_string(), AvnValue::Absent));
+        }
+        Ok(())
+    }
+
+    fn encode_choice<E: crate::Encode + crate::types::Choice>(
+        &mut self,
+        _c: Constraints,
+        tag: Tag,
+        encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        let variants = variants::Variants::from_slice(
+            &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
+        );
+
+        let identifier = variants
+            .iter()
+            .enumerate()
+            .find_map(|(i, &variant_tag)| {
+                (tag == variant_tag)
+                    .then_some(E::IDENTIFIERS.get(i))
+                    .flatten()
+            })
+            .ok_or_else(|| crate::error::EncodeError::variant_not_in_choice(self.codec()))?;
+
+        if variants.is_empty() {
+            self.update_root_or_constructed(AvnValue::Null)
+        } else {
+            // Push an inner constructed frame and the identifier name so the
+            // inner encode_fn deposits the value there.
+            self.constructed_stack.push(alloc::vec![]);
+            self.stack.push(identifier);
+            (encode_fn)(self)?;
+            let fields =
+                self.constructed_stack
+                    .pop()
+                    .ok_or_else(|| AvnEncodeErrorKind::AvnEncoder {
+                        msg: "Internal stack mismatch!".into(),
+                    })?;
+            // Retrieve the single inner value that was deposited.
+            let inner_value = fields
+                .into_iter()
+                .next()
+                .map(|(_, v)| v)
+                .unwrap_or(AvnValue::Null);
+            self.update_root_or_constructed(AvnValue::Choice {
+                identifier: identifier.to_string(),
+                value: alloc::boxed::Box::new(inner_value),
+            })
+        }
+    }
+
+    fn encode_extension_addition<E: crate::Encode>(
+        &mut self,
+        _t: Tag,
+        _c: Constraints,
+        value: E,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.encode(self)
+    }
+
+    fn encode_extension_addition_group<const RL: usize, const EL: usize, E>(
+        &mut self,
+        value: Option<&E>,
+        _: Identifier,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        E: crate::Encode + crate::types::Constructed<RL, EL>,
+    {
+        match value {
+            Some(v) => v.encode(self),
+            None => self.encode_none::<E>(Identifier::EMPTY),
+        }
+    }
+
+    fn codec(&self) -> crate::Codec {
+        crate::Codec::Avn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Encoder as AvnEncoder;
+    use crate::enc::Encoder as EncoderTrait;
+    use crate::prelude::*;
+
+    #[test]
+    fn bool_encodes_correctly() {
+        let mut enc = AvnEncoder::new();
+        enc.encode_bool(Tag::BOOL, true, Identifier::EMPTY).unwrap();
+        assert_eq!(enc.to_string(), "TRUE");
+
+        let mut enc = AvnEncoder::new();
+        enc.encode_bool(Tag::BOOL, false, Identifier::EMPTY)
+            .unwrap();
+        assert_eq!(enc.to_string(), "FALSE");
+    }
+
+    #[test]
+    fn null_encodes_correctly() {
+        let mut enc = AvnEncoder::new();
+        enc.encode_null(Tag::NULL, Identifier::EMPTY).unwrap();
+        assert_eq!(enc.to_string(), "NULL");
+    }
+
+    #[test]
+    fn integer_encodes_correctly() {
+        let mut enc = AvnEncoder::new();
+        enc.encode_integer(
+            Tag::INTEGER,
+            Constraints::default(),
+            &42_i64,
+            Identifier::EMPTY,
+        )
+        .unwrap();
+        assert_eq!(enc.to_string(), "42");
+    }
+
+    #[test]
+    fn octet_string_encodes_correctly() {
+        let mut enc = AvnEncoder::new();
+        enc.encode_octet_string(
+            Tag::OCTET_STRING,
+            Constraints::default(),
+            &[0x01, 0xFF, 0xAB],
+            Identifier::EMPTY,
+        )
+        .unwrap();
+        assert_eq!(enc.to_string(), "'01FFAB'H");
+    }
+}

--- a/src/avn/value.rs
+++ b/src/avn/value.rs
@@ -26,8 +26,9 @@ pub enum AvnValue {
     Real(alloc::string::String),
     /// ENUMERATED value as an identifier string
     Enumerated(alloc::string::String),
-    /// SEQUENCE / SET as an ordered list of (field-name, value) pairs
-    Sequence(alloc::vec::Vec<(alloc::string::String, AvnValue)>),
+    /// SEQUENCE / SET as an ordered list of (field-name, value) pairs.
+    /// `None` entries represent absent OPTIONAL fields and are omitted from output.
+    Sequence(alloc::vec::Vec<(alloc::string::String, Option<AvnValue>)>),
     /// SEQUENCE OF / SET OF as an ordered list of values
     SequenceOf(alloc::vec::Vec<AvnValue>),
     /// CHOICE value: `identifier : value`
@@ -39,8 +40,6 @@ pub enum AvnValue {
     },
     /// Any character-string type: `"quoted string"` (X.680 double-quote escaping)
     CharString(alloc::string::String),
-    /// Sentinel for absent OPTIONAL fields — must not appear in output
-    Absent,
 }
 
 // ---------------------------------------------------------------------------
@@ -130,10 +129,9 @@ impl fmt::Display for AvnFmt<'_> {
             AvnValue::Enumerated(id) => f.write_str(id),
 
             AvnValue::Sequence(fields) => {
-                // Filter out Absent sentinels
                 let present: alloc::vec::Vec<_> = fields
                     .iter()
-                    .filter(|(_, v)| !matches!(v, AvnValue::Absent))
+                    .filter_map(|(name, v)| v.as_ref().map(|v| (name, v)))
                     .collect();
 
                 if present.is_empty() {
@@ -184,8 +182,6 @@ impl fmt::Display for AvnFmt<'_> {
                 }
                 f.write_str("\"")
             }
-
-            AvnValue::Absent => Ok(()),
         }
     }
 }
@@ -284,10 +280,30 @@ mod tests {
     #[test]
     fn sequence_display() {
         let v = AvnValue::Sequence(alloc::vec![
-            ("field1".into(), AvnValue::Boolean(true)),
-            ("field2".into(), AvnValue::Integer("42".into())),
+            ("field1".into(), Some(AvnValue::Boolean(true))),
+            ("field2".into(), Some(AvnValue::Integer("42".into()))),
         ]);
         let expected = "{\n  field1 TRUE,\n  field2 42\n}";
+        assert_eq!(v.to_string(), expected);
+    }
+
+    #[test]
+    fn sequence_display_skips_absent() {
+        let v = AvnValue::Sequence(alloc::vec![
+            ("field1".into(), Some(AvnValue::Boolean(true))),
+            ("field2".into(), None),
+        ]);
+        let expected = "{\n  field1 TRUE\n}";
+        assert_eq!(v.to_string(), expected);
+    }
+
+    #[test]
+    fn sequence_display_with_null_field() {
+        let v = AvnValue::Sequence(alloc::vec![
+            ("field1".into(), Some(AvnValue::Boolean(true))),
+            ("flag".into(), Some(AvnValue::Null)),
+        ]);
+        let expected = "{\n  field1 TRUE,\n  flag NULL\n}";
         assert_eq!(v.to_string(), expected);
     }
 
@@ -299,10 +315,5 @@ mod tests {
         ]);
         let expected = "{\n  1,\n  2\n}";
         assert_eq!(v.to_string(), expected);
-    }
-
-    #[test]
-    fn absent_display() {
-        assert_eq!(AvnValue::Absent.to_string(), "");
     }
 }

--- a/src/avn/value.rs
+++ b/src/avn/value.rs
@@ -1,0 +1,308 @@
+//! Intermediate representation for AVN values.
+
+use core::fmt;
+
+/// Intermediate representation of an ASN.1 Value Notation value.
+#[derive(Debug, Clone)]
+pub enum AvnValue {
+    /// BOOLEAN value: `TRUE` or `FALSE`
+    Boolean(bool),
+    /// INTEGER value as decimal string, e.g. `42`
+    Integer(alloc::string::String),
+    /// OCTET STRING value as raw bytes; displayed as `'HEX'H`
+    OctetString(alloc::vec::Vec<u8>),
+    /// BIT STRING value with explicit bit length for non-byte-aligned strings
+    BitString {
+        /// Raw byte storage (last byte may be partially used)
+        bytes: alloc::vec::Vec<u8>,
+        /// Number of meaningful bits
+        bit_length: usize,
+    },
+    /// NULL value: `NULL`
+    Null,
+    /// OBJECT IDENTIFIER as a vec of arcs; displayed as `{ 1 2 3 }`
+    Oid(alloc::vec::Vec<u32>),
+    /// REAL value as a decimal string or special keyword
+    Real(alloc::string::String),
+    /// ENUMERATED value as an identifier string
+    Enumerated(alloc::string::String),
+    /// SEQUENCE / SET as an ordered list of (field-name, value) pairs
+    Sequence(alloc::vec::Vec<(alloc::string::String, AvnValue)>),
+    /// SEQUENCE OF / SET OF as an ordered list of values
+    SequenceOf(alloc::vec::Vec<AvnValue>),
+    /// CHOICE value: `identifier : value`
+    Choice {
+        /// The chosen alternative's identifier
+        identifier: alloc::string::String,
+        /// The value of the chosen alternative
+        value: alloc::boxed::Box<AvnValue>,
+    },
+    /// Any character-string type: `"quoted string"` (X.680 double-quote escaping)
+    CharString(alloc::string::String),
+    /// Sentinel for absent OPTIONAL fields — must not appear in output
+    Absent,
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/// Helper that carries a depth counter for indentation.
+struct AvnFmt<'a> {
+    value: &'a AvnValue,
+    depth: usize,
+}
+
+impl<'a> AvnFmt<'a> {
+    fn new(value: &'a AvnValue, depth: usize) -> Self {
+        Self { value, depth }
+    }
+}
+
+impl fmt::Display for AvnFmt<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let depth = self.depth;
+        // Indentation strings: items at depth+1, closing brace at depth
+        let inner_indent = alloc::format!("{:width$}", "", width = (depth + 1) * 2);
+        let outer_indent = alloc::format!("{:width$}", "", width = depth * 2);
+
+        match self.value {
+            AvnValue::Boolean(b) => {
+                if *b {
+                    f.write_str("TRUE")
+                } else {
+                    f.write_str("FALSE")
+                }
+            }
+
+            AvnValue::Integer(s) => f.write_str(s),
+
+            AvnValue::OctetString(bytes) => {
+                f.write_str("'")?;
+                for b in bytes {
+                    write!(f, "{b:02X}")?;
+                }
+                f.write_str("'H")
+            }
+
+            AvnValue::BitString { bytes, bit_length } => {
+                if *bit_length == 0 {
+                    return f.write_str("''H");
+                }
+                if bit_length % 8 == 0 {
+                    // Byte-aligned: hex notation
+                    f.write_str("'")?;
+                    for b in bytes {
+                        write!(f, "{b:02X}")?;
+                    }
+                    f.write_str("'H")
+                } else {
+                    // Non-byte-aligned: binary notation — emit exactly bit_length bits from MSB
+                    f.write_str("'")?;
+                    let mut remaining = *bit_length;
+                    for b in bytes {
+                        let bits_in_this_byte = remaining.min(8);
+                        // Emit bits from MSB downward
+                        for shift in (8 - bits_in_this_byte..8).rev() {
+                            write!(f, "{}", (b >> shift) & 1)?;
+                        }
+                        remaining = remaining.saturating_sub(8);
+                        if remaining == 0 {
+                            break;
+                        }
+                    }
+                    f.write_str("'B")
+                }
+            }
+
+            AvnValue::Null => f.write_str("NULL"),
+
+            AvnValue::Oid(arcs) => {
+                f.write_str("{")?;
+                for arc in arcs {
+                    write!(f, " {arc}")?;
+                }
+                f.write_str(" }")
+            }
+
+            AvnValue::Real(s) => f.write_str(s),
+
+            AvnValue::Enumerated(id) => f.write_str(id),
+
+            AvnValue::Sequence(fields) => {
+                // Filter out Absent sentinels
+                let present: alloc::vec::Vec<_> = fields
+                    .iter()
+                    .filter(|(_, v)| !matches!(v, AvnValue::Absent))
+                    .collect();
+
+                if present.is_empty() {
+                    return f.write_str("{}");
+                }
+
+                writeln!(f, "{{")?;
+                for (idx, (name, val)) in present.iter().enumerate() {
+                    let comma = if idx + 1 < present.len() { "," } else { "" };
+                    writeln!(
+                        f,
+                        "{inner_indent}{name} {val}{comma}",
+                        val = AvnFmt::new(val, depth + 1)
+                    )?;
+                }
+                write!(f, "{outer_indent}}}")
+            }
+
+            AvnValue::SequenceOf(items) => {
+                if items.is_empty() {
+                    return f.write_str("{}");
+                }
+                writeln!(f, "{{")?;
+                for (idx, item) in items.iter().enumerate() {
+                    let comma = if idx + 1 < items.len() { "," } else { "" };
+                    writeln!(
+                        f,
+                        "{inner_indent}{val}{comma}",
+                        val = AvnFmt::new(item, depth + 1)
+                    )?;
+                }
+                write!(f, "{outer_indent}}}")
+            }
+
+            AvnValue::Choice { identifier, value } => {
+                write!(f, "{identifier} : {}", AvnFmt::new(value, depth))
+            }
+
+            AvnValue::CharString(s) => {
+                // X.680: embed a literal `"` as `""`
+                f.write_str("\"")?;
+                for ch in s.chars() {
+                    if ch == '"' {
+                        f.write_str("\"\"")?;
+                    } else {
+                        write!(f, "{ch}")?;
+                    }
+                }
+                f.write_str("\"")
+            }
+
+            AvnValue::Absent => Ok(()),
+        }
+    }
+}
+
+impl fmt::Display for AvnValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        AvnFmt::new(self, 0).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boolean_display() {
+        assert_eq!(AvnValue::Boolean(true).to_string(), "TRUE");
+        assert_eq!(AvnValue::Boolean(false).to_string(), "FALSE");
+    }
+
+    #[test]
+    fn integer_display() {
+        assert_eq!(AvnValue::Integer("42".into()).to_string(), "42");
+        assert_eq!(AvnValue::Integer("-1".into()).to_string(), "-1");
+    }
+
+    #[test]
+    fn null_display() {
+        assert_eq!(AvnValue::Null.to_string(), "NULL");
+    }
+
+    #[test]
+    fn octet_string_display() {
+        assert_eq!(AvnValue::OctetString(alloc::vec![]).to_string(), "''H");
+        assert_eq!(
+            AvnValue::OctetString(alloc::vec![0x01, 0xFF, 0xAB]).to_string(),
+            "'01FFAB'H"
+        );
+    }
+
+    #[test]
+    fn bit_string_hex_display() {
+        // Byte-aligned (8 bits)
+        let v = AvnValue::BitString {
+            bytes: alloc::vec![0xA0],
+            bit_length: 8,
+        };
+        assert_eq!(v.to_string(), "'A0'H");
+    }
+
+    #[test]
+    fn bit_string_empty_display() {
+        let v = AvnValue::BitString {
+            bytes: alloc::vec![],
+            bit_length: 0,
+        };
+        assert_eq!(v.to_string(), "''H");
+    }
+
+    #[test]
+    fn oid_display() {
+        let v = AvnValue::Oid(alloc::vec![1, 2, 840, 113549]);
+        assert_eq!(v.to_string(), "{ 1 2 840 113549 }");
+    }
+
+    #[test]
+    fn enumerated_display() {
+        assert_eq!(
+            AvnValue::Enumerated("someIdentifier".into()).to_string(),
+            "someIdentifier"
+        );
+    }
+
+    #[test]
+    fn char_string_display() {
+        assert_eq!(
+            AvnValue::CharString("hello".into()).to_string(),
+            "\"hello\""
+        );
+        // embedded quote must be doubled
+        assert_eq!(
+            AvnValue::CharString("say \"hi\"".into()).to_string(),
+            "\"say \"\"hi\"\"\""
+        );
+    }
+
+    #[test]
+    fn choice_display() {
+        let v = AvnValue::Choice {
+            identifier: "myField".into(),
+            value: alloc::boxed::Box::new(AvnValue::Boolean(true)),
+        };
+        assert_eq!(v.to_string(), "myField : TRUE");
+    }
+
+    #[test]
+    fn sequence_display() {
+        let v = AvnValue::Sequence(alloc::vec![
+            ("field1".into(), AvnValue::Boolean(true)),
+            ("field2".into(), AvnValue::Integer("42".into())),
+        ]);
+        let expected = "{\n  field1 TRUE,\n  field2 42\n}";
+        assert_eq!(v.to_string(), expected);
+    }
+
+    #[test]
+    fn sequence_of_display() {
+        let v = AvnValue::SequenceOf(alloc::vec![
+            AvnValue::Integer("1".into()),
+            AvnValue::Integer("2".into()),
+        ]);
+        let expected = "{\n  1,\n  2\n}";
+        assert_eq!(v.to_string(), expected);
+    }
+
+    #[test]
+    fn absent_display() {
+        assert_eq!(AvnValue::Absent.to_string(), "");
+    }
+}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -23,6 +23,8 @@ pub enum Codec {
     Coer,
     /// X.693 — XML Encoding Rules
     Xer,
+    /// ASN.1 Value Notation (X.680 text format)
+    Avn,
 }
 
 impl core::fmt::Display for Codec {
@@ -37,6 +39,7 @@ impl core::fmt::Display for Codec {
             Self::Oer => write!(f, "OER"),
             Self::Coer => write!(f, "COER"),
             Self::Xer => write!(f, "XER"),
+            Self::Avn => write!(f, "AVN"),
         }
     }
 }
@@ -61,6 +64,7 @@ impl Codec {
             Self::Oer => crate::oer::encode(value),
             Self::Coer => crate::coer::encode(value),
             Self::Xer => crate::xer::encode(value),
+            Self::Avn => crate::avn::encode(value).map(alloc::string::String::into_bytes),
         }
     }
 
@@ -93,6 +97,17 @@ impl Codec {
                 },
                 |s| crate::jer::decode(&s),
             ),
+            Self::Avn => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
+                |e| {
+                    Err(crate::error::DecodeError::from_kind(
+                        crate::error::DecodeErrorKind::Custom {
+                            msg: alloc::format!("Failed to decode AVN from UTF8 bytes: {e:?}"),
+                        },
+                        *self,
+                    ))
+                },
+                |s| crate::avn::decode(&s),
+            ),
         }
     }
     /// Decodes `input` to `D` based on the encoded defined by `Codec`, returning the decoded value and the remaining input.
@@ -120,6 +135,12 @@ impl Codec {
                 },
                 *self,
             )),
+            Self::Avn => Err(crate::error::DecodeError::from_kind(
+                crate::error::DecodeErrorKind::Custom {
+                    msg: "AVN does not support decoding with remainder. ".into(),
+                },
+                *self,
+            )),
         }
     }
 
@@ -135,6 +156,7 @@ impl Codec {
     ) -> Result<alloc::string::String, crate::error::EncodeError> {
         match self {
             Self::Jer => crate::jer::encode(value),
+            Self::Avn => crate::avn::encode(value),
             codec => Err(crate::error::EncodeError::from_kind(
                 crate::error::EncodeErrorKind::Custom {
                     msg: alloc::format!(
@@ -155,10 +177,11 @@ impl Codec {
     pub fn decode_from_str<D: Decode>(&self, input: &str) -> Result<D, crate::error::DecodeError> {
         match self {
             Self::Jer => crate::jer::decode(input),
+            Self::Avn => crate::avn::decode(input),
             codec => Err(crate::error::DecodeError::from_kind(
                 crate::error::DecodeErrorKind::Custom {
                     msg: alloc::format!(
-                        "{codec} is a text-based encoding. Call `Codec::decode_from_binary` instead."
+                        "{codec} is a binary-based encoding. Call `Codec::decode_from_binary` instead."
                     ),
                 },
                 *codec,

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,13 +20,14 @@ pub mod strings {
 
 pub use decode::DecodeErrorKind;
 pub use decode::{
-    BerDecodeErrorKind, CodecDecodeError, CoerDecodeErrorKind, DecodeError, DerDecodeErrorKind,
-    JerDecodeErrorKind, OerDecodeErrorKind, XerDecodeErrorKind,
+    AvnDecodeErrorKind, BerDecodeErrorKind, CodecDecodeError, CoerDecodeErrorKind, DecodeError,
+    DerDecodeErrorKind, JerDecodeErrorKind, OerDecodeErrorKind, XerDecodeErrorKind,
 };
 pub use encode::EncodeErrorKind;
 pub use encode::JerEncodeErrorKind;
 pub use encode::{
-    BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError, XerEncodeErrorKind,
+    AvnEncodeErrorKind, BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError,
+    XerEncodeErrorKind,
 };
 
 pub use components::InnerSubtypeConstraintError;

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -28,6 +28,7 @@ pub enum CodecDecodeError {
     Oer(OerDecodeErrorKind),
     Coer(CoerDecodeErrorKind),
     Xer(XerDecodeErrorKind),
+    Avn(AvnDecodeErrorKind),
 }
 
 impl core::fmt::Display for CodecDecodeError {
@@ -42,6 +43,7 @@ impl core::fmt::Display for CodecDecodeError {
             CodecDecodeError::Oer(kind) => write!(f, "OER decoding error: {kind}"),
             CodecDecodeError::Coer(kind) => write!(f, "COER decoding error: {kind}"),
             CodecDecodeError::Xer(kind) => write!(f, "XER decoding error: {kind}"),
+            CodecDecodeError::Avn(kind) => write!(f, "AVN decoding error: {kind}"),
         }
     }
 }
@@ -66,6 +68,7 @@ impl_from!(Jer, JerDecodeErrorKind);
 impl_from!(Oer, OerDecodeErrorKind);
 impl_from!(Coer, CoerDecodeErrorKind);
 impl_from!(Xer, XerDecodeErrorKind);
+impl_from!(Avn, AvnDecodeErrorKind);
 
 impl From<CodecDecodeError> for DecodeError {
     fn from(error: CodecDecodeError) -> Self {
@@ -436,6 +439,7 @@ impl DecodeError {
             CodecDecodeError::Oer(_) => crate::Codec::Oer,
             CodecDecodeError::Coer(_) => crate::Codec::Coer,
             CodecDecodeError::Xer(_) => crate::Codec::Xer,
+            CodecDecodeError::Avn(_) => crate::Codec::Avn,
         };
         Self {
             kind: Box::new(DecodeErrorKind::CodecSpecific { inner }),
@@ -1025,6 +1029,65 @@ impl OerDecodeErrorKind {
     #[must_use]
     pub fn invalid_preamble(msg: alloc::string::String) -> DecodeError {
         CodecDecodeError::Oer(Self::InvalidPreamble { msg }).into()
+    }
+}
+
+/// An error that occurred when decoding AVN.
+#[derive(Snafu, Debug)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum AvnDecodeErrorKind {
+    /// Unexpected end of AVN input.
+    #[snafu(display("Unexpected end of AVN input"))]
+    AvnEndOfInput {},
+    /// Mismatched AVN value type.
+    #[snafu(display("AVN type mismatch: expected {needed}, found {found}"))]
+    AvnTypeMismatch {
+        /// Expected type name.
+        needed: &'static str,
+        /// Found value description.
+        found: alloc::string::String,
+    },
+    /// Invalid hex string in AVN.
+    #[snafu(display("Invalid hex string in AVN"))]
+    InvalidHexString,
+    /// Invalid binary string in AVN.
+    #[snafu(display("Invalid binary string in AVN"))]
+    InvalidBinString,
+    /// Invalid OID value.
+    #[snafu(display("Invalid OID in AVN: {value}"))]
+    InvalidOid {
+        /// The invalid value string.
+        value: alloc::string::String,
+    },
+    /// Invalid enumerated discriminant.
+    #[snafu(display("Invalid enumerated discriminant in AVN: {discriminant}"))]
+    AvnInvalidEnumDiscriminant {
+        /// The invalid discriminant string.
+        discriminant: alloc::string::String,
+    },
+    /// Unexpected token found in AVN input.
+    #[snafu(display("Unexpected token in AVN: {found}"))]
+    UnexpectedToken {
+        /// Description of the unexpected token.
+        found: alloc::string::String,
+    },
+    /// Unterminated string literal.
+    #[snafu(display("Unterminated string literal in AVN"))]
+    UnterminatedString,
+    /// Integer parse error.
+    #[snafu(display("Integer parse error in AVN: {msg}"))]
+    IntegerParseError {
+        /// The error message.
+        msg: alloc::string::String,
+    },
+}
+
+impl AvnDecodeErrorKind {
+    /// Helper to create an end-of-input [`CodecDecodeError`].
+    #[must_use]
+    pub fn eoi() -> CodecDecodeError {
+        CodecDecodeError::Avn(AvnDecodeErrorKind::AvnEndOfInput {})
     }
 }
 

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -20,6 +20,7 @@ pub enum CodecEncodeError {
     Jer(JerEncodeErrorKind),
     Coer(CoerEncodeErrorKind),
     Xer(XerEncodeErrorKind),
+    Avn(AvnEncodeErrorKind),
 }
 
 impl core::fmt::Display for CodecEncodeError {
@@ -33,6 +34,7 @@ impl core::fmt::Display for CodecEncodeError {
             CodecEncodeError::Jer(kind) => write!(f, "JER encoding error: {kind}"),
             CodecEncodeError::Coer(kind) => write!(f, "COER encoding error: {kind}"),
             CodecEncodeError::Xer(kind) => write!(f, "XER encoding error: {kind}"),
+            CodecEncodeError::Avn(kind) => write!(f, "AVN encoding error: {kind}"),
         }
     }
 }
@@ -56,6 +58,7 @@ impl_from!(Aper, AperEncodeErrorKind);
 impl_from!(Jer, JerEncodeErrorKind);
 impl_from!(Coer, CoerEncodeErrorKind);
 impl_from!(Xer, XerEncodeErrorKind);
+impl_from!(Avn, AvnEncodeErrorKind);
 
 impl From<CodecEncodeError> for EncodeError {
     fn from(error: CodecEncodeError) -> Self {
@@ -261,6 +264,7 @@ impl EncodeError {
             CodecEncodeError::Jer(_) => crate::Codec::Jer,
             CodecEncodeError::Coer(_) => crate::Codec::Coer,
             CodecEncodeError::Xer(_) => crate::Codec::Xer,
+            CodecEncodeError::Avn(_) => crate::Codec::Avn,
         };
         Self {
             kind: Box::new(EncodeErrorKind::CodecSpecific { inner }),
@@ -476,6 +480,25 @@ pub enum CoerEncodeErrorKind {
     /// Error type for a secenario when the provided integer value exceeds the limits of the constrained word sizes.
     #[snafu(display("Provided integer exceeds limits of the constrained word sizes"))]
     InvalidConstrainedIntegerOctetSize,
+}
+
+/// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for AVN.
+#[derive(Snafu, Debug)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum AvnEncodeErrorKind {
+    /// Error to be thrown when the AVN encoder contains no encoded root value
+    #[snafu(display("No encoded AVN root value found"))]
+    AvnNoRootValueFound,
+    /// Internal AVN encoder error
+    #[snafu(display("Error in AVN encoder: {}", msg))]
+    AvnEncoder {
+        /// The error's message.
+        msg: alloc::string::String,
+    },
+    /// Error to be thrown when encoding real values that exceed the supported range
+    #[snafu(display("Exceeds supported real value range for AVN encoding"))]
+    AvnExceedsSupportedRealRange,
 }
 
 impl crate::enc::Error for EncodeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod types;
 // Data Formats
 
 pub mod aper;
+pub mod avn;
 pub mod ber;
 pub mod cer;
 pub mod coer;


### PR DESCRIPTION
Add a new `Codec::Avn` variant implementing the ASN.1 Value Notation text format as defined in ITU-T X.680. AVN is the native textual representation used in ASN.1 modules for DEFAULT values and value assignments, distinct from JER (JSON) and XER (XML).

Architecture mirrors the JER codec:
- `src/avn/value.rs`: `AvnValue` IR enum with `Display` impl for pretty-printed output (indented SEQUENCEs, `'HEX'H`/`'BIN'B` bit strings, `{ arc... }` OIDs, `id : val` CHOICEs)
- `src/avn/enc.rs`: `Encoder` struct preserving SEQUENCE field declaration order via `Vec<(String, AvnValue)>` (vs JER's BTreeMap)
- `src/avn/de.rs`: two-phase decode — recursive-descent lexer/parser producing `AvnValue` tree, then type-directed dispatch; handles space-separated OID arc notation and underscore identifiers
- Error types `AvnDecodeErrorKind` / `AvnEncodeErrorKind` integrated into the existing snafu error hierarchy
- `Codec::Avn` dispatch wired into all five `Codec` methods

Key format rules:
- BOOLEAN: `TRUE` / `FALSE`
- OCTET STRING: `'01FF'H`
- BIT STRING: `'A0'H` (byte-aligned) or `'10'B` (non-byte-aligned)
- OID: `{ 2 5 4 3 }` (space-separated, no commas)
- SEQUENCE: `{\n  field value,\n  ...\n}`
- CHOICE: `identifier : value`
- Absent OPTIONAL fields omitted entirely

Round-trip tests cover: bool, integer, null, octet string, bit string, OID, enumerated, choice, sequence-of, nested sequences with absent optionals, and hyphenated/underscored field identifiers.