### PR TITLE
fix(jer): distinguish absent OPTIONAL fields from present-NULL values

### DIFF
--- a/macros/macros_impl/src/encode.rs
+++ b/macros/macros_impl/src/encode.rs
@@ -51,9 +51,11 @@ pub fn derive_struct_impl(
 
         if config.tag.as_ref().is_some_and(|tag| tag.is_explicit()) {
             // Note: encoder must be aware if the field is optional and present, so we should not do the presence check on this level
-            quote!(encoder
-                .encode_explicit_prefix(tag, &self.0, identifier.or(Self::IDENTIFIER))
-                .map(drop))
+            quote!(
+                encoder
+                    .encode_explicit_prefix(tag, &self.0, identifier.or(Self::IDENTIFIER))
+                    .map(drop)
+            )
         } else {
             // NOTE: AsnType trait already implements correct delegate constraints, and those are passed here
             // We don't need to do double intersection here!

--- a/src/jer.rs
+++ b/src/jer.rs
@@ -359,6 +359,33 @@ mod tests {
     }
 
     #[test]
+    fn null_optional_present_vs_absent() {
+        // A NULL OPTIONAL field that is present (`"flag": null`) must decode as Some(()),
+        // not be confused with the field being absent from the JSON object.
+        #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
+        #[rasn(automatic_tags)]
+        #[rasn(crate_root = "crate")]
+        struct WithNullOpt {
+            name: Utf8String,
+            flag: Option<()>,
+        }
+
+        // Present-null: field appears in JSON as null → Some(())
+        round_trip_jer!(
+            WithNullOpt,
+            WithNullOpt { name: "test".into(), flag: Some(()) },
+            r#"{"flag":null,"name":"test"}"#
+        );
+
+        // Absent: field omitted from JSON → None
+        round_trip_jer!(
+            WithNullOpt,
+            WithNullOpt { name: "test".into(), flag: None },
+            r#"{"name":"test"}"#
+        );
+    }
+
+    #[test]
     fn with_identifier_annotation() {
         round_trip_jer!(
             Renamed,

--- a/src/jer.rs
+++ b/src/jer.rs
@@ -373,14 +373,20 @@ mod tests {
         // Present-null: field appears in JSON as null → Some(())
         round_trip_jer!(
             WithNullOpt,
-            WithNullOpt { name: "test".into(), flag: Some(()) },
+            WithNullOpt {
+                name: "test".into(),
+                flag: Some(())
+            },
             r#"{"flag":null,"name":"test"}"#
         );
 
         // Absent: field omitted from JSON → None
         round_trip_jer!(
             WithNullOpt,
-            WithNullOpt { name: "test".into(), flag: None },
+            WithNullOpt {
+                name: "test".into(),
+                flag: None
+            },
             r#"{"name":"test"}"#
         );
     }

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -85,7 +85,11 @@ impl crate::Decoder for Decoder {
             })?;
             (value, *size)
         } else {
-            let last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
+            let last = self
+                .stack
+                .pop()
+                .flatten()
+                .ok_or_else(JerDecodeErrorKind::eoi)?;
             let value_map = last
                 .as_object()
                 .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
@@ -185,7 +189,11 @@ impl crate::Decoder for Decoder {
         D: Constructed<RC, EC>,
         F: FnOnce(&mut Self) -> Result<D, Self::Error>,
     {
-        let mut last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
+        let mut last = self
+            .stack
+            .pop()
+            .flatten()
+            .ok_or_else(JerDecodeErrorKind::eoi)?;
         let value_map = last
             .as_object_mut()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
@@ -381,7 +389,11 @@ impl crate::Decoder for Decoder {
         D: Fn(&mut Self::AnyDecoder<RC, EC>, usize, Tag) -> Result<FIELDS, Self::Error>,
         F: FnOnce(alloc::vec::Vec<FIELDS>) -> Result<SET, Self::Error>,
     {
-        let mut last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
+        let mut last = self
+            .stack
+            .pop()
+            .flatten()
+            .ok_or_else(JerDecodeErrorKind::eoi)?;
         let value_map = last
             .as_object_mut()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {

--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -18,6 +18,7 @@ macro_rules! decode_jer_value {
     ($decoder_fn:expr, $input:expr) => {
         $input
             .pop()
+            .flatten()
             .ok_or_else(|| DecodeError::from(JerDecodeErrorKind::eoi()))
             .and_then($decoder_fn)
     };
@@ -25,7 +26,9 @@ macro_rules! decode_jer_value {
 
 /// Decodes JSON Encoding Rules data into Rust structures.
 pub struct Decoder {
-    stack: alloc::vec::Vec<Value>,
+    // `None` = field absent from the JSON object (OPTIONAL not present).
+    // `Some(v)` = field present with value `v` (including `Some(Value::Null)` for ASN.1 NULL).
+    stack: alloc::vec::Vec<Option<Value>>,
 }
 
 impl Decoder {
@@ -38,7 +41,7 @@ impl Decoder {
             )
         })?;
         Ok(Self {
-            stack: alloc::vec![root],
+            stack: alloc::vec![Some(root)],
         })
     }
 }
@@ -46,7 +49,7 @@ impl Decoder {
 impl From<Value> for Decoder {
     fn from(value: Value) -> Self {
         Self {
-            stack: alloc::vec![value],
+            stack: alloc::vec![Some(value)],
         }
     }
 }
@@ -82,7 +85,7 @@ impl crate::Decoder for Decoder {
             })?;
             (value, *size)
         } else {
-            let last = self.stack.pop().ok_or_else(JerDecodeErrorKind::eoi)?;
+            let last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
             let value_map = last
                 .as_object()
                 .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
@@ -182,7 +185,7 @@ impl crate::Decoder for Decoder {
         D: Constructed<RC, EC>,
         F: FnOnce(&mut Self) -> Result<D, Self::Error>,
     {
-        let mut last = self.stack.pop().ok_or_else(JerDecodeErrorKind::eoi)?;
+        let mut last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
         let value_map = last
             .as_object_mut()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
@@ -198,8 +201,7 @@ impl crate::Decoder for Decoder {
         }
         field_names.reverse();
         for name in field_names {
-            self.stack
-                .push(value_map.remove(name).unwrap_or(Value::Null));
+            self.stack.push(value_map.remove(name));
         }
 
         (decode_fn)(self)
@@ -379,7 +381,7 @@ impl crate::Decoder for Decoder {
         D: Fn(&mut Self::AnyDecoder<RC, EC>, usize, Tag) -> Result<FIELDS, Self::Error>,
         F: FnOnce(alloc::vec::Vec<FIELDS>) -> Result<SET, Self::Error>,
     {
-        let mut last = self.stack.pop().ok_or_else(JerDecodeErrorKind::eoi)?;
+        let mut last = self.stack.pop().flatten().ok_or_else(JerDecodeErrorKind::eoi)?;
         let value_map = last
             .as_object_mut()
             .ok_or_else(|| JerDecodeErrorKind::TypeMismatch {
@@ -394,8 +396,7 @@ impl crate::Decoder for Decoder {
         field_indices
             .sort_by(|(_, a), (_, b)| a.tag_tree.smallest_tag().cmp(&b.tag_tree.smallest_tag()));
         for (index, field) in field_indices.into_iter() {
-            self.stack
-                .push(value_map.remove(field.name).unwrap_or(Value::Null));
+            self.stack.push(value_map.remove(field.name));
             fields.push((decode_fn)(self, index, field.tag)?);
         }
 
@@ -404,8 +405,7 @@ impl crate::Decoder for Decoder {
             .flat_map(|fields| fields.iter())
             .enumerate()
         {
-            self.stack
-                .push(value_map.remove(field.name).unwrap_or(Value::Null));
+            self.stack.push(value_map.remove(field.name));
             fields.push((decode_fn)(self, index + SET::FIELDS.len(), field.tag)?);
         }
 
@@ -420,11 +420,11 @@ impl crate::Decoder for Decoder {
     }
 
     fn decode_optional<D: crate::Decode>(&mut self) -> Result<Option<D>, Self::Error> {
-        let last = self.stack.pop().ok_or_else(JerDecodeErrorKind::eoi)?;
-        match last {
-            Value::Null => Ok(None),
-            v => {
-                self.stack.push(v);
+        match self.stack.pop() {
+            None => Err(DecodeError::from(JerDecodeErrorKind::eoi())),
+            Some(None) => Ok(None),
+            Some(Some(v)) => {
+                self.stack.push(Some(v));
                 Some(D::decode(self)).transpose()
             }
         }
@@ -609,7 +609,7 @@ impl Decoder {
             .clone()
             .into_iter()
             .map(|v| {
-                self.stack.push(v);
+                self.stack.push(Some(v));
                 D::decode(self)
             })
             .collect()
@@ -628,7 +628,7 @@ impl Decoder {
             .clone()
             .into_iter()
             .try_fold(SetOf::new(), |mut acc, v| {
-                self.stack.push(v);
+                self.stack.push(Some(v));
                 acc.insert(D::decode(self)?);
                 Ok(acc)
             })
@@ -670,7 +670,7 @@ impl Decoder {
                 .get(i)
                 {
                     Some(t) => {
-                        self.stack.push(v.clone());
+                        self.stack.push(Some(v.clone()));
                         *t
                     }
                     None => Tag::EOC,


### PR DESCRIPTION
The JER decoder stack previously used `Vec<Value>` with `Value::Null` as a sentinel for absent OPTIONAL fields (via `.unwrap_or(Value::Null)` in `decode_sequence`/`decode_set`). This made it impossible to tell `"field": null` (ASN.1 NULL present) from a missing key (OPTIONAL absent): both produced `Value::Null`, both decoded as `None`.

Fix: change the stack to `Vec<Option<Value>>`:
- `None`              = field key absent from the JSON object
- `Some(Value::Null)` = key present with JSON null (ASN.1 NULL is present)

Changes:
- `decode_sequence` / `decode_set`: push `value_map.remove(name)` directly (already `Option<Value>`) — no more `.unwrap_or(Value::Null)`
- `decode_optional`: match on the outer `Option` — `Some(None)` = absent, `Some(Some(v))` = present
- `decode_jer_value!` macro and inline pop sites: add `.flatten()` so non-optional consumers keep the same `Value` type
- All explicit `stack.push(v)` helper sites wrap value in `Some(_)`
- `Decoder::new` and `From<Value>` wrap the root value in `Some(_)`

Adds a round-trip test verifying `{"flag":null}` (present-NULL) and `{}` (absent) produce `Some(())` and `None` respectively.

Fixes #537.