### PR TITLE
WIP: add ITS standard ETSI TS 103301

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +46,12 @@ name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-slice"
@@ -81,7 +81,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -199,7 +199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
 dependencies = [
  "bitvec",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -262,16 +262,15 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -449,7 +448,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -517,6 +516,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "flagset"
@@ -709,6 +717,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -751,6 +762,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1009,7 +1029,7 @@ dependencies = [
  "cryptography-x509",
  "either",
  "iai-callgrind",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1017,7 +1037,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
- "rasn-compiler",
+ "rasn-compiler 0.7.5",
  "rasn-derive",
  "rasn-derive-impl",
  "rasn-its",
@@ -1084,7 +1104,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d5816cedd3af9154bb693828b9e82b70ca7c52ee0cdf7bf2172772e70bd2891"
 dependencies = [
  "chrono",
- "nom",
+ "nom 7.1.3",
+ "num",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rasn-compiler"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91a52dc3da30fea05dad6eff23bc87e3661c191296bee8e96fe8853cff4e594"
+dependencies = [
+ "chrono",
+ "nom 8.0.0",
  "num",
  "proc-macro2",
  "quote",
@@ -1131,9 +1166,13 @@ dependencies = [
 name = "rasn-its"
 version = "0.28.10"
 dependencies = [
+ "anyhow",
  "bon",
+ "encoding_rs",
+ "lazy_static",
  "pretty_assertions",
  "rasn",
+ "rasn-compiler 0.16.0",
 ]
 
 [[package]]
@@ -1262,7 +1301,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1387,6 +1426,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -1645,7 +1690,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result",
  "windows-strings",
 ]
@@ -1679,12 +1724,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -1693,7 +1744,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -1837,7 +1888,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -43,9 +43,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -124,15 +124,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -140,7 +140,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -151,15 +151,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcder"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ffdaa8c6398acd07176317eb6c1f9082869dd1cc3fee7c72c6354866b928cc"
+checksum = "b593e5aeaf7992d388c08a9831c921cd703718064b3e50ba8e6d666d6cf86ca7"
 dependencies = [
  "bytes",
  "smallvec",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.5.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65268237be94042665b92034f979c42d431d2fd998b49809543afe3e66abad1c"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.5.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803c95b2ecf650eb10b5f87dda6b9f6a1b758cee53245e2b7b825c9b3803a443"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling",
  "ident_case",
@@ -229,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -247,30 +247,31 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -302,18 +303,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -321,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "const-oid"
@@ -374,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cryptography-x509"
@@ -388,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -398,11 +399,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -423,15 +423,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -467,30 +467,28 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -502,9 +500,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -513,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -527,16 +525,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "funty"
@@ -545,43 +555,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -591,9 +642,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -603,9 +654,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22275f8051874cd2f05b2aa1e0098d5cbec34df30ff92f1a1e2686a4cefed870"
+checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
 dependencies = [
  "bincode",
  "derive_more",
@@ -615,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e6677dc52bd798b988e62ffd6831bf7eb46e4348cb1c74c1164954ebd0e5a1"
+checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
 dependencies = [
  "derive_more",
  "proc-macro-error2",
@@ -630,18 +681,18 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02dd95fe4949513b45a328b5b18f527ee02e96f3428b48090aa7cf9043ab0b8"
+checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -662,20 +713,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
+name = "indexmap"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -698,17 +767,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -722,22 +792,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.171"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -747,9 +823,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -807,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -852,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -870,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -882,12 +958,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -898,6 +974,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -945,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -977,27 +1059,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1011,7 +1093,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1115,15 +1197,13 @@ dependencies = [
 [[package]]
 name = "rasn-compiler"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91a52dc3da30fea05dad6eff23bc87e3661c191296bee8e96fe8853cff4e594"
+source = "git+https://github.com/schphil/compiler.git?rev=51e27a43de53c7e2499daf411aea2c1c85c2dedd#51e27a43de53c7e2499daf411aea2c1c85c2dedd"
 dependencies = [
  "chrono",
  "nom 8.0.0",
  "num",
  "proc-macro2",
  "quote",
- "regex",
  "wasm-bindgen",
 ]
 
@@ -1248,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1260,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1271,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -1283,7 +1363,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1291,9 +1371,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -1306,9 +1395,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1323,15 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -1341,6 +1427,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1374,21 +1466,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1400,16 +1493,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.14.0"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
 dependencies = [
  "backtrace",
  "snafu-derive",
@@ -1417,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1451,9 +1550,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1462,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1499,30 +1598,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1561,9 +1659,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1573,11 +1677,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
 ]
 
 [[package]]
@@ -1592,50 +1696,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1643,31 +1743,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1675,31 +1809,31 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.1",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1708,20 +1842,14 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-link"
@@ -1731,20 +1859,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1758,11 +1886,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1830,12 +1958,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1908,21 +2121,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
-name = "zeroize"
-version = "1.8.1"
+name = "zerocopy"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/standards/its/Cargo.toml
+++ b/standards/its/Cargo.toml
@@ -11,7 +11,13 @@ default = ["rasn/f32", "rasn/f64", "rasn/bytes"]
 
 [dependencies]
 bon = { version = "3.5", default-features = false }
+lazy_static = { version = "1", features = ["spin_no_std"] }
 rasn = { path = "../..", version = "0.28", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+
+[build-dependencies]
+anyhow = "1"
+encoding_rs = "0.8.35"
+rasn-compiler = "0.16.0"

--- a/standards/its/Cargo.toml
+++ b/standards/its/Cargo.toml
@@ -20,4 +20,4 @@ pretty_assertions = "1.4.1"
 [build-dependencies]
 anyhow = "1"
 encoding_rs = "0.8.35"
-rasn-compiler = "0.16.0"
+rasn-compiler = { git = "https://github.com/schphil/compiler.git", rev = "51e27a43de53c7e2499daf411aea2c1c85c2dedd" }

--- a/standards/its/README.md
+++ b/standards/its/README.md
@@ -2,4 +2,5 @@
 
 This crate currently includes `rasn` implementation of the following standards
  * IEEE 1609.2 2022 (module ieee1609dot2)
+ * ETSI TS 102 894-2 (module ts1028942)
  * ETSI TS 103 097 (module ts103097)

--- a/standards/its/README.md
+++ b/standards/its/README.md
@@ -4,3 +4,4 @@ This crate currently includes `rasn` implementation of the following standards
  * IEEE 1609.2 2022 (module ieee1609dot2)
  * ETSI TS 102 894-2 (module ts1028942)
  * ETSI TS 103 097 (module ts103097)
+ * ETSI TS 103 301 (module ts103301)

--- a/standards/its/build.rs
+++ b/standards/its/build.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Ok, Result};
+use rasn_compiler::{OutputMode::SingleFile, prelude::*};
+
+fn compile_ts102894_2() -> Result<()> {
+    Compiler::<RasnBackend, _>::new_with_config(RasnConfig {
+        opaque_open_types: false,
+        default_wildcard_imports: false,
+        no_std_compliant_bindings: true,
+        ..Default::default()
+    })
+    .add_asn_by_path("src/ts102894_2/asn1/ETSI-ITS-CDD.asn")
+    .set_output_mode(SingleFile(PathBuf::from("./src/ts102894_2/mod.rs")))
+    .compile()
+    .map_err(|e| anyhow::anyhow!("{e:?}"))
+    .context("Failed to compile CDD ASN source")?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    compile_ts102894_2()?;
+
+    Ok(())
+}

--- a/standards/its/build.rs
+++ b/standards/its/build.rs
@@ -19,8 +19,37 @@ fn compile_ts102894_2() -> Result<()> {
     Ok(())
 }
 
+fn compile_ts103301() -> Result<()> {
+    Compiler::<RasnBackend, _>::new_with_config(RasnConfig {
+        opaque_open_types: false,
+        default_wildcard_imports: false,
+        no_std_compliant_bindings: true,
+        ..Default::default()
+    })
+    .add_asn_sources_by_path(
+        [
+            PathBuf::from("src/ts103301/asn1/DSRC.asn"),
+            PathBuf::from("src/ts103301/asn1/DSRC-addgrp-C.asn"),
+            PathBuf::from("src/ts103301/asn1/DSRC-region.asn"),
+            PathBuf::from("src/ts103301/asn1/MAPEM-PDU-Descriptions.asn"),
+            PathBuf::from("src/ts103301/asn1/RTCMEM-PDU-Descriptions.asn"),
+            PathBuf::from("src/ts103301/asn1/SPATEM-PDU-Descriptions.asn"),
+            PathBuf::from("src/ts103301/asn1/SREM-PDU-Descriptions.asn"),
+            PathBuf::from("src/ts103301/asn1/SSEM-PDU-Descriptions.asn"),
+        ]
+        .iter(),
+    )
+    .set_output_mode(SingleFile(PathBuf::from("./src/ts103301/ts103301.rs")))
+    .compile()
+    .map_err(|e| anyhow::anyhow!("{e:?}"))
+    .context("Failed to compile ts103301 source")?;
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
     compile_ts102894_2()?;
+    compile_ts103301()?;
 
     Ok(())
 }

--- a/standards/its/src/lib.rs
+++ b/standards/its/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(not(test), no_std)]
 extern crate alloc;
 
+/// ASN.1 definitions for ETSI TS 102 894-2
+pub mod ts102894_2;
+
 /// ASN.1 definitions for ETSI TS 103 097
 pub mod ts103097;
 

--- a/standards/its/src/lib.rs
+++ b/standards/its/src/lib.rs
@@ -7,6 +7,9 @@ pub mod ts102894_2;
 /// ASN.1 definitions for ETSI TS 103 097
 pub mod ts103097;
 
+/// ASN.1 definitions for ETSI TS 103 301
+pub mod ts103301;
+
 /// ASN.1 definitions for IEEE 1609.2
 pub mod ieee1609dot2;
 

--- a/standards/its/src/ts102894_2/README.md
+++ b/standards/its/src/ts102894_2/README.md
@@ -1,0 +1,3 @@
+# `rasn` implementation of ETSI TS 102 894-2
+
+Based on ASN.1 defined in [here](https://forge.etsi.org/rep/ITS/asn1/cdd_ts102894_2).

--- a/standards/its/src/ts102894_2/asn1/ETSI-ITS-CDD.asn
+++ b/standards/its/src/ts102894_2/asn1/ETSI-ITS-CDD.asn
@@ -1,0 +1,7800 @@
+ETSI-ITS-CDD {itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-3 (3)}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+------------------------------------------
+-- Specification of CDD Data Elements: 
+------------------------------------------
+
+/** 
+ * This DE indicates a change of acceleration.
+ *
+ * The value shall be set to:
+ * - 0 - `accelerate` - if the magnitude of the horizontal velocity vector increases.
+ * - 1 - `decelerate` - if the magnitude of the horizontal velocity vector decreases.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+AccelerationChange::= ENUMERATED { 
+    accelerate (0), 
+    decelerate (1) 
+}
+
+/**
+ * This DE indicates the acceleration confidence value which represents the estimated absolute accuracy of an acceleration value with a default confidence level of 95 %. 
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 101`) if the confidence value is equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `101` if the confidence value is out of range i.e. greater than 10 m/s^2,
+ * - `102` if the confidence value is unavailable.
+ *
+ * The value 0 shall not be used.
+ *
+ * @note: The fact that an acceleration value is received with confidence value set to `unavailable(102)` can be caused by several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the acceleration value may be valid and used by the application.
+ * 
+ * @note: If an acceleration value is received and its confidence value is set to `outOfRange(101)`, it means that the value is not valid and therefore cannot be trusted. Such value is not useful for the application.
+ *
+ * @unit 0,1 m/s^2
+ * @category: Kinematic information
+ * @revision: Description revised in V2.1.1
+ */
+AccelerationConfidence ::= INTEGER {
+    outOfRange                 (101), 
+    unavailable                (102)
+} (0..102)
+
+/**
+ * This DE indicates the status of the controlling mechanisms for longitudinal movement of the vehicle.
+ * The data may be provided via the in-vehicle network. It indicates whether a specific in-vehicle
+ * acceleration control system is engaged or not. 
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 - `brakePedalEngaged`      - Driver is stepping on the brake pedal,
+ * - 1 - `gasPedalEngaged`        - Driver is stepping on the gas pedal,
+ * - 2 - `emergencyBrakeEngaged`  - emergency brake system is engaged,
+ * - 3 - `collisionWarningEngaged`- collision warning system is engaged,
+ * - 4 - `accEngaged`             - ACC is engaged,
+ * - 5 - `cruiseControlEngaged`   - cruise control is engaged,
+ * - 6 - `speedLimiterEngaged`    - speed limiter is engaged.
+ *
+ * Otherwise (for example when the corresponding system is not available due to non equipped system
+ * or information is unavailable), the corresponding bit shall be set to 0.
+ *
+ * @note: The system engagement condition is OEM specific and therefore out of scope of the present document.
+ * @category: Vehicle information
+ * @revision: V1.3.1, description revised in V2.3.1
+ */
+AccelerationControl ::= BIT STRING {
+    brakePedalEngaged       (0),
+    gasPedalEngaged         (1),
+    emergencyBrakeEngaged   (2),
+    collisionWarningEngaged (3),
+    accEngaged              (4),
+    cruiseControlEngaged    (5),
+    speedLimiterEngaged     (6)
+} (SIZE(7))
+
+/**
+ * This DE represents the extension of DE AccelerationControl and should only be used together with DE AccelerationControl.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0  - `rearCrossTrafficAlertEngaged`       - rear cross traffic alert system is engaged
+ * - 1  - `emergencyBrakeRearEngaged`          - emergency brake system for rear driving is engaged
+ * - 2  - `assistedParkingLongitudinalEngaged` - assisted parking system (longitudinal control) is engaged
+ *
+ * Otherwise (for example when the corresponding system is not available due to non-equipped system 
+ * or information is unavailable), the corresponding bit shall be set to 0. 
+ *
+ * @category: Vehicle information
+ * @revision: Created in V2.3.1
+ */
+AccelerationControlExtension::= BIT STRING {    
+	rearCrossTrafficAlertEngaged (0),
+	emergencyBrakeRearEngaged (1),
+	assistedParkingLongitudinalEngaged (2)
+} (SIZE(3,...))
+
+
+/** 
+ * This DE represents the magnitude of the acceleration vector in a defined coordinate system.
+ *
+ * The value shall be set to:
+ * - `0` to indicate no acceleration,
+ * - `n` (`n > 0` and `n < 160`) to indicate acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `160` for acceleration values greater than 15,9 m/s^2,
+ * - `161` when the data is unavailable.
+ *
+ * @unit 0,1 m/s^2
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+AccelerationMagnitudeValue ::= INTEGER {
+    positiveOutOfRange (160),
+    unavailable        (161)  
+} (0.. 161)
+
+/** 
+ * This DE represents the value of an acceleration component in a defined coordinate system.
+ *
+ * The value shall be set to:
+ * - `-160` for acceleration values equal to or less than -16 m/s^2,
+ * - `n` (`n > -160` and `n <= 0`) to indicate negative acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `n` (`n > 0` and `n < 160`) to indicate positive acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `160` for acceleration values greater than 15,9 m/s^2,
+ * - `161` when the data is unavailable.
+ *
+ * @note: the formula for values > -160 and <160 results in rounding up to the next value. Zero acceleration is indicated using n=0.
+ * @unit 0,1 m/s^2
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+AccelerationValue ::= INTEGER {
+    negativeOutOfRange (-160),
+    positiveOutOfRange (160),
+    unavailable        (161)  
+} (-160 .. 161)
+
+
+/**
+ * This DE indicates an access technology.
+ *
+ * The value shall be set to:
+ * - `0`: in case of any access technology class,
+ * - `1`: in case of ITS-G5 access technology class,
+ * - `2`: in case of LTE-V2X access technology class,
+ * - `3`: in case of NR-V2X access technology class.
+ * 
+ * @category: Communication information
+ * @revision: Created in V2.1.1
+ */
+AccessTechnologyClass ::= ENUMERATED {
+   any         (0), 
+   itsg5Class  (1), 
+   ltev2xClass (2), 
+   nrv2xClass  (3),
+   ...
+}
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `accident`.
+ *
+ * The value shall be set to:
+ * - 0 - `unavailable`                        - in case the information on the sub cause of the accident is unavailable,
+ * - 1 - `multiVehicleAccident`               - in case more than two vehicles are involved in accident,
+ * - 2 - `heavyAccident`                      - in case the airbag of the vehicle involved in the accident is triggered, 
+ *                                              the accident requires important rescue and/or recovery work,
+ * - 3 - `accidentInvolvingLorry`             - in case the accident involves a lorry,
+ * - 4 - `accidentInvolvingBus`               - in case the accident involves a bus,
+ * - 5 - `accidentInvolvingHazardousMaterials`- in case the accident involves hazardous material,
+ * - 6 - `accidentOnOppositeLane-deprecated`  - deprecated,
+ * - 7 - `unsecuredAccident`                  - in case the accident is not secured,
+ * - 8 - `assistanceRequested`                - in case rescue and assistance are requested,
+ * - 9-255                                    - reserved for future usage. 
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 6 deprecated in V2.4.1
+ */
+AccidentSubCauseCode ::= INTEGER {
+    unavailable                         (0),
+    multiVehicleAccident                (1),
+    heavyAccident                       (2),
+    accidentInvolvingLorry              (3),
+    accidentInvolvingBus                (4),
+    accidentInvolvingHazardousMaterials (5),
+    accidentOnOppositeLane-deprecated   (6),
+    unsecuredAccident                   (7),
+    assistanceRequested                 (8)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `adhesion`. 
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`     - in case information on the cause of the low road adhesion is unavailable,
+ * - 1 - `heavyFrostOnRoad`- in case the low road adhesion is due to heavy frost on the road,
+ * - 2 - `fuelOnRoad`      - in case the low road adhesion is due to fuel on the road,
+ * - 3 - `mudOnRoad`       - in case the low road adhesion is due to mud on the road,
+ * - 4 - `snowOnRoad`      - in case the low road adhesion is due to snow on the road,
+ * - 5 - `iceOnRoad`       - in case the low road adhesion is due to ice on the road,
+ * - 6 - `blackIceOnRoad`  - in case the low road adhesion is due to black ice on the road,
+ * - 7 - `oilOnRoad`       - in case the low road adhesion is due to oil on the road,
+ * - 8 - `looseChippings`  - in case the low road adhesion is due to loose gravel or stone fragments on the road,
+ * - 9 - `instantBlackIce` - in case the low road adhesion is due to instant black ice on the road surface,
+ * - 10 - `roadsSalted`    - when the low road adhesion is due to salted road,
+ * - 11 - `flooding`       - in case low road adhesion is due to flooding of the road,
+ * - 12 - `waterOnRoad`    - in case low road adhesion is due to a shallow layer of standing water on the road (not flooding). 
+ * - 12-255                - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, name changed to AdhesionSubCauseCode in V2.4.1, value 11 moved from hazardousLocation-SurfaceCondition to this DE and value 12 added in V2.4.1 
+ */
+AdhesionSubCauseCode ::= INTEGER {
+    unavailable      (0),
+    heavyFrostOnRoad (1),
+    fuelOnRoad       (2),
+    mudOnRoad        (3),
+    snowOnRoad       (4),
+    iceOnRoad        (5),
+    blackIceOnRoad   (6),
+    oilOnRoad        (7),
+    looseChippings   (8),
+    instantBlackIce  (9),
+    roadsSalted      (10),
+    flooding         (11),
+    waterOnRoad      (12) 
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Wind`.
+ *
+ * The value shall be set to:
+ * - 0 - `unavailable`             - in case information on the type of wind is unavailable,
+ * - 1 - `strongWinds`             - in case the type of wind is strong wind such as gale or storm (e.g. Beaufort scale number 9-11),
+ * - 2 - `damagingHail-deprecated` - deprecated since not representing a wind related event,
+ * - 3 - `hurricane`               - in case the type of storm is hurricane (e.g. Beaufort scale number 12),
+ * - 4 - `thunderstorm`            - in case the type of storm is thunderstorm,
+ * - 5 - `tornado`                 - in case the type of storm is tornado,
+ * - 6 - `blizzard`                - in case the type of storm is blizzard.
+ * - 7-255                         - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, DE renamed in V2.4.1, value 2 deprecated, description of value 1 and 3  amended in V2.4.1
+ */
+AdverseWeatherCondition-WindSubCauseCode ::= INTEGER {
+    unavailable             (0),
+    strongWinds             (1),
+    damagingHail-deprecated (2),
+    hurricane               (3),
+    thunderstorm            (4),
+    tornado                 (5),
+    blizzard                (6)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Precipitation`. 
+ *
+ * The value shall be set to:
+ * - 0 - `unavailable`   - in case information on the type of precipitation is unavailable,
+ * - 1 - `rain`          - in case the type of precipitation is rain,
+ * - 2 - `snowfall`      - in case the type of precipitation is snowfall,
+ * - 3 - `hail`          - in case the type of precipitation is hail.
+ * - 4-255               - are reserved for future usage
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, values 1,2,3 renamed in V2.4.1
+ */
+AdverseWeatherCondition-PrecipitationSubCauseCode ::= INTEGER {
+    unavailable  (0),
+    rain         (1),
+    snowfall     (2),
+    hail         (3)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Visibility`.
+ *
+ * The value shall be set to:
+ * - 0 - `unavailable`    - in case information on the cause of low visibility is unavailable,
+ * - 1 - `fog`            - in case the cause of low visibility is fog,
+ * - 2 - `smoke`          - in case the cause of low visibility is smoke,
+ * - 3 - `snowfall`       - in case the cause of low visibility is snow fall,
+ * - 4 - `rain`           - in case the cause of low visibility is rain,
+ * - 5 - `hail`           - in case the cause of low visibility is hail,
+ * - 6 - `lowSunGlare`    - in case the cause of low visibility is sun glare,
+ * - 7 - `sandstorms`     - in case the cause of low visibility is sand storm,
+ * - 8 - `swarmsOfInsects`- in case the cause of low visibility is swarm of insects.
+ * - 9-255                - are reserved for future usage
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, values 3, 4, 5 renamed in V2.4.1
+ */
+AdverseWeatherCondition-VisibilitySubCauseCode ::= INTEGER {
+    unavailable     (0),
+    fog             (1),
+    smoke           (2),
+    snowfall        (3),
+    rain            (4),
+    hail            (5),
+    lowSunGlare     (6),
+    sandstorms      (7),
+    swarmsOfInsects (8)
+} (0..255)
+
+/**
+ * This DE represents the air humidity in tenths of percent.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 1001`) indicates that the applicable value is equal to or less than n x 0,1 percent and greater than (n-1) x 0,1 percent.
+ * - `1001` indicates that the air humidity is unavailable.
+ *
+ * @category: Basic information
+ * @unit: 0,1 % 
+ * @revision: created in V2.1.1
+ */
+AirHumidity ::= INTEGER {
+	oneHundredPercent   (1000),
+	unavailable         (1001)
+} (1..1001)
+
+/**
+ * This DE indicates the altitude confidence value which represents the estimated absolute accuracy of an altitude value of a geographical point with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to: 
+ *   - 0  - `alt-000-01`   - if the confidence value is equal to or less than 0,01 metre,
+ *   - 1  - `alt-000-02`   - if the confidence value is equal to or less than 0,02 metre and greater than 0,01 metre,
+ *   - 2  - `alt-000-05`   - if the confidence value is equal to or less than 0,05 metre and greater than 0,02 metre,            
+ *   - 3  - `alt-000-10`   - if the confidence value is equal to or less than 0,1 metre and greater than 0,05 metre,            
+ *   - 4  - `alt-000-20`   - if the confidence value is equal to or less than 0,2 metre and greater than 0,1 metre,            
+ *   - 5  - `alt-000-50`   - if the confidence value is equal to or less than 0,5 metre and greater than 0,2 metre,             
+ *   - 6  - `alt-001-00`   - if the confidence value is equal to or less than 1 metre and greater than 0,5 metre,             
+ *   - 7  - `alt-002-00`   - if the confidence value is equal to or less than 2 metres and greater than 1 metre,             
+ *   - 8  - `alt-005-00`   - if the confidence value is equal to or less than 5 metres and greater than 2 metres,              
+ *   - 9  - `alt-010-00`   - if the confidence value is equal to or less than 10 metres and greater than 5 metres,             
+ *   - 10 - `alt-020-00`   - if the confidence value is equal to or less than 20 metres and greater than 10 metres,            
+ *   - 11 - `alt-050-00`   - if the confidence value is equal to or less than 50 metres and greater than 20 metres,            
+ *   - 12 - `alt-100-00`   - if the confidence value is equal to or less than 100 metres and greater than 50 metres,           
+ *   - 13 - `alt-200-00`   - if the confidence value is equal to or less than 200 metres and greater than 100 metres,           
+ *   - 14 - `outOfRange`   - if the confidence value is out of range, i.e. greater than 200 metres,
+ *   - 15 - `unavailable`  - if the confidence value is unavailable.       
+ *
+ * @note: The fact that an altitude value is received with confidence value set to `unavailable(15)` can be caused
+ * by several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the altitude value may be valid and used by the application.
+ * 
+ * @note: If an altitude value is received and its confidence value is set to `outOfRange(14)`, it means that the  
+ * altitude value is not valid and therefore cannot be trusted. Such value is not useful for the application.             
+ *
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1
+ */
+AltitudeConfidence ::= ENUMERATED {
+    alt-000-01  (0),
+    alt-000-02  (1),
+    alt-000-05  (2),
+    alt-000-10  (3),
+    alt-000-20  (4),
+    alt-000-50  (5),
+    alt-001-00  (6),
+    alt-002-00  (7),
+    alt-005-00  (8),
+    alt-010-00  (9),
+    alt-020-00  (10),
+    alt-050-00  (11),
+    alt-100-00  (12),
+    alt-200-00  (13),
+    outOfRange  (14),
+    unavailable (15)
+}
+
+/**
+ * This DE represents the altitude value in a WGS84 coordinate system.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * The value shall be set to: 
+ * - `-100 000` if the altitude is equal to or less than -1 000 m,
+ * - `n` (`n > -100 000` and `n < 800 000`) if the altitude is equal to or less than n  x 0,01 metre and greater than (n-1) x 0,01 metre,
+ * - `800 000` if the altitude  greater than 7 999,99 m,
+ * - `800 001` if the information is not available.
+ *
+ * @note: the range of this DE does not use the full binary encoding range, but all reasonable values are covered. In order to cover all possible altitude ranges a larger encoding would be necessary.
+ * @unit: 0,01 metre
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1 (definition of 800 000 has slightly changed) 
+ */
+AltitudeValue ::= INTEGER {
+    negativeOutOfRange (-100000),
+    postiveOutOfRange  (800000),
+    unavailable        (800001)
+} (-100000..800001)
+
+/** 
+ * This DE indicates the angle confidence value which represents the estimated absolute accuracy of an angle value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to: 
+ * - `n` (`n > 0` and `n < 126`)  if the accuracy is equal to or less than n * 0,1 degrees and greater than (n-1) x * 0,1 degrees,
+ * - `126` if the  accuracy is out of range, i.e. greater than 12,5 degrees,
+ * - `127` if the accuracy information is not available.
+ *
+ * @unit: 0,1 degrees
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+AngleConfidence ::= INTEGER {
+    outOfRange  (126),
+    unavailable (127)   
+} (1..127)
+
+/** 
+ * This DE indicates the angular speed confidence value which represents the estimated absolute accuracy of an angular speed value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * For correlation computation, maximum interval levels can be assumed.
+ *
+ * The value shall be set to:
+ * - 0 - `degSec-01`   - if the accuracy is equal to or less than 1 degree/second,
+ * - 1 - `degSec-02`   - if the accuracy is equal to or less than 2 degrees/second and greater than 1 degree/second,
+ * - 2 - `degSec-05`   - if the accuracy is equal to or less than 5 degrees/second and greater than 2 degrees/second,
+ * - 3 - `degSec-10`   - if the accuracy is equal to or less than 10 degrees/second and greater than 5 degrees/second,
+ * - 4 - `degSec-20`   - if the accuracy is equal to or less than 20 degrees/second and greater than 10 degrees/second,
+ * - 5 - `degSec-50`   - if the accuracy is equal to or less than 50 degrees/second and greater than 20 degrees/second,
+ * - 6 - `outOfRange`  - if the accuracy is out of range, i.e. greater than 50 degrees/second,
+ * - 7 - `unavailable` - if the accuracy information is unavailable.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+AngularSpeedConfidence ::= ENUMERATED {
+    degSec-01   (0), 
+    degSec-02   (1),  
+    degSec-05   (2), 
+    degSec-10   (3), 
+    degSec-20   (4),  
+    degSec-50   (5), 
+    outOfRange  (6),   
+    unavailable (7)   
+}
+
+/** 
+ * This DE indicates the angular acceleration confidence value which represents the estimated accuracy of an angular acceleration value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * For correlation computation, maximum interval levels shall be assumed.
+ *
+ * The value shall be set to:
+ * - 0 - `degSecSquared-01` - if the accuracy is equal to or less than 1 degree/second^2,
+ * - 1 - `degSecSquared-02` - if the accuracy is equal to or less than 2 degrees/second^2 and greater than 1 degree/second^2,
+ * - 2 - `degSecSquared-05` - if the accuracy is equal to or less than 5 degrees/second^2 and greater than 1 degree/second^2,
+ * - 3 - `degSecSquared-10` - if the accuracy is equal to or less than 10 degrees/second^2 and greater than 5 degrees/second^2,
+ * - 4 - `degSecSquared-20` - if the accuracy is equal to or less than 20 degrees/second^2 and greater than 10 degrees/second^2,
+ * - 5 - `degSecSquared-50` - if the accuracy is equal to or less than 50 degrees/second^2 and greater than 20 degrees/second^2,
+ * - 6 - `outOfRange`       - if the accuracy is out of range, i.e. greater than 50 degrees/second^2,
+ * - 7 - `unavailable`      - if the accuracy information is unavailable.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+AngularAccelerationConfidence ::= ENUMERATED {
+    degSecSquared-01 (0), 
+    degSecSquared-02 (1), 
+    degSecSquared-05 (2),  
+    degSecSquared-10 (3), 
+    degSecSquared-20 (4),  
+    degSecSquared-50 (5),  
+    outOfRange       (6),     
+    unavailable      (7)   
+}
+
+/**
+ * This DE indicates the status of the controlling mechanisms for the lateral and combined lateral and longitudinal movements of the vehicle.
+ * The data may be provided via the in-vehicle network. It indicates whether a specific in-vehicle
+ * acceleration control system combined with steering of the direction of the vehicle is engaged or not. 
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0  - `emergencySteeringSystemEngaged`       - emergency steering system is engaged,
+ * - 1  - `autonomousEmergencySteeringEngaged`   - autonomous emergency steering system is engaged,
+ * - 2  - `automaticLaneChangeEngaged`           - automatic lane change system is engaged,
+ * - 3  - `laneKeepingAssistEngaged`             - lane keeping assist is engaged,
+ * - 4  - `assistedParkingLateralEngaged`        - assisted parking system (lateral  control) is engaged,
+ * - 5  - `emergencyAssistEngaged`               - emergency assist (lateral and longitudinal control) is engaged.
+ *
+ * Otherwise (for example when the corresponding system is not available due to non-equipped system or information is unavailable), 
+ * the corresponding bit shall be set to 0. 
+ *
+ * @category: Vehicle information
+ * @revision: Created in V2.3.1
+*/
+AutomationControl::= BIT STRING {    
+	emergencySteeringSystemEngaged     (0),
+	autonomousEmergencySteeringEngaged (1),
+	automaticLaneChangeEngaged         (2),
+	laneKeepingAssistEngaged           (3),
+	assistedParkingLateralEngaged      (4),
+	emergencyAssistEngaged             (5)
+}(SIZE(6,...))
+
+/**
+ * This DE indicates the number of axles of a passing train.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 2` and `n < 1001`) indicates that the train has n x axles,
+ * - `1001`indicates that the number of axles is out of range,
+ * - `1002` the information is unavailable.
+ *
+ * 
+ * @unit: Number of axles
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+*/
+AxlesCount ::= INTEGER{
+    outOfRange   (1001),
+    unavailable  (1002)
+} (2..1002) 
+
+/**
+ * This DE represents the measured uncompensated atmospheric pressure.
+ * 
+ * The value shall be set to:
+ * - `2999` indicates that the applicable value is less than 29990 Pa,
+ * - `n` (`n > 2999` and `n <= 12000`) indicates that the applicable value is equal to or less than n x 10 Pa and greater than (n-1) x 10 Pa, 
+ * - `12001` indicates that the values is greater than 120000 Pa,
+ * - `12002` indicates that the information is not available.
+ *
+ * @category: Basic information
+ * @unit: 10 Pascal
+ * @revision: Created in V2.1.1
+*/
+BarometricPressure ::= INTEGER{
+	outOfRangelower        (2999),
+	outOfRangeUpper        (12001),
+	unavailable            (12002)
+} (2999..12002)
+
+
+/**
+ * This DE indicates the cardinal number of bogies of a train.
+ *
+ * The value shall be set to: 
+ * - `n` (`n > 1` and `n < 100`) indicates that the train has n x bogies,
+ * - `100`indicates that the number of bogies is out of range, 
+ * - `101` the information is unavailable.
+ *
+ * @unit: Number of bogies
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+*/
+BogiesCount ::= INTEGER{
+	outOfRange   (100),
+	unavailable  (101)
+} (2..101)
+
+/**
+ * This DE indicates the status of the vehicleÂ´s brake control system during an externally defined period of time. 
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 `abs`        - the anti-lock braking system is engaged or has been engaged,
+ * - 1 `tcs`        - the traction control system is engaged or has been engaged,
+ * - 2 `esc`        - the electronic stability control system is engaged or has been engaged.
+ *
+ * Otherwise (for example when the corresponding system is not available due to non equipped system
+ * or information is unavailable), the corresponding bit shall be set to 0.
+ *
+ * @category: Vehicle information 
+ * @revision: created in V2.3.1
+ */
+BrakeControl::= BIT STRING {
+   abs   (0),
+   tcs   (1),
+   esc   (2)
+} (SIZE(3, ...))
+
+/**
+ * The DE represents a cardinal number that counts the size of a set. 
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CardinalNumber1B ::= INTEGER(0..255)
+
+/**
+ * The DE represents a cardinal number that counts the size of a set. 
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CardinalNumber3b ::= INTEGER(1..8)
+
+/** 
+ * This DE represents an angle value described in a local Cartesian coordinate system, per default counted positive in
+ * a right-hand local coordinate system from the abscissa.
+ *
+ * The value shall be set to: 
+ * - `n` (`n >= 0` and `n < 3600`) if the angle is equal to or less than n x 0,1 degrees, and greater than (n-1) x 0,1 degrees,
+ * - `3601` if the information is not available.
+ *
+ * The value 3600 shall not be used. 
+ * 
+ * @unit 0,1 degrees
+ * @category: Basic information
+ * @revision: Created in V2.1.1, description and value for 3601 corrected in V2.2.1
+*/
+CartesianAngleValue ::= INTEGER {
+    valueNotUsed (3600),
+    unavailable  (3601)
+} (0..3601)
+
+/**
+ * This DE represents an angular acceleration value described in a local Cartesian coordinate system, per default counted positive in
+ * a right-hand local coordinate system from the abscissa.
+ *
+  * The value shall be set to: 
+ * - `-255` if the acceleration is equal to or less than -255 degrees/s^2,
+ * - `n` (`n > -255` and `n < 255`) if the acceleration is equal to or less than n x 1 degree/s^2,
+      and greater than `(n-1)` x 0,01 degree/s^2,
+ * - `255` if the acceleration is greater than 254 degrees/s^2,
+ * - `256` if the information is unavailable.
+ *
+ * @unit:  degree/s^2 (degrees per second squared)
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+CartesianAngularAccelerationComponentValue ::= INTEGER {
+    negativeOutOfRange (-255),
+    positiveOutOfRange (255),
+    unavailable        (256)
+} (-255..256)
+
+/**
+ * This DE represents an angular velocity component described in a local Cartesian coordinate system, per default counted positive in
+ * a right-hand local coordinate system from the abscissa.
+ *
+ * The value shall be set to: 
+ * - `-255` if the velocity is equal to or less than -255 degrees/s,
+ * - `n` (`n > -255` and `n < 255`) if the velocity is equal to or less than n x 1 degree/s, and greater than (n-1) x 1 degree/s,
+ * - `255` if the velocity is greater than 254 degrees/s,
+ * - `256` if the information is unavailable.
+ *
+ * @unit: degree/s
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+CartesianAngularVelocityComponentValue ::= INTEGER {
+    negativeOutofRange (-255),
+    positiveOutOfRange (255),
+    unavailable	       (256)
+} (-255..256)
+
+/**
+ *The DE represents the value of the cause code of an event. 
+ * 
+ * The value shall be set to:
+ * - 0                                                     - reserved for future use,
+ * - 1  - `trafficCondition`                               - in case the type of event is an abnormal traffic condition,
+ * - 2  - `accident`                                       - in case the type of event is a road accident,
+ * - 3  - `roadworks`                                      - in case the type of event is roadworks, based on authoritative information,
+ * - 4  - `detectedRoadworks`                              - in case the type of event is roadworks, based on non-authoritative information such as factual detections, 
+ * - 5  - `impassability`                                  - in case the  type of event is unmanaged road blocking, referring to any
+ *                                                           blocking of a road, partial or total, which has not been adequately
+ *                                                           secured and signposted,
+ * - 6  - `adhesion`                                       - in case the  type of event is low adhesion of the road surface,
+ * - 7  - `aquaplaning`                                    - danger of aquaplaning on the road,
+ * - 8                                                     - reserved for future usage,
+ * - 9  - `hazardousLocation-SurfaceCondition`             - in case the type of event is abnormal road surface condition not covered by `adhesion`
+ * - 10 - `hazardousLocation-ObstacleOnTheRoad`            - in case the type of event is obstacle on the road,
+ * - 11 - `hazardousLocation-AnimalOnTheRoad`              - in case the type of event is animal on the road,
+ * - 12 - `humanPresenceOnTheRoad`                         - in case the type of event is presence of human vulnerable road user on the road,
+ * - 13                                                    - reserved for future usage,
+ * - 14 - `wrongWayDriving`                                - in case the type of the event is vehicle driving in wrong way,
+ * - 15 - `rescueRecoveryAndMaintenanceWorkInProgress`     - in case the type of event is rescue, recovery and maintenance work for accident or for a road hazard in progress,
+ * - 16                                                    - reserved for future usage,
+ * - 17 - `adverseWeatherCondition-Wind                   `- in case the type of event is wind,
+ * - 18 - `adverseWeatherCondition-Visibility`             - in case the type of event is low visibility,
+ * - 19 - `adverseWeatherCondition-Precipitation`          - in case the type of event is precipitation,
+ * - 20 - `violence`                                       - in case the the type of event is human violence on or near the road,
+ * - 21-25                                                 - reserved for future usage,
+ * - 26 - `slowVehicle`                                    - in case the type of event is slow vehicle driving on the road,
+ * - 27 - `dangerousEndOfQueue`                            - in case the type of event is dangerous end of vehicle queue,
+ * - 28 - `publicTransportVehicleApproaching               - in case the type of event is a public transport vehicle approaching, with a priority defined by applicable traffic regulations,
+ * - 29-90                                                 - are reserved for future usage,
+ * - 91 - `vehicleBreakdown`                               - in case the type of event is break down vehicle on the road,
+ * - 92 - `postCrash`                                      - in case the type of event is a detected crash,
+ * - 93 - `humanProblem`                                   - in case the type of event is human health problem in vehicles involved in traffic,
+ * - 94 - `stationaryVehicle`                              - in case the type of event is stationary vehicle,
+ * - 95 - `emergencyVehicleApproaching`                    - in case the type of event is an approaching vehicle operating on a mission for which the applicable 
+                                                             traffic regulations provide it with defined priority rights in traffic. 
+ * - 96 - `hazardousLocation-DangerousCurve`               - in case the type of event is dangerous curve,
+ * - 97 - `collisionRisk`                                  - in case the type of event is a collision risk,
+ * - 98 - `signalViolation`                                - in case the type of event is signal violation,
+ * - 99 - `dangerousSituation`                             - in case the type of event is dangerous situation in which autonomous safety system in vehicle 
+ *                                                             is activated,
+ * - 100 - `railwayLevelCrossing`                          - in case the type of event is a railway level crossing. 
+ * - 101-255                                               - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 20 and 100 added in V2.1.1, value 28 added in V2.2.1, definition of values 12 and 95 changed in V2.2.1,
+ *            name and/or definition of values 3, 6, 9, 15 and 17 changed in V2.4.1, value 4 assigned in V2.4.1
+ */
+CauseCodeType ::= INTEGER {
+    trafficCondition                                (1),
+    accident                                        (2),
+    roadworks                                       (3),
+    detectedRoadworks                               (4),
+    impassability                                   (5),
+    adhesion                                        (6),
+    aquaplaning                                     (7),
+    hazardousLocation-SurfaceCondition              (9),
+    hazardousLocation-ObstacleOnTheRoad             (10),
+    hazardousLocation-AnimalOnTheRoad               (11),
+    humanPresenceOnTheRoad                          (12),
+    wrongWayDriving                                 (14),
+    rescueRecoveryAndMaintenanceWorkInProgress      (15),
+    adverseWeatherCondition-ExtremeWeatherCondition (17),
+    adverseWeatherCondition-Visibility              (18),
+    adverseWeatherCondition-Precipitation           (19),
+    violence                                        (20),
+    slowVehicle                                     (26),
+    dangerousEndOfQueue                             (27),
+    publicTransportVehicleApproaching               (28),
+    vehicleBreakdown                                (91),
+    postCrash                                       (92),
+    humanProblem                                    (93),
+    stationaryVehicle                               (94),
+    emergencyVehicleApproaching                     (95),
+    hazardousLocation-DangerousCurve                (96),
+    collisionRisk                                   (97),
+    signalViolation                                 (98),
+    dangerousSituation                              (99),
+    railwayLevelCrossing                            (100) 
+} (0..255)
+
+/**
+ * This DF represents the value of a cartesian coordinate with a range of -30,94 metres to +10,00 metres.
+ *
+ * The value shall be set to:
+ * - `3094` if the longitudinal offset is out of range, i.e. less than or equal to -30,94 metres,
+ * - `n` (`n > -3 094` and `n < 1 001`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,
+ * - `1001` if the longitudinal offset is out of range, i.e. greater than 10 metres.
+ *
+ * @unit 0,01 m
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CartesianCoordinateSmall::= INTEGER {
+    negativeOutOfRange (-3094),
+    positiveOutOfRange (1001)
+} (-3094..1001) 
+
+/**
+ * This DF represents the value of a cartesian coordinate with a range of -327,68 metres to +327,66 metres.
+ *
+ * The value shall be set to:
+ * - `-32 768` if the longitudinal offset is out of range, i.e. less than or equal to -327,68 metres,
+ * - `n` (`n > -32 768` and `n < 32 767`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,
+ * - `32 767` if the longitudinal offset is out of range, i.e. greater than + 327,66 metres.
+ *
+ * @unit 0,01 m
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CartesianCoordinate::= INTEGER{
+    negativeOutOfRange (-32768),
+    positiveOutOfRange (32767)
+} (-32768..32767)
+
+/**
+ * This DF represents the value of a cartesian coordinate with a range of -1 310,72 metres to +1 310,70 metres.
+ *
+ * The value shall be set to:
+ * - `-131072` if the longitudinal offset is out of range, i.e. less than or equal to -1 310,72 metres,
+ * - `n` (`n > 131 072` and `n < 131 071`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,
+ * - `131 071` if the longitudinal offset is out of range, i.e. greater than + 1 310,70 metres.
+ *  
+ * @unit 0,01 m
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CartesianCoordinateLarge::= INTEGER{ 
+    negativeOutOfRange (-131072),
+    positiveOutOfRange (131071)
+} (-131072..131071)
+
+/**
+ * This DE represents the ID of a CEN DSRC tolling zone. 
+ * 
+ * @category: Communication information
+ * @revision: V1.3.1
+ * @note: this DE is deprecated and shall not be used anymore.  
+ */
+CenDsrcTollingZoneID::= ProtectedZoneId
+
+/**
+ * This DE indicates the reason why a cluster leader intends to break up the cluster.
+ * 
+ * The value shall be set to:
+ * - 0 - `notProvided`                          - if the information is not provided,
+ * - 1 - `clusteringPurposeCompleted`           - if the cluster purpose has been completed,
+ * - 2 - `leaderMovedOutOfClusterBoundingBox`   - if the leader moved out of the cluster's bounding box,
+ * - 3 - `joiningAnotherCluster`                - if the cluster leader is about to join another cluster,
+ * - 4 - `enteringLowRiskAreaBasedOnMaps`       - if the cluster is entering an area idenrified as low risk based on the use of maps,
+ * - 5 - `receptionOfCpmContainingCluster`      - if the leader received a Collective Perception Message containing information about the same cluster. 
+ * - 6 to 15                                    - are reserved for future use.                                    
+ *
+ * @category: Cluster information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+*/
+ClusterBreakupReason ::= INTEGER {
+    notProvided                        (0),
+    clusteringPurposeCompleted         (1),
+    leaderMovedOutOfClusterBoundingBox (2),    
+    joiningAnotherCluster              (3),
+    enteringLowRiskAreaBasedOnMaps     (4),
+    receptionOfCpmContainingCluster    (5)                                                                
+}(0..15)
+
+/**
+ * This DE indicates the reason why a cluster participant is leaving the cluster.
+ * 
+ * The value shall be set to:
+ * - 0 - `notProvided `                 - if the information is not provided,
+ * - 1 - `clusterLeaderLost`            - if the cluster leader cannot be found anymore,   
+ * - 2 - `clusterDisbandedByLeader`     - if the cluster has been disbanded by the leader,
+ * - 3 - `outOfClusterBoundingBox`      - if the participants moved out of the cluster's bounding box,
+ * - 4 - `outOfClusterSpeedRange`       - if the cluster speed moved out of a defined range, 
+ * - 5 - `joiningAnotherCluster`        - if the participant is joining another cluster,
+ * - 6 - `cancelledJoin`                - if the participant is cancelling a joining procedure,
+ * - 7 - `failedJoin`                   - if the participant failed to join the cluster,
+ * - 8 - `safetyCondition`              - if a safety condition applies.
+ * - 9 to 15                            - are reserved for future use                             
+ *
+ * @category: Cluster information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+ */
+ClusterLeaveReason ::= INTEGER {
+    notProvided                   (0), 
+    clusterLeaderLost             (1),    
+    clusterDisbandedByLeader      (2),    
+    outOfClusterBoundingBox       (3),    
+    outOfClusterSpeedRange        (4),
+    joiningAnotherCluster         (5),
+    cancelledJoin                 (6),
+    failedJoin                    (7),
+    safetyCondition               (8)     
+}(0..15)
+
+/**
+ * This DE represents the sub cause codes of the @ref CauseCode `collisionRisk`.
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                    - in case information on the type of collision risk is unavailable,
+ * - 1 - `longitudinalCollisionRisk`      - in case the type of detected collision risk is longitudinal collision risk, 
+ *                                          e.g. forward collision or face to face collision,
+ * - 2 - `crossingCollisionRisk`          - in case the type of detected collision risk is crossing collision risk,
+ * - 3 - `lateralCollisionRisk`           - in case the type of detected collision risk is lateral collision risk,
+ * - 4 - `vulnerableRoadUser`             - in case the type of detected collision risk involves vulnerable road users
+ *                                          e.g. pedestrians or bicycles.
+ * - 5 - `collisionRiskWithPedestrian`    - in case the type of detected collision risk involves at least one pedestrian, 
+ * - 6 - `collisionRiskWithCyclist`       - in case the type of detected collision risk involves at least one cyclist (and no pedestrians),
+ * - 7 - `collisionRiskWithMotorVehicle`  - in case the type of detected collision risk involves at least one motor vehicle (and no pedestrians or cyclists),
+ * - 8 - `erraticDriving`                 - in case the collision risk is due a vehicle exhibiting inconsistent and unpredictable actions like swerving, abrupt lane changes, and inconsistent speed.
+ * - 9 - `recklessDriving`                - in case the collision risk is due a vehicle exhibiting aggressive manoeuvres like tailgating and sudden lane changes and which ignores traffic rules. 
+ * - 10-255                               - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, values 5-7 assigned in V2.2.1, values 8-9 added in V2.4.1
+ */
+CollisionRiskSubCauseCode ::= INTEGER {
+    unavailable                   (0), 
+    longitudinalCollisionRisk     (1), 
+    crossingCollisionRisk         (2), 
+    lateralCollisionRisk          (3), 
+    vulnerableRoadUser            (4),
+    collisionRiskWithPedestrian   (5), 
+    collisionRiskWithCyclist      (6), 
+    collisionRiskWithMotorVehicle (7), 
+    erraticDriving                (8),
+    recklessDriving               (9) 
+}(0..255)
+
+/** 
+ * This DE represents a confidence level in percentage.
+ * 
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 101`) : for the confidence level in %,
+ * - `101`                   : in case the confidence level is not available.
+ *
+ * @unit Percent 
+ * @category: Basic information 
+ * @revision: Created in V2.1.1 
+*/
+ConfidenceLevel ::= INTEGER {
+    unavailable (101)  
+} (1..101)
+
+/** 
+ * This DE indicates the coordinate confidence value which represents the estimated absolute accuracy of a position coordinate with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to: 
+ * - `n` (`n > 0` and `n < 4095`) if the confidence value is is equal to or less than n x 0,01 metre, and greater than (n-1) x 0,01 metre,
+ * - `4095` if the confidence value is greater than 40,94 metres,
+ * - `4096` if the confidence value is not available.
+ *
+ * @unit 0,01 m
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+CoordinateConfidence ::= INTEGER {
+    outOfRange            (4095),
+    unavailable           (4096) 
+} (1..4096)
+
+/** 
+ * This DE represents the Bravais-Pearson correlation value for each cell of a lower triangular correlation matrix.
+ *
+ * The value shall be set to: 
+ * - `-100` in case of full negative correlation,
+ * - `n` (`n > -100` and `n < 0`) if the correlation is negative and equal to n/100,
+ * - `0` in case of no correlation,
+ * - `n` (`n > 0` and `n < 100`) if the correlation is positive and equal to n/100,
+ * - `100` in case of full positive correlation,
+ * - `101` in case the correlation information is unavailable. 
+ *
+ * @unit: the value is scaled by 100
+ * @category: Basic information
+ * @revision: Created in V2.1.1, corrected the value to n/100 on V2.4.1
+*/
+CorrelationCellValue ::= INTEGER {
+    full-negative-correlation    (-100),     
+    no-correlation               (0),       
+    full-positive-correlation    (100),
+    unavailable (101)  
+} (-100..101)
+
+/** 
+ * This DE represents an ISO 3166-1 [25] country code encoded using ITA-2 encoding.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.2.1 based on ISO 14816 [23]
+*/
+CountryCode ::= BIT STRING(SIZE(10))
+
+/**
+ * The DE describes whether the yaw rate is used to calculate the curvature for a curvature value.
+ * 
+ * The value shall be set to:
+ * - 0 - `yawRateUsed`    - if the yaw rate is used,
+ * - 1 - `yawRateNotUsed` - if the yaw rate is not used,
+ * - 2 - `unavailable`    - if the information of curvature calculation mode is unknown.
+ *
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+CurvatureCalculationMode ::= ENUMERATED {
+    yawRateUsed    (0), 
+    yawRateNotUsed (1), 
+    unavailable    (2), 
+    ...
+}
+
+/**
+ * This DE indicates the acceleration confidence value which represents the estimated absolute accuracy range of a curvature value with a confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * 
+ * The value shall be set to:
+ * - 0 - `onePerMeter-0-00002` - if the confidence value is less than or equal to 0,00002 m-1,
+ * - 1 - `onePerMeter-0-0001`  - if the confidence value is less than or equal to 0,0001 m-1 and greater than 0,00002 m-1,
+ * - 2 - `onePerMeter-0-0005`  - if the confidence value is less than or equal to 0,0005 m-1 and greater than 0,0001 m-1,
+ * - 3 - `onePerMeter-0-002`   - if the confidence value is less than or equal to 0,002 m-1 and greater than 0,0005 m-1,
+ * - 4 - `nePerMeter-0-01`     - if the confidence value is less than or equal to 0,01 m-1 and greater than 0,002 m-1,
+ * - 5 - `nePerMeter-0-1`      - if the confidence value is less than or equal to 0,1 m-1  and greater than 0,01 m-1,
+ * - 6 - `outOfRange`          - if the confidence value is out of range, i.e. greater than 0,1 m-1,
+ * - 7 - `unavailable`         - if the confidence value is not available.
+ * 
+ * @note:	The fact that a curvature value is received with confidence value set to `unavailable(7)` can be caused by
+ * several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the curvature value may be valid and used by the application.
+ * 
+ * @note: If a curvature value is received and its confidence value is set to `outOfRange(6)`, it means that the curvature value is not valid 
+ * and therefore cannot be trusted. Such value is not useful for the application.
+ * 
+ * @category: Vehicle information
+ * @revision: Description revised in V2.1.1
+*/
+CurvatureConfidence ::= ENUMERATED {
+    onePerMeter-0-00002 (0),
+    onePerMeter-0-0001  (1),
+    onePerMeter-0-0005  (2),
+    onePerMeter-0-002   (3),
+    onePerMeter-0-01    (4),
+    onePerMeter-0-1     (5),
+    outOfRange          (6),
+    unavailable         (7)
+}
+
+/**
+ * This DE describes vehicle turning curve with the following information:
+ * ```
+ *     Value = 1 / Radius * 10000
+ * ```
+ * wherein radius is the vehicle turning curve radius in metres. 
+ * 
+ * Positive values indicate a turning curve to the left hand side of the driver.
+ * It corresponds to the vehicle coordinate system as defined in ISO 8855 [21].
+ *
+ * The value shall be set to:
+ * - `-1023` for  values smaller than -1023,
+ * - `n` (`n > -1023` and `n < 0`) for negative values equal to or less than `n`, and greater than `(n-1)`,
+ * - `0` when the vehicle is moving straight,
+ * - `n` (`n > 0` and `n < 1022`) for positive values equal to or less than `n`, and greater than `(n-1)`,
+ * - `1022`, for values  greater than 1021,
+ * - `1023`, if the information is not available.
+ * 
+ * @note: The present DE is limited to vehicle types as defined in ISO 8855 [21].
+ * 
+ * @unit: 1 over 10 000 metres
+ * @category: Vehicle information
+ * @revision: description revised in V2.1.1 (the definition of value 1022 has changed slightly)
+ */
+CurvatureValue ::= INTEGER {
+    outOfRangeNegative (-1023),
+    straight           (0),
+    outOfRangePositive (1022), 
+    unavailable        (1023)
+} (-1023..1023)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `dangerousEndOfQueue`. 
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`     - in case information on the type of dangerous queue is unavailable,
+ * - 1 - `suddenEndOfQueue`- in case a sudden end of queue is detected, e.g. due to accident or obstacle,
+ * - 2 - `queueOverHill`   - in case the dangerous end of queue is detected on the road hill,
+ * - 3 - `queueAroundBend` - in case the dangerous end of queue is detected around the road bend,
+ * - 4 - `queueInTunnel`   - in case queue is detected in tunnel,
+ * - 5-255                 - reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+DangerousEndOfQueueSubCauseCode ::= INTEGER {
+    unavailable      (0), 
+    suddenEndOfQueue (1), 
+    queueOverHill    (2), 
+    queueAroundBend  (3), 
+    queueInTunnel    (4)
+} (0..255)
+
+/**
+ * This DE indicates the type of the dangerous goods being carried by a heavy vehicle.
+ * The value is assigned according to `class` and `division` definitions of dangerous goods as specified in part II,
+ * chapter 2.1.1.1 of European Agreement concerning the International Carriage of Dangerous Goods by Road [3].
+ * 
+ * 
+ * @category Vehicle information
+ * @revision: V1.3.1
+ */
+DangerousGoodsBasic::= ENUMERATED {
+    explosives1                                          (0),
+    explosives2                                          (1),
+    explosives3                                          (2),
+    explosives4                                          (3),
+    explosives5                                          (4),
+    explosives6                                          (5),
+    flammableGases                                       (6),
+    nonFlammableGases                                    (7),
+    toxicGases                                           (8),
+    flammableLiquids                                     (9),
+    flammableSolids                                      (10),
+    substancesLiableToSpontaneousCombustion              (11),
+    substancesEmittingFlammableGasesUponContactWithWater (12),
+    oxidizingSubstances                                  (13),
+    organicPeroxides                                     (14),
+    toxicSubstances                                      (15),
+    infectiousSubstances                                 (16),
+    radioactiveMaterial                                  (17),
+    corrosiveSubstances                                  (18),
+    miscellaneousDangerousSubstances                     (19)
+}
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `dangerousSituation` 
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                      - in case information on the type of dangerous situation is unavailable,
+ * - 1 - `emergencyElectronicBrakeEngaged`  - in case emergency electronic brake is engaged,
+ * - 2 - `preCrashSystemEngaged`            - in case pre-crash system is engaged,
+ * - 3 - `espEngaged`                       - in case Electronic Stability Program (ESP) system is engaged,
+ * - 4 - `absEngaged`                       - in case Anti-lock Braking System (ABS) is engaged,
+ * - 5 - `aebEngaged`                       - in case Autonomous Emergency Braking (AEB) system is engaged,
+ * - 6 - `brakeWarningEngaged`              - in case brake warning is engaged,
+ * - 7 - `collisionRiskWarningEngaged`      - in case collision risk warning is engaged,
+ * - 8 - `riskMitigationFunctionEngaged`    - in case the Risk Mitigation Function according to UNECE Regulation 79 is engaged,
+ * - 9-255                                  - reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 8 assigned in V2.4.1
+ */
+DangerousSituationSubCauseCode ::= INTEGER {
+    unavailable                     (0), 
+    emergencyElectronicBrakeEngaged (1), 
+    preCrashSystemEngaged           (2), 
+    espEngaged                      (3), 
+    absEngaged                      (4), 
+    aebEngaged                      (5), 
+    brakeWarningEngaged             (6), 
+    collisionRiskWarningEngaged     (7),
+    riskMitigationFunctionEngaged   (8)
+} (0..255)
+
+/**
+ * This DE represents an offset altitude with regards to a defined altitude value.
+ * It may be used to describe a geographical point with regards to a specific reference geographical position.
+ *
+ * The value shall be set to:
+ * - `-12 700` for values equal to or lower than -127 metres,
+ * - `n` (`n > -12 700` and `n <= 0`) for altitude offset n x 0,01 metre below the reference position,
+ * - `0` for no altitudinal offset,
+ * - `n` (`n > 0` and `n < 12799`) for altitude offset n x 0,01 metre above the reference position,
+ * - `12 799` for values equal to or greater than 127,99 metres,
+ * - `12 800` when the information is unavailable.
+ *
+ * @unit: 0,01 metre
+ * @category: GeoReference information
+ * @revision: editorial update in V2.1.1
+ */
+DeltaAltitude ::= INTEGER {
+    negativeOutOfRange (-12700),
+    positiveOutOfRange (12799),
+    unavailable        (12800)
+} (-12700..12800)
+
+/**
+ * This DE represents an offset latitude with regards to a defined latitude value.
+ * It may be used to describe a geographical point with regards to a specific reference geographical position.
+ *
+ * The value shall be set to:
+ * - `n` (`n >= -131 071` and `n < 0`) for offset n x 10^-7 degree towards the south from the reference position,
+ * - `0` for no latitudinal offset,
+ * - `n` (`n > 0` and `n < 131 072`) for offset n x 10^-7 degree towards the north from the reference position,
+ * - `131 072` when the information is unavailable.
+ *
+ * @unit: 10^-7 degree
+ * @category: GeoReference information
+ * @revision: editorial update in V2.1.1
+ */
+DeltaLatitude ::= INTEGER {
+    unavailable (131072)
+} (-131071..131072)
+
+/**
+ * This DE represents an offset longitude with regards to a defined longitude value.
+ * It may be used to describe a geographical point with regards to a specific reference geographical position.
+ *
+ * The value shall be set to:
+ * - `n` (`n >= -131 071` and `n < 0`) for offset n x 10^-7 degree towards the west from the reference position,
+ * - `0` for no longitudinal offset,
+ * - `n` (`n > 0` and `n < 131 072`) for offset n x 10^-7 degree towards the east from the reference position, 
+ * - `131 072` when the information is unavailable.
+ *
+ * @unit: 10^-7 degree
+ * @category: GeoReference information
+ * @revision: editorial update in V2.1.1
+ */
+DeltaLongitude ::= INTEGER {
+    unavailable (131072)
+} (-131071..131072)
+
+/**
+ * This DE represents a difference in time with respect to a reference time.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 10001`) to indicate a time value equal to or less than n x 0,001 s, and greater than (n-1) x 0,001 s,
+ *
+ * Example: a time interval between two consecutive message transmissions.
+ * 
+ * @unit: 0,001 s
+ * @category: Basic information
+ * @revision: Created in V2.1.1 from the DE TransmissionInterval in [2]
+ */
+DeltaTimeMilliSecondPositive ::= INTEGER (1..10000)
+
+/** 
+ * This DE represents a signed difference in time with respect to a reference time.
+ *
+ * The value shall be set to:
+ * - `-2048` for time values equal to or less than -2,048 s,
+ * - `n` (`n > -2048` and `n < 2047`) to indicate a time value equal to or less than n x 0,001 s, and greater than (n-1) x 0,001 s,
+ * - `2047` for time values greater than 2,046 s
+ *
+ * @unit: 0,001 s
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+DeltaTimeMilliSecondSigned ::= INTEGER (-2048..2047)
+
+/** 
+ * This DE represents a difference in time with respect to a reference time.
+ * It can be interpreted as the first 8 bits of a GenerationDeltaTime. To convert it to a @ref GenerationDeltaTime, 
+ * multiply by 256 (i.e. append a `00` byte)
+ *
+ * @unit: 256 * 0,001 s 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+DeltaTimeQuarterSecond::= INTEGER {
+    unavailable (255)  
+} (1..255) 
+
+/** 
+ * This DE represents a difference in time with respect to a reference time.
+ *
+ * The value shall be set to:
+ * - `0` for a difference in time of 0 seconds. 
+ * - `n` (`n > 0` and `n < 128`) to indicate a time value equal to or less than n x 0,1 s, and greater than (n-1) x 0,1 s,
+ *
+ * @unit: 0,1 s
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+DeltaTimeTenthOfSecond::= INTEGER {
+    unavailable (127)  
+} (0..127) 
+
+/** 
+ * This DE represents a  difference in time with respect to a reference time.
+ *
+ * The value shall be set to:
+ * - `-0` for a difference in time of 0 seconds. 
+ * - `n` (`n > 0` and `n <= 86400`) to indicate a time value equal to or less than n x 1 s, and greater than (n-1) x 1 s,
+ *
+ * @unit: 1 s
+ * @category: Basic information
+ * @revision: Created in V2.1.1 from ValidityDuration
+*/
+DeltaTimeSecond ::= INTEGER  (0..86400)
+
+/**
+ * This DE represents a difference in time with respect to a reference time.
+ *
+ * The value shall be set to:
+ * - `-0` for a difference in time of 0 seconds. 
+ * - `n` (`n > 0` and `n < 128`) to indicate a time value equal to or less than n x 10 s, and greater than (n-1) x 10 s,
+ *
+ * @unit: 10 s
+ * @category: Basic information
+ * @revision: Created in V2.2.1
+*/
+DeltaTimeTenSeconds ::= INTEGER  (0..127)  
+
+/**
+ * This DE indicates a direction with respect to a defined reference direction.
+ * Example: a reference direction may be implicitly defined by the definition of a geographical zone.
+ *
+ * The value shall be set to:
+ * - 0 - `sameDirection`     - to indicate the same direction as the reference direction,
+ * - 1 - `oppositeDirection` - to indicate opposite direction as the reference direction,
+ * - 2 - `bothDirections`    - to indicate both directions, i.e. the same and the opposite direction,
+ * - 3 - `unavailable`       - to indicate that the information is unavailable.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+ */
+Direction::= INTEGER{
+    sameDirection     (0),
+    oppositeDirection (1),
+    bothDirections    (2),
+    unavailable       (3)
+ } (0..3)
+
+/**
+ * This DE indicates in which direction something is moving.
+ *
+ * The value shall be set to:
+ * - 0 - `forward`     - to indicate it is moving forward,
+ * - 1 - `backwards`   - to indicate it is moving backwards,
+ * - 2 - `unavailable` - to indicate that the information is unavailable.
+ *
+ * @category: Kinematic information
+ * @revision: editorial update in V2.1.1
+ */
+DriveDirection ::= ENUMERATED {
+    forward     (0), 
+    backward    (1), 
+    unavailable (2)
+}
+
+/**
+ * This DE indicates whether a driving lane is open to traffic.
+ * 
+ * A lane is counted from inside border of the road excluding the hard shoulder. The size of the bit string shall
+ * correspond to the total number of the driving lanes in the carriageway.
+ * 
+ * The numbering is matched to @ref LanePosition.
+ * The bit `0` is used to indicate the innermost lane, bit `1` is used to indicate the second lane from inside border.
+ * 
+ * If a lane is closed to traffic, the corresponding bit shall be set to `1`. Otherwise, it shall be set to `0`.
+ * 
+ * @note: hard shoulder status is not provided by this DE but in @ref HardShoulderStatus.
+ * 
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+DrivingLaneStatus ::= BIT STRING (SIZE (1..13))
+
+/**
+ * This DE indicates whether a vehicle (e.g. public transport vehicle, truck) is under the embarkation process.
+ * If that is the case, the value is *TRUE*, otherwise *FALSE*.
+ *
+ * @category: Vehicle information
+ * @revision: editorial update in V2.1.1
+ */
+EmbarkationStatus ::= BOOLEAN
+
+/**
+ * This DE indicates the right of priority requested or assumed by an operating emergency vehicle.
+ * The right-of-priority bit shall be set to `1` if the corresponding right is requested.
+ * 
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 - `requestForRightOfWay`                  - when the vehicle is requesting/assuming the right of way,
+ * - 1 - `requestForFreeCrossingAtATrafficLight` - when the vehicle is requesting/assuming the right to pass at a (red) traffic light.
+ *
+ * @category: Traffic information
+ * @revision: description revised in V2.1.1
+ */
+EmergencyPriority ::= BIT STRING {
+    requestForRightOfWay                  (0), 
+    requestForFreeCrossingAtATrafficLight (1)
+} (SIZE(2))
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode "emergencyVehicleApproaching". 
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                   - in case further detailed information on the emergency vehicle approaching event 
+ *                                         is unavailable,
+ * - 1 - `emergencyVehicleApproaching`   - in case an operating emergency vehicle is approaching,
+ * - 2 - `prioritizedVehicleApproaching` - in case a prioritized vehicle is approaching,
+ * - 3-255                               - reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+EmergencyVehicleApproachingSubCauseCode ::= INTEGER {
+    unavailable                   (0), 
+    emergencyVehicleApproaching   (1), 
+    prioritizedVehicleApproaching (2)
+} (0..255)
+
+/**
+ * This DE indicated the type of energy being used and stored in vehicle.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 - `hydrogenStorage`       - when hydrogen is being used and stored in vehicle,
+ * - 1 - `electricEnergyStorage` - when electric energy is being used and stored in vehicle,
+ * - 2 - `liquidPropaneGas`      - when liquid Propane Gas (LPG) is being used and stored in vehicle,   
+ * - 3 - `compressedNaturalGas ` - when compressedNaturalGas (CNG) is being used and stored in vehicle,
+ * - 4 - `diesel`                - when diesel is being used and stored in vehicle,
+ * - 5 - `gasoline`              - when gasoline is being used and stored in vehicle,
+ * - 6 - `ammonia`               - when ammonia is being used and stored in vehicle.
+ *
+ * - Otherwise, the corresponding bit shall be set to `0`.
+ *
+ * @category: Vehicle information
+ * @revision: editorial revision in V2.1.1 
+ */
+EnergyStorageType ::= BIT STRING {
+    hydrogenStorage       (0), 
+    electricEnergyStorage (1), 
+    liquidPropaneGas      (2), 
+    compressedNaturalGas  (3), 
+    diesel                (4), 
+    gasoline              (5), 
+    ammonia               (6)
+}(SIZE(7))
+
+/**
+ * This DE represents one of the specific categories in the L category: L1, L2, L3, L4, L5, L6, or L7 according to UNECE/TRANS/WP.29/78/Rev.4 [16].
+ *
+ *
+ * @category: Vehicle information
+ * @revision: V2.1.1
+ */
+EuVehicleCategoryL ::= ENUMERATED { l1, l2, l3, l4, l5, l6, l7 }
+
+/**
+ * This DE represents one of the specific categories in the M category: M1, M2, or M3 according to UNECE/TRANS/WP.29/78/Rev.4 [16].
+ *
+ *
+ * @category: Vehicle information
+ * @revision: V2.1.1
+ */
+EuVehicleCategoryM ::= ENUMERATED {m1, m2, m3}
+
+/**
+ * This DE represents one of the specific categories in the N category: N1, N2, or N3 according to UNECE/TRANS/WP.29/78/Rev.4 [16].
+ *
+ *
+ * @category: Vehicle information
+ * @revision: V2.1.1
+ */
+EuVehicleCategoryN ::= ENUMERATED {n1, n2, n3}
+
+/**
+ * This DE represents one of the specific categories in the O category: O1, O2, O3 or O4 according to UNECE/TRANS/WP.29/78/Rev.4 [16].
+ *
+ *
+ * @category: Vehicle information
+ * @revision: V2.1.1
+ */
+EuVehicleCategoryO ::= ENUMERATED {o1, o2, o3, o4}
+
+/**
+ * This DE describes the status of the exterior light switches of a vehicle incl. VRU vehicles.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 - `lowBeamHeadlightsOn`    - when the low beam head light switch is on,
+ * - 1 - `highBeamHeadlightsOn`   - when the high beam head light switch is on,
+ * - 2 - `leftTurnSignalOn`       - when the left turnSignal switch is on,
+ * - 3 - `rightTurnSignalOn`      - when the right turn signal switch is on,
+ * - 4 - `daytimeRunningLightsOn` - when the daytime running light switch is on,
+ * - 5 - `reverseLightOn`         - when the reverse light switch is on,
+ * - 6 - `fogLightOn`             - when the tail fog light switch is on,
+ * - 7 - `parkingLightsOn`        - when the parking light switch is on.
+ * 
+ * @note: The value of each bit indicates the state of the switch, which commands the corresponding light.
+ * The bit corresponding to a specific light is set to `1`, when the corresponding switch is turned on,
+ * either manually by the driver or automatically by a vehicle system. The bit value does not indicate
+ * if the corresponding lamps are alight or not.
+ * 
+ * If a vehicle is not equipped with a certain light or if the light switch status information is not available,
+ * the corresponding bit shall be set to `0`.
+ * 
+ * As the bit value indicates only the state of the switch, the turn signal and hazard signal bit values shall not
+ * alternate with the blinking interval.
+ * 
+ * For hazard indicator, the `leftTurnSignalOn (2)` and `rightTurnSignalOn (3)` shall be both set to `1`.
+ * 
+ * @category Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+ExteriorLights ::= BIT STRING {
+    lowBeamHeadlightsOn      (0),
+    highBeamHeadlightsOn     (1),
+    leftTurnSignalOn         (2),
+    rightTurnSignalOn        (3),
+    daytimeRunningLightsOn   (4),
+    reverseLightOn           (5),
+    fogLightOn               (6),
+    parkingLightsOn          (7)
+} (SIZE(8))
+
+/**
+ * This DE represents a timestamp based on TimestampIts modulo 65 536.
+ * This means that generationDeltaTime = TimestampIts mod 65 536.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.1.1 based on ETSI TS 103 900 [1]
+*/
+GenerationDeltaTime ::= INTEGER { oneMilliSec(1) } (0..65535)
+
+/**
+ * This DE indicates the current status of a hard shoulder: whether it is available for special usage
+ * (e.g. for stopping or for driving) or closed for all vehicles.
+ * 
+ * The value shall be set to:
+ * - 0 - `availableForStopping` - if the hard shoulder is available for stopping in e.g. emergency situations,
+ * - 1 - `closed`               - if the hard shoulder is closed and cannot be occupied in any case,
+ * - 2 - `availableForDriving`  - if the hard shoulder is available for regular driving.
+ *
+ * @category: Traffic information
+ * @revision: Description revised in V2.1.1
+ */
+HardShoulderStatus ::= ENUMERATED {
+    availableForStopping (0), 
+    closed               (1), 
+    availableForDriving  (2)
+}
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-AnimalOnTheRoad`.
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`          - in case further detailed information on the animal(s) on the road is unavailable,
+ * - 1 - `wildAnimals`          - in case wild animals of unknown size are present on the road,
+ * - 2 - `herdOfAnimals`        - in case a herd of animals is present on the road,
+ * - 3 - `smallAnimals`         - in case small size animals of unknown type are present on the road,
+ * - 4 - `largeAnimals`         - in case large size animals of unknown type are present on the road,
+ * - 5 - `wildAnimalsSmall`     - in case small size wild animal(s) are present on the road,
+ * - 6 - `wildAnimalsLarge`     - in case large size wild animal(s) are present on the road,
+ * - 7 - `domesticAnimals`      - in case domestic animal(s) of unknown size are detected on the road,
+ * - 8 - `domesticAnimalsSmall` - in case small size domestic animal(s) are present on the road,
+ * - 9 - `domesticAnimalsLarge` - in case large size domestic animal(s) are present on the road.
+ * - 10-255                     - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, named values 5 to 9 added in V2.2.1 
+ */
+HazardousLocation-AnimalOnTheRoadSubCauseCode ::= INTEGER {
+    unavailable           (0), 
+    wildAnimals           (1), 
+    herdOfAnimals         (2), 
+    smallAnimals          (3), 
+    largeAnimals          (4),
+    wildAnimalsSmall      (5),
+    wildAnimalsLarge      (6),
+    domesticAnimals       (7),
+    domesticAnimalsSmall  (8),
+    domesticAnimalsLarge  (9)
+} (0..255)
+
+/**
+ * This DE represents the sub cause code of the @ref CauseCode  `hazardousLocation-DangerousCurve`.
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                                        - in case further detailed information on the dangerous curve is unavailable,
+ * - 1 - `dangerousLeftTurnCurve`                             - in case the dangerous curve is a left turn curve,
+ * - 2 - `dangerousRightTurnCurve`                            - in case the dangerous curve is a right turn curve,
+ * - 3 - `multipleCurvesStartingWithUnknownTurningDirection`  - in case of multiple curves for which the starting curve turning direction is not known,
+ * - 4 - `multipleCurvesStartingWithLeftTurn`                 - in case of multiple curves starting with a left turn curve,
+ * - 5 - `multipleCurvesStartingWithRightTurn`                - in case of multiple curves starting with a right turn curve.
+ * - 6-255                                                    - are reserved for future usage.
+ * 
+ * The definition of whether a curve is dangerous may vary according to region and according to vehicle types/mass
+ * and vehicle speed driving on the curve. This definition is out of scope of the present document.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+HazardousLocation-DangerousCurveSubCauseCode ::= INTEGER {
+    unavailable                                       (0), 
+    dangerousLeftTurnCurve                            (1), 
+    dangerousRightTurnCurve                           (2), 
+    multipleCurvesStartingWithUnknownTurningDirection (3), 
+    multipleCurvesStartingWithLeftTurn                (4), 
+    multipleCurvesStartingWithRightTurn               (5)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-ObstacleOnTheRoad`. 
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                - in case further detailed information on the detected obstacle is unavailable,
+ * - 1 - `shedLoad`                   - in case detected obstacle is large amount of obstacles (shedload),
+ * - 2 - `partsOfVehicles`            - in case detected obstacles are parts of vehicles,
+ * - 3 - `partsOfTyres`               - in case the detected obstacles are parts of tyres,
+ * - 4 - `bigObjects`                 - in case the detected obstacles are big objects,
+ * - 5 - `fallenTrees`                - in case the detected obstacles are fallen trees,
+ * - 6 - `hubCaps`                    - in case the detected obstacles are hub caps,
+ * - 7 - `waitingVehicles-deprecated` - deprecated since not representing an obstacle and already covered by StationaryVehicleSubCauseCode.
+ * - 8-255                - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 7 deprecated in V2.4.1
+ */
+HazardousLocation-ObstacleOnTheRoadSubCauseCode ::= INTEGER {
+    unavailable                (0), 
+    shedLoad                   (1), 
+    partsOfVehicles            (2), 
+    partsOfTyres               (3), 
+    bigObjects                 (4), 
+    fallenTrees                (5), 
+    hubCaps                    (6), 
+    waitingVehicles-deprecated (7)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-SurfaceCondition`. 
+ * 
+The value shall be set to:
+ * - 0  - `unavailable`                  - in case further detailed information on the road surface condition is unavailable,
+ * - 1  - `rockfalls`                    - in case rock falls have fallen on the road surface,
+ * - 2  - `earthquakeDamage-deprecated`  - deprecated since it is covered by 1 rockfalls and 4 subsidence,
+ * - 3  - `sinkhole`                     - in case of a partial collapse of the road surface that creates a depression (hole) in the pavement,
+ * - 4  - `subsidence`                   - in case road surface is damaged by subsidence,
+ * - 5  - `snowDrifts-deprecated`        - deprecated since not representing a road damage,
+ * - 6  - `stormDamage-deprecated`       - deprecated since not representing a road damage,
+ * - 7  - `burstPipe-deprecated`         - deprecated since not representing a road damage,
+ * - 8  - `lava           `              - in case road surface is damaged due to  lava on the road,
+ * - 9  - `fallingIce-deprecated`        - deprecated since not representing a road damage,
+ * - 10 - `fire`                         - in case there is fire on or near to the road surface,
+ * - 11 - `flooding-deprecated`          - deprecated since not representing a road damage.
+ * - 12 - `wearAndTear`                  - in case the road surface is damaged by wear and tear.
+ * - 13-255                              - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 10 added in V2.1.1, value 11 added in V2.3.1, 
+              name and definition of value 3 and 8 changed in V2.4.1, values 2, 5, 6, 7, 9 and 11 deprecated in V2.4.1, vaue 12 added in V2.4.1
+ */
+HazardousLocation-SurfaceConditionSubCauseCode ::= INTEGER {
+    unavailable                 (0), 
+    rockfalls                   (1), 
+    earthquakeDamage-deprecated (2), 
+    sinkhole                    (3), 
+    subsidence                  (4), 
+    snowDrifts-deprecated       (5), 
+    stormDamage-deprecated      (6), 
+    burstPipe-deprecated        (7), 
+    lava                        (8), 
+    fallingIce-deprecated       (9), 
+    fire                        (10),
+    flooding-deprecated         (11),
+    wearAndTear                 (12)      
+} (0..255)
+
+/**
+ * This DE indicates the heading confidence value which represents the estimated absolute accuracy of a heading value with a confidence level of 95 %.
+ * 
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n x 0,1 degree and more than (n-1) x 0,1 degree,
+ * - `126` if the confidence value is out of range, i.e. greater than 12,5 degrees,
+ * - `127` if the confidence value information is not available.
+ * 
+ * @note:	The fact that a value is received with confidence value set to `unavailable(127)` can be caused by several reasons,
+ * such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the heading value may be valid and used by the application.
+ *
+ * @note: If a heading value is received and its confidence value is set to `outOfRange(126)`, it means that the 
+ * heading value is not valid and therefore cannot be trusted. Such value is not useful for the application.
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84AngleConfidence instead. 
+ * 
+ * @unit: 0,1 degree
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1
+ */
+HeadingConfidence ::= INTEGER {
+    outOfRange  (126), 
+    unavailable (127)  
+} (1..127)
+
+/**
+ * This DE represents the orientation of the horizontal velocity vector with regards to the WGS84 north.
+ * When the information is not available, the DE shall be set to 3 601. The value 3600 shall not be used.
+ *
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84AngleValue instead. 
+ *
+ * Unit: 0,1 degree
+ * Categories: GeoReference information
+ * @revision: Description revised in V2.1.1 (usage of value 3600 specified) 
+*/
+HeadingValue ::= INTEGER { 
+    wgs84North  (0),
+    wgs84East   (900),
+    wgs84South  (1800),
+    wgs84West   (2700),
+    doNotUse    (3600),
+    unavailable (3601)
+} (0..3601)
+
+/**
+ * This DE represents the height of the left or right longitude carrier of vehicle from base to top (left or right carrier seen from vehicle
+ * rear to front). 
+ *
+ * The value shall be set to:
+ * - `n` (`n >= 1` and `n < 99`) if the height information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,
+ * - `99` if the height is out of range, i.e. equal to or greater than 0,98 m,
+ * - `100` if the height information is not available.
+ *
+ * @unit 0,01 metre
+ * @category Vehicle information
+ * @revision: Description revised in V2.1.1 (the definition of 99 has changed slightly) 
+ */
+HeightLonCarr ::= INTEGER {
+    outOfRange(99),
+    unavailable(100)
+} (1..100)
+
+/**
+ * This DE represents the value of the sub cause code of the @ref CauseCode `humanPresenceOnTheRoad`.
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`                    - in case further detailed information abou the human presence on the road is unavailable,
+ * - 1 - `childrenOnRoadway`              - in case children are present on the road,
+ * - 2 - `cyclistOnRoadway`               - in case cyclist(s) are present on the road,
+ * - 3 - `motorcyclistOnRoadway`          - in case motorcyclist(s) are present on the road,
+ * - 4 - `pedestrian`                     - in case pedestrian(s) of any type are present on the road,
+ * - 5 - `ordinary-pedestrian`            - in case pedestrian(s) to which no more-specific profile applies are present on the road,
+ * - 6 - `road-worker`                    - in case pedestrian(s) with the role of a road worker applies are present on the road,
+ * - 7 - `first-responder`                - in case pedestrian(s) with the role of a first responder applies are present on the road,  
+ * - 8 - `lightVruVehicle                 - in case light vru vehicle(s) of any type are present on the road,
+ * - 9 - `bicyclist `                     - in case cycle(s) and their bicyclist(s) are present on the road,
+ * - 10 - `wheelchair-user`               - in case wheelchair(s) and their user(s) are present on the road,
+ * - 11 - `horse-and-rider`               - in case horse(s) and rider(s) are present on the road,
+ * - 12 - `rollerskater`                  - in case rolleskater(s) and skater(s) are present on the road,
+ * - 13 - `e-scooter`                     - in case e-scooter(s) and rider(s) are present on the road,
+ * - 14 - `personal-transporter`          - in case personal-transporter(s) and rider(s) are present on the road,
+ * - 15 - `pedelec`                       - in case pedelec(s) and rider(s) are present on the road,
+ * - 16 - `speed-pedelec`                 - in case speed-pedelec(s) and rider(s) are present on the road,
+ * - 17 - `ptw`                           - in case powered-two-wheeler(s) of any type are present on the road,
+ * - 18 - `moped`                         - in case moped(s) and rider(s) are present on the road,
+ * - 19 - `motorcycle`                    - in case motorcycle(s) and rider(s) are present on the road,
+ * - 20 - `motorcycle-and-sidecar-right`  - in case motorcycle(s) with sidecar(s) on the right and rider are present on the road,
+ * - 21 - `motorcycle-and-sidecar-left`   - in case motorcycle(s) with sidecar(s) on the left and rider are present on the road.
+ * - 22-255                               - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: editorial revision in V2.1.1, named values 4-21 added in V2.2.1
+ */
+HumanPresenceOnTheRoadSubCauseCode ::= INTEGER {
+    unavailable                  (0), 
+    childrenOnRoadway            (1), 
+    cyclistOnRoadway             (2), 
+    motorcyclistOnRoadway        (3),
+    pedestrian                   (4),
+    ordinary-pedestrian          (5),
+    road-worker                  (6),
+    first-responder              (7),
+    lightVruVehicle              (8), 
+    bicyclist                    (9), 
+    wheelchair-user              (10), 
+    horse-and-rider              (11), 
+    rollerskater                 (12), 
+    e-scooter                    (13), 
+    personal-transporter         (14),
+    pedelec                      (15), 
+    speed-pedelec                (16),
+    ptw                          (17), 
+    moped                        (18), 
+    motorcycle                   (19), 
+    motorcycle-and-sidecar-right (20), 
+    motorcycle-and-sidecar-left  (21)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode "humanProblem".
+ * 
+ * The value shall be set to:
+ * - 0 - `unavailable`        - in case further detailed information on human health problem is unavailable,
+ * - 1 - `glycemiaProblem`    - in case human problem is due to glycaemia problem,
+ * - 2 - `heartProblem`       - in case human problem is due to heart problem,
+ * - 3 - `unresponsiveDriver` - in case an unresponsive driver is detected.
+ * - 3-255                    - reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 3 assigned in V2.4.1
+ */
+HumanProblemSubCauseCode ::= INTEGER {
+    unavailable        (0), 
+    glycemiaProblem    (1), 
+    heartProblem       (2),
+    unresponsiveDriver (3)
+} (0..255)
+
+/** 
+ * This DE is a general identifier.
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+Identifier1B ::= INTEGER (0..255)
+
+/** 
+ * This DE is a general identifier.
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+Identifier2B ::= INTEGER (0..65535)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `impassability`
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`              - in case further detailed information about the unmanaged road blockage is unavailable,
+ * - 1 `flooding          `       - in case the road is affected by flooding,
+ * - 2 `dangerOfAvalanches`       - in case the road is at risk of being affected or blocked by avalanches,
+ * - 3 `blastingOfAvalanches`     - in case there is an active blasting of avalanches on or near the road,
+ * - 4 `landslips`                - in case the road is affected by landslips,
+ * - 5 `chemicalSpillage`         - in case the road is affected by chemical spillage,
+ * - 6 `winterClosure`            - in case the road is impassable due to a winter closure.
+ * - 7 `sinkhole`                 - in case the road is impassable due to large holes in the road surface.
+ * - 8 `earthquakeDamage`         - in case the road is obstructed or partially obstructed because of damage caused by an earthquake.
+ * - 9 `fallenTrees`              - in case the road is obstructed or partially obstructed by one or more fallen trees. 
+ * - 10 `rockfalls`               - in case the road is obstructed or partially obstructed due to fallen rocks.
+ * - 11 `sewerOverflow`           - in case the road is obstructed or partially obstructed by overflows from one or more sewers. 
+ * - 12 `stormDamage`             - in case the road is obstructed or partially obstructed by debris caused by strong winds.
+ * - 13 `subsidence`              - in case the road surface has sunken or collapsed in places.
+ * - 14 `burstPipe`               - in case the road surface has sunken or collapsed in places due to burst pipes.
+ * - 15 `burstWaterMain`          - in case the road is obstructed due to local flooding and/or subsidence. 
+ * - 16 `fallenPowerCables`       - in case the road is obstructed or partly obstructed by one or more fallen power cables.
+ * - 17 `snowDrifts`              - in case the road is obstructed or partially obstructed by snow drifting in progress or patches of deep snow due to earlier drifting.
+ * - 15-255                       - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: Created in V2.2.1
+*/
+ImpassabilitySubCauseCode ::= INTEGER {
+    unavailable               (0), 
+    flooding                  (1),
+    dangerOfAvalanches        (2), 
+    blastingOfAvalanches      (3), 
+    landslips                 (4), 
+    chemicalSpillage          (5),
+    winterClosure             (6),
+    sinkhole                  (7),
+    earthquakeDamage          (8),
+    fallenTrees               (9),
+    rockfalls                 (10),
+    sewerOverflow             (11),
+    stormDamage               (12),
+    subsidence                (13),
+    burstPipe                 (14),
+    burstWaterMain            (15),
+    fallenPowerCables         (16),
+    snowDrifts                (17)
+} (0..255)
+
+/**
+ * This DE represents the quality level of provided information.
+ * 
+ * The value shall be set to:
+ * - `0` if the information is unavailable,
+ * - `1` if the quality level is lowest,
+ * - `n` (`n > 1` and `n < 7`) if the quality level is n, 
+ * - `7` if the quality level is highest.
+ *
+ * @note: Definition of quality level is out of scope of the present document.
+ * @category: Basic information
+ * @revision: Editorial update in V2.1.1
+ */
+InformationQuality ::= INTEGER (0..7)
+
+/** 
+ * This DE defines the type of an interference management zone, so that an ITS-S can 
+ * assert the actions to do while passing by such zone (e.g. reduce the transmit power in case of a DSRC tolling station).
+ * It is an extension of the type @ref ProtectedZoneType.
+ *
+ * The value shall be set to:
+ * - 0 - `permanentCenDsrcTolling` - as specified in ETSI TS 102 792 [14],
+ * - 1 - `temporaryCenDsrcTolling` - as specified in ETSI TS 102 792 [14],
+ * - 2 - `unavailable`             - default value. Set to 2 for backwards compatibility with DSRC tolling,
+ * - 3 - `urbanRail`               - as specified in ETSI TS 103 724 [13], clause 7,
+ * - 4 - `satelliteStation`        - as specified in ETSI TS 103 724 [13], clause 7,
+ * - 5 - `fixedLinks`              - as specified in ETSI TS 103 724 [13], clause 7.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.1.1
+ */
+InterferenceManagementZoneType ::= ENUMERATED {
+    permanentCenDsrcTolling (0),
+    temporaryCenDsrcTolling (1),
+    unavailable             (2), 
+    urbanRail               (3),      
+    satelliteStation        (4),
+    fixedLinks              (5), 
+    ...
+}
+
+/**
+ * This DE represents the vehicle type according to ISO 3833 [22].
+ * A "term No" refers to the number of the corresponding term and its definition in ISO 3833.
+ *
+ * The value shall be set to:
+ * - 0	- `passengerCar`              - term No 3.1.1
+ * - 1	- `saloon`                    - term No 3.1.1.1 (sedan)
+ * - 2	- `convertibleSaloon`         - term No 3.1.1.2
+ * - 3	- `pullmanSaloon`             - term No 3.1.1.3
+ * - 4	- `stationWagon`              - term No 3.1.1.4
+ * - 5	- `truckStationWagon`         - term No 3.1.1.4.1
+ * - 6	- `coupe`                     - term No 3.1.1.5 (coupe)
+ * - 7	- `convertible`               - term No 3.1.1.6 (open tourer, roadstar, spider)
+ * - 8	- `multipurposePassengerCar`  - term No 3.1.1.7
+ * - 9	- `forwardControlPassengerCar`- term No 3.1.1.8
+ * - 10	- `specialPassengerCar`       - term No 3.1.1.9
+ * - 11	- `bus`                       - term No 3.1.2
+ * - 12	- `minibus`                   - term No 3.1.2.1
+ * - 13	- `urbanBus`                  - term No 3.1.2.2
+ * - 14	- `interurbanCoach`           - term No 3.1.2.3
+ * - 15	- `longDistanceCoach`         - term No 3.1.2.4
+ * - 16	- `articulatedBus`            - term No 3.1.2.5
+ * - 17	- `trolleyBus	`             - term No 3.1.2.6
+ * - 18	- `specialBus`                - term No 3.1.2.7
+ * - 19	- `commercialVehicle`         - term No 3.1.3
+ * - 20	- `specialCommercialVehicle`  - term No 3.1.3.1
+ * - 21	- `specialVehicle`            - term No 3.1.4
+ * - 22	- `trailingTowingVehicle`     - term No 3.1.5 (draw-bar tractor)
+ * - 23	- `semiTrailerTowingVehicle`  - term No 3.1.6 (fifth wheel tractor)
+ * - 24	- `trailer`                   - term No 3.2.1
+ * - 25	- `busTrailer`                - term No 3.2.1.1
+ * - 26	- `generalPurposeTrailer`     - term No 3.2.1.2
+ * - 27	- `caravan`                   - term No 3.2.1.3
+ * - 28	- `specialTrailer`            - term No 3.2.1.4
+ * - 29	- `semiTrailer`               - term No 3.2.2
+ * - 30	- `busSemiTrailer`            - term No 3.2.2.1
+ * - 31	- `generalPurposeSemiTrailer` - term No 3.2.2.2
+ * - 32	- `specialSemiTrailer`        - term No 3.2.2.3
+ * - 33	- `roadTrain`                 - term No 3.3.1
+ * - 34	- `passengerRoadTrain`        - term No 3.3.2
+ * - 35	- `articulatedRoadTrain`      - term No 3.3.3
+ * - 36	- `doubleRoadTrain`           - term No 3.3.4
+ * - 37	- `compositeRoadTrain`        - term No 3.3.5
+ * - 38	- `specialRoadTrain`          - term No 3.3.6
+ * - 39	- `moped`                     - term No 3.4
+ * - 40	- `motorCycle`                - term No 3.5
+ * - 41-255                           - reserved for future use
+ * 
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+ */
+Iso3833VehicleType ::= INTEGER {
+    passengerCar                 (0),
+    saloon                       (1),	
+    convertibleSaloon            (2),	
+    pullmanSaloon                (3),	
+    stationWagon                 (4),	
+    truckStationWagon            (5),	
+    coupe                        (6),
+    convertible                  (7),	
+    multipurposePassengerCar     (8),	
+    forwardControlPassengerCar   (9),	
+    specialPassengerCar	         (10),
+    bus	                         (11),
+    minibus                      (12),	
+    urbanBus                     (13),	
+    interurbanCoach              (14),	
+    longDistanceCoach            (15),	
+    articulatedBus               (16),	
+    trolleyBus                   (17),
+    specialBus                   (18),	
+    commercialVehicle            (19),	
+    specialCommercialVehicle     (20),
+    specialVehicle               (21),	
+    trailingTowingVehicle        (22),	
+    semiTrailerTowingVehicle     (23),	
+    trailer                      (24),	
+    busTrailer                   (25),
+    generalPurposeTrailer        (26),
+    caravan                      (27),	
+    specialTrailer               (28),	
+    semiTrailer	                 (29),	
+    busSemiTrailer               (30),	
+    generalPurposeSemiTrailer    (31),
+    specialSemiTrailer           (32),	
+    roadTrain                    (33),	
+    passengerRoadTrain           (34),	
+    articulatedRoadTrain         (35),	
+    doubleRoadTrain	             (36),
+    compositeRoadTrain           (37),	
+    specialRoadTrain             (38),	
+    moped                        (39),	
+    motorCycle                   (40)	
+	} (0..255)
+
+/** 
+ * This DE represent the identifier of an organization according to the applicable registry.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.2.1 based on ISO 14816 [23]
+*/
+IssuerIdentifier ::= INTEGER(0 .. 16383)
+
+/** 
+ * This DE represents the identifier of the IVIM.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.2.1 based on ETSI TS 103 301 [15]
+*/
+IviIdentificationNumber::= INTEGER(1..32767,..., 8388607) 
+
+/**
+ * This DE indicates a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway. 
+ *
+ * For right-hand traffic roads, the value shall be set to:
+ * - `-1` if the position is off, i.e. besides the road,
+ * - `0` if the position is on the inner hard shoulder, i.e. the hard should adjacent to the leftmost lane,
+ * - `n` (`n > 0` and `n < 14`), if the position is on the n-th driving lane counted from the leftmost lane to the rightmost lane of a specific traffic direction,
+ * - `14` if the position is on the outer hard shoulder, i.e. the hard should adjacent to rightmost lane (if present).
+ *
+ * For left-hand traffic roads, the value shall be set to:
+ * - `-1` if the position is off, i.e. besides the road,
+ * - `0` if the position is on the inner hard shoulder, i.e. the hard should adjacent to the rightmost lane,
+ * - `n` (`n > 0` and `n < 14`), if the position is on the n-th driving lane counted from the rightmost lane to the leftmost lane of a specific traffic direction,
+ * - `14` if the position is on the outer hard shoulder, i.e. the hard should adjacent to leftmost lane (if present).
+ *
+ *  @note: in practice this means that the position is counted from "inside" to "outside" no matter which traffic practice is used.
+ *
+ * If the carriageway allows only traffic in one direction (e.g. in case of dual or multiple carriageway roads), the position is counted from the physical border of the carriageway. 
+ * If the carriageway allows traffic in both directions and there is no physical delimitation between traffic directions (e.g. on a single carrriageway road), 
+ * the position is counted from the legal (i.e. optical) separation between traffic directions (horizontal marking). 
+ *
+ * If not indicated otherwise (by lane markings or traffic signs), the legal separation on carriageways allowing traffic on both directions is identified as follows:
+ * - If the total number of lanes N is even, the lanes are divided evenly between the traffic directions starting from the outside of the carriageway on both sides and the 
+ *   imaginary separation between traffic directions is on the border between the even number of lanes N/2.
+ * - If the total number of lanes N is odd, the lanes are divided evenly between traffic direction starting from the outside of the carriageway on both sides. 
+ *   The remaining middle lane is assigned to both traffic directions as innermost lane.
+ *
+ * @category: Road topology information
+ * @revision: Description of the legal separation of carriageways added in V2.2.1
+*/
+LanePosition ::= INTEGER {
+    offTheRoad           (-1), 
+    innerHardShoulder    (0), 
+    outerHardShoulder    (14) 
+} (-1..14)
+
+/**
+ * This DE represents the type of a lane. 
+ * 
+ * The value shall be set to:
+ * - 0	- `traffic`            - Lane dedicated to the movement of vehicles,
+ * - 1	- `through`            - Lane dedicated to the movement of vehicles travelling ahead and not turning,
+ * - 2	- `reversible`         - Lane where the direction of traffic can be changed to match the peak flow,
+ * - 3	- `acceleration`	   - Lane that allows vehicles entering a road to accelerate to the speed of through traffic before merging with it,
+ * - 4	- `deceleration`       - Lane that allows vehicles exiting a road to decelerate before leaving it,
+ * - 5	- `leftHandTurning`    - Lane reserved for slowing down and making a left turn, so as not to disrupt traffic,
+ * - 6	- `rightHandTurning`   - Lane reserved for slowing down and making a right turn so as not to disrupt traffic,
+ * - 7	- `dedicatedVehicle`   - Lane dedicated to movement of motor vehicles with specific characteristics, such as heavy goods vehicles, etc., 
+ * - 8	- `bus`                - Lane dedicated to movement of buses providing public transport,
+ * - 9	- `taxi`               - Lane dedicated to movement of taxis,
+ * - 10	- `hov`                - Carpooling lane or high occupancy vehicle lane,
+ * - 11	- `hot`                - High occupancy vehicle lanes that is allowed to be used without meeting the occupancy criteria by paying a toll,
+ * - 12	- `pedestrian`         - Lanes dedicated to pedestrians such as pedestrian sidewalk paths,
+ * - 13	- `cycleLane`	       - Lane dedicated to exclusive or preferred use by bicycles,
+ * - 14	- `median`             - Lane not dedicated to movement of vehicles but representing a median / central reservation  such as the central median, 
+                                 separating the two directional carriageways of the highway,
+ * - 15	- `striping`	       - Lane not dedicated to movement of vehicles but covered with roadway markings,
+ * - 16	- `trackedVehicle`     - Lane dedicated to movement of trains, trams and trolleys,
+ * - 17	- `parking`            - Lanes dedicated to vehicles parking, stopping and loading lanes,
+ * - 18	- `emergency`          - Lane dedicated to vehicles in breakdown or to emergency vehicles also called hard shoulder,
+ * - 19	- `verge`              - Lane representing the verge, i.e. a narrow strip of grass or plants and sometimes also trees located between 
+                                 the road surface edge and the boundary of a road,
+ * - 20	`minimumRiskManoeuvre` - Lane dedicated to automated vehicles making a minimum risk manoeuvre,
+ * - 21	`separatedCycleLane`   - Lane dedicated to exclusive or preferred use by bicycles that is phyisically separated from the vehicle-traffic lanes, e.g. by a verge.
+ * - values 22 to 30             reserved for future use. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.1.1, named value 21 added in V2.2.1
+*/
+LaneType::= INTEGER{
+	traffic              (0),
+	through	             (1),
+	reversible           (2),
+	acceleration         (3),
+	deceleration         (4),
+	leftHandTurning      (5),
+	rightHandTurning     (6),
+	dedicatedVehicle     (7),
+	bus                  (8),
+	taxi                 (9),
+	hov                  (10),
+	hot                  (11),
+	pedestrian           (12),
+	cycleLane            (13),
+	median               (14),   
+	striping             (15),
+	trackedVehicle       (16),
+	parking	             (17),
+	emergency            (18),
+	verge                (19),
+	minimumRiskManoeuvre (20),
+    exclusiveCycleLane   (21),
+	unknown              (31)
+}(0..31)
+
+/**
+ * This DE represents the width of a lane measured at a defined position.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 1022`) if the lane width information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,
+ * - `1022` if the lane width is out of range, i.e. greater than 10,21 m,
+ * - `1023` if the lane width information is not available.
+ *
+ * The value 0 shall not be used.
+ *
+ * @unit: 0,01 metre
+ * @category: Road topology information
+ * @revision: Created in V2.1.1
+ */
+LaneWidth::= INTEGER (0..1023)
+
+/**
+ * This DE represents the absolute geographical latitude in a WGS84 coordinate system, providing a range of 90 degrees in north or
+ * in south hemisphere.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * The value shall be set to:
+ * - `n` (`n >= -900 000 000` and `n < 0`) x 10^-7 degree, i.e. negative values for latitudes south of the Equator,
+ * - `0` is used for the latitude of the equator,
+ * - `n` (`n > 0` and `n < 900 000 001`) x 10^-7 degree, i.e. positive values for latitudes north of the Equator,
+ * - `900 000 001` when the information is unavailable.
+ *
+ * @unit: 10^-7 degree
+ * @category: GeoReference information
+ * @revision: Editorial update in V2.1.1
+ */
+Latitude ::= INTEGER {
+    unavailable(900000001)
+} (-900000000..900000001)
+
+/**
+ * This DE represents the vehicle acceleration at lateral direction in the centre of the mass of the empty vehicle.
+ * It corresponds to the vehicle coordinate system as specified in ISO 8855 [21].
+ *
+ * The value shall be set to:
+ * - `-160` for acceleration values equal to or less than -16 m/s^2,
+ * - `n` (`n > -160` and `n <= 0`) to indicate that the vehicle is accelerating towards the right side with regards to the vehicle orientation 
+ *                            with acceleration equal to or less than n x 0,1 m/s^2 and greater than (n-1) x 0,1 m/s^2,
+ * - `n` (`n > 0` and `n < 160`) to indicate that the vehicle is accelerating towards the left hand side with regards to the vehicle orientation 
+						     with acceleration equal to or less than n x 0,1 m/s^2 and greater than (n-1) x 0,1 m/s^2,
+ * - `160` for acceleration values greater than 15,9 m/s^2,
+ * - `161` when the data is unavailable.
+ *
+ * @note: the empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationValue instead.
+ *  
+ * @unit: 0,1 m/s^2
+ * @category: Vehicle information
+ * @revision: Description updated in V2.1.1 (the meaning of 160 has changed slightly). 
+ */
+LateralAccelerationValue ::= INTEGER {
+    negativeOutOfRange (-160),
+    positiveOutOfRange (160),
+    unavailable        (161)  
+} (-160 .. 161)
+
+/**
+ * This DE indicates the status of light bar and any sort of audible alarm system besides the horn.
+ * This includes various common sirens as well as backup up beepers and other slow speed manoeuvring alerts.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 - `lightBarActivated`      - when the light bar is activated,
+ * - 1 - `sirenActivated`         - when the siren is activated.
+ *
+ * Otherwise, it shall be set to 0.
+ *
+ * @category Vehicle information
+ * @revision: Editorial update in V2.1.1
+ */
+LightBarSirenInUse ::= BIT STRING {
+    lightBarActivated (0),
+    sirenActivated    (1)
+} (SIZE(2))
+
+/**
+ * This DE represents the absolute geographical longitude in a WGS84 coordinate system, providing a range of 180 degrees
+ * to the east or to the west of the prime meridian.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * The value shall be set to:
+ * - `n` (`n > -1 800 000 000` and `n < 0`) x 10^-7 degree, i.e. negative values for longitudes to the west,
+ * - `0` to indicate the prime meridian,
+ * - `n` (`n > 0` and `n < 1 800 000 001`) x 10^-7 degree, i.e. positive values for longitudes to the east,
+ * - `1 800 000 001` when the information is unavailable.
+ *
+ * The value -1 800 000 000 shall not be used. 
+ * 
+ * @unit: 10^-7 degree
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1
+ */
+Longitude ::= INTEGER {
+    valueNotUsed (-1800000000),
+    unavailable  (1800000001)
+} (-1800000000..1800000001)
+
+ /**
+ * This DE represents the vehicle acceleration at longitudinal direction in the centre of the mass of the empty vehicle.
+ * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11.
+ *
+ * The value shall be set to:
+ * - `-160` for acceleration values equal to or less than -16 m/s^2,
+ * - `n` (`n > -160` and `n <= 0`) to indicate that the vehicle is braking with acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2
+ * - `n` (`n > 0` and `n < 160`) to indicate that the vehicle is accelerating with acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `160` for acceleration values greater than 15,9 m/s^2,
+ * - `161` when the data is unavailable. 
+ * 
+ * This acceleration is along the tangent plane of the road surface and does not include gravity components.
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationValue instead.
+ * 
+ * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ * @unit: 0,1 m/s^2
+ * @category: Vehicle information
+ * @revision: description revised in V2.1.1 (the meaning of 160 has changed slightly). T
+ */
+LongitudinalAccelerationValue::= INTEGER {
+    negativeOutOfRange (-160),
+    positiveOutOfRange (160),
+    unavailable        (161)  
+} (-160 .. 161)
+
+/** 
+ * This DE represents the longitudinal offset of a map-matched position along a matched lane, beginning from the lane's starting point.
+ * 
+ * The value shall be set to:
+ * - `n` (`n >= 0` and `n < 32766`) if the longitudinal offset information is equal to or less than n x 0,1 metre and more than (n-1) x 0,1 metre,
+ * - `32 766` if the longitudinal offset is out of range, i.e. greater than 3276,5 m,
+ * - `32 767` if the longitudinal offset information is not available. 
+ *
+ * @unit 0,1 metre
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+LongitudinalLanePositionValue ::= INTEGER {
+    outOfRange(32766),
+    unavailable(32767)
+}(0..32767)
+
+/** 
+ * This DE indicates the longitudinal lane position confidence value which represents the estimated accuracy of longitudinal lane position measurement with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 1 022`) if the  confidence value is equal to or less than n x 0,1 m, and more than (n-1) x 0,1 m,
+ * - `1 022` if the confidence value is out of range i.e. greater than 102,1 m,
+ * - `1 023` if the confidence value is unavailable.
+ *
+ * @unit 0,1 metre
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+LongitudinalLanePositionConfidence ::= INTEGER {
+    outOfRange  (1022),
+    unavailable (1023)  
+} (0..1023)
+
+/**
+ * This DE indicates the components of an @ref PerceivedObject that are included in the @ref LowerTriangularPositiveSemidefiniteMatrix.
+ *
+ * The corresponding bit shall be set to 1 if the component is included:
+ * - 0 - `xCoordinate`                   - when the component xCoordinate of the component @ref CartesianPosition3dWithConfidence is included,
+ * - 1 - `yCoordinate`                   - when the component yCoordinate of the component @ref CartesianPosition3dWithConfidence is included,   
+ * - 2 - `zCoordinate`                   - when the component zCoordinate of the component @ref CartesianPosition3dWithConfidence is included, 
+ * - 3 - `xVelocityOrVelocityMagnitude`  - when the component xVelocity of the component @ref VelocityCartesian or the component VelocityMagnitude of the component @ref VelocityPolarWithZ is included,   
+ * - 4 - `yVelocityOrVelocityDirection`  - when the component yVelocity of the component @ref VelocityCartesian or the component VelocityDirection of the component @ref VelocityPolarWithZ is included,   
+ * - 5 - `zVelocity`                     - when the component zVelocity of the component @ref VelocityCartesian or of the component @ref VelocityPolarWithZ is included,
+ * - 6 - `xAccelOrAccelMagnitude`        - when the component xAcceleration of the component @ref AccelerationCartesian or the component AccelerationMagnitude of the component @ref AccelerationPolarWithZ is included,  
+ * - 7 - `yAccelOrAccelDirection`        - when the component yAcceleration of the component @ref AccelerationCartesian or the component AccelerationDirection of the component @ref AccelerationPolarWithZ is included,   
+ * - 8 - `zAcceleration`                 - when the component zAcceleration of the component @ref AccelerationCartesian or of the component @ref AccelerationPolarWithZ is included,
+ * - 9 - `zAngle`                        - when the component zAngle is included,
+ * - 10 - `yAngle`                       - when the component yAngle is included,   
+ * - 11 - `xAngle`                       - when the component xAngle is included,   
+ * - 12 - `zAngularVelocity`             - when the component zAngularVelocity is included.   
+ *
+ * Otherwise, it shall be set to 0.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+ */
+MatrixIncludedComponents::= BIT STRING{
+    xPosition                    (0),
+    yPosition                    (1),
+    zPosition                    (2),
+    xVelocityOrVelocityMagnitude (3),
+    yVelocityOrVelocityDirection (4),
+    zSpeed                       (5),
+    xAccelOrAccelMagnitude       (6),
+    yAccelOrAccelDirection       (7),
+    zAcceleration                (8),
+    zAngle                       (9),  
+    yAngle                      (10), 
+    xAngle                      (11), 
+    zAngularVelocity              (12)
+} (SIZE(13,...))
+
+/** 
+ * This DE represents the type of facility layer message.
+ *
+ *  The value shall be set to:
+ *	- 1  - `denm`              - for Decentralized Environmental Notification Message (DENM) as specified in ETSI EN 302 637-3 [2],
+ *  - 2  - `cam`               - for Cooperative Awareness Message (CAM) as specified in ETSI EN 302 637-2 [1],
+ *  - 3  - `poim`              - for Point of Interest Message as specified in ETSI TS 103 916 [9],
+ *  - 4  - `spatem`            - for Signal Phase And Timing Extended Message (SPATEM) as specified in ETSI TS 103 301 [15],
+ *  - 5  - `mapem`             - for MAP Extended Message (MAPEM) as specified in ETSI TS 103 301 [15],
+ *  - 6  - `ivim`              - for in Vehicle Information Message (IVIM) as specified in ETSI TS 103 301 [15],
+ *  - 7  - `rfu1`              - reserved for future usage,
+ *  - 8  - `rfu2`              - reserved for future usage,
+ *  - 9  - `srem`              - for Signal Request Extended Message as specified in ETSI TS 103 301 [15],
+ *  - 10 - `ssem`              - for Signal request Status Extended Message as specified in ETSI TS 103 301 [15],
+ *  - 11 - `evcsn`             - for Electrical Vehicle Charging Spot Notification message as specified in ETSI TS 101 556-1 [9],
+ *  - 12 - `saem`              - for Services Announcement Extended Message as specified in ETSI EN 302 890-1 [17],
+ *  - 13 - `rtcmem`            - for Radio Technical Commission for Maritime Services Extended Message (RTCMEM) as specified in ETSI TS 103 301 [15],
+ *  - 14 - `cpm`               - for Collective Perception Message (CPM) as specified in ETSI TS 103 324 [10], 
+ *  - 15 - `imzm`              - for Interference Management Zone Message (IMZM) as specified in ETSI TS 103 724 [13],
+ *  - 16 - `vam`               - for Vulnerable Road User Awareness Message as specified in ETSI TS 130 300-3 [12], 
+ *  - 17 - `dsm`               - reserved for Diagnosis, logging and Status Message,
+ *  - 18 - `mim`               - for Marshalling Infrastructure Message as specified in ETSI TS TS 103 882 [11],
+ *  - 19 - `mvm`               - for Marshalling Vehicle Message as specified in ETSI TS TS 103 882 [11],
+ *  - 20 - `mcm`               - reserved for Manoeuvre Coordination Message,
+ *  - 21 - `pim`               - reserved for Parking Information Message, 
+ *  - 22-255                   - reserved for future usage.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.1.1 from @ref ItsPduHeader. Value 3 re-assigned to poim and value 7 and 8 reserved in V2.2.1, values 18 and 19 assigned in V2.3.1, 
+              value 21 assigned in V2.4.1
+ */
+MessageId::= INTEGER { 
+    denm              (1),  
+    cam               (2), 
+    poim              (3), 
+    spatem            (4), 
+    mapem             (5), 
+    ivim              (6), 
+    rfu1              (7), 
+    rfu2              (8), 
+    srem              (9), 
+    ssem              (10), 
+    evcsn             (11), 
+    saem              (12), 
+    rtcmem            (13), 
+    cpm               (14),
+    imzm              (15),
+    vam               (16),
+    dsm               (17), 
+    mim               (18),
+    mvm               (19),
+    mcm               (20),
+    pim               (21)
+} (0..255)
+
+/**
+ * This DE provides a factor to be multiplied with a DE that represents a measure of something, to extend the range/change the unit. 
+ * The DE that is multiplied is to be specified outside of the context of this DE, e.g. in a facility layer service specification.
+ *
+ * The value shall be set to:
+ * - `tenth`      - to indicate a factor of 0,1,        
+ * - `half`       - to indicate a factor of 0,5,        
+ * - `two`        - to indicate a factor of 2,        
+ * - `three`      - to indicate a factor of 3,        
+ * - `five`       - to indicate a factor of 5,        
+ * - `tenth`      - to indicate a factor of 10,        
+ * - `fifthy`     - to indicate a factor of 50,        
+ * - `hundred`    - to indicate a factor of 100,        
+ *
+ * @category: Basic information
+ * @revision: Created in V2.4.1
+ */
+MultiplicativeFactor::= ENUMERATED { 
+    tenth,
+    half, 
+    two,
+    three,
+    five,
+    ten,
+    fifty,
+    hundred,
+    ...
+}
+
+/**
+ * This DE represents the number of occupants in a vehicle.
+ *
+ * The value shall be set to:
+ * - `n` (`n >= 0` and `n < 126`) for the number n of occupants,
+ * - `126` for values equal to or higher than 125,
+ * - `127` if information is not available.
+ *
+ * @unit: 1 person
+ * @category: Vehicle information
+ * @revision: Editorial update in V2.1.1
+ */
+NumberOfOccupants ::= INTEGER {
+    outOfRange  (126),
+    unavailable (127)
+} (0 .. 127)
+
+/** 
+ * This DE represents a single-value indication about the overall information quality of a perceived object.
+ * 
+ * The value shall be set to:  
+ * - `0`                        : if there is no confidence in detected object, e.g. for "ghost"-objects or if confidence could not be computed,
+ * - `n` (`n > 0` and `n < 15`) : for the applicable confidence value,
+ * - `15`                       : if there is full confidence in the detected Object.
+ * 
+ * @unit n/a
+ * @category: Sensing information
+ * @revision: Created in V2.1.1 
+*/
+ObjectPerceptionQuality ::= INTEGER {
+    noConfidence        (0), 
+    fullConfidence      (15) 
+} (0..15)
+
+/** 
+ * This DE represents a single dimension of an object.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 255`) if the dimension is equal to or less than n x 0,1 m, and more than (n-1) x 0,1 m,
+ * - `255` if the dimension is out of range i.e. greater than 25,4 m,
+ * - `256` if the dimension is unavailable.
+ *
+ * @unit 0,1 m
+ * @category: Basic information
+ * @revision: Created in V2.1.1, corrected the wording in V2.4.1 
+*/
+ObjectDimensionValue ::= INTEGER { 
+    outOfRange              (255),
+    unavailable             (256)
+}(1..256)
+
+/** 
+ * This DE indicates the object dimension confidence value which represents the estimated absolute accuracy of an object dimension value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 31`) if the confidence value is equal to or less than n x 0,1 metre, and more than (n-1) x 0,1 metre,
+ * - `31` if the confidence value is out of range i.e. greater than 3,0 m,
+ * - `32` if the confidence value is unavailable.
+ *
+ * @unit 0,1 m
+ * @category: Sensing information
+ * @revision: Created in V2.1.1 
+*/
+ObjectDimensionConfidence ::= INTEGER { 
+    outOfRange              (31),
+    unavailable             (32)
+} (1..32)
+
+/**
+ * This DE indicates the face or part of a face of a solid object.
+ *
+ * The object is modelled  as a rectangular prism that has a length that is greater than its width, with the faces of the object being defined as:
+ * - front: the face defined by the prism's width and height, and which is the first face in direction of longitudinal movement of the object,
+ * - back: the face defined by the prism's width and height, and which is the last face in direction of longitudinal movement of the object,
+ * - side: the faces defined by the prism's length and height with "left" and "right" defined by looking at the front face and "front" and "back" defined w.r.t to the front and back faces. 
+ *
+ * Note: It is permissible to derive the required object dimensions and orientation from models to provide a best guess.
+ * 
+ * @category: Basic information
+ * @revision: V2.1.1
+*/
+ObjectFace ::= ENUMERATED {
+    front          (0), 
+    sideLeftFront  (1), 
+    sideLeftBack   (2), 
+    sideRightFront (3), 
+    sideRightBack  (4),
+    back           (5)   
+}
+
+/**
+ * This DE represents a time period to describe the opening days and hours of a Point of Interest.
+ * (for example local commerce).
+ *
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+OpeningDaysHours ::= UTF8String 
+
+/**
+ * The DE represents an ordinal number that indicates the position of an element in a set. 
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+OrdinalNumber1B ::= INTEGER(0..255) 
+
+
+/**
+ * The DE represents an ordinal number that indicates the position of an element in a set. 
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+OrdinalNumber3b ::= INTEGER(1..8) 
+
+/** 
+ * This DE indicates the subclass of a detected object for @ref ObjectClass "otherSubclass".
+ *
+ * The value shall be set to:
+ * - `0` - unknown          - if the subclass is unknown.
+ * - `1` - singleObject     - if the object is a single object.
+ * - `2` - multipleObjects  - if the object is a group of multiple objects.
+ * - `3` - bulkMaterial     - if the object is a bulk material.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+ */
+OtherSubClass ::= INTEGER {
+    unknown         (0),
+    singleObject    (1),
+    multipleObjects (2),
+    bulkMaterial    (3)
+} (0..255)
+
+/** 
+ * This DE indicates the arrangement of parking space in a parking area.
+ *
+ * The value shall be set to:
+ * - `0` to indicate that the parking spaces are arranged in a line and parallel to a road or curb,
+ * - `1` to indicate that the parking spaces are arranged side-by-side and diagonally to a curb,
+ * - `2` to indicate that the parking spaces are arranged side-by-side and perpendicularly to a curb,
+ * - `3` to indicate that the parking spaces are arranged so that vehicles form a queue,
+ * - `4` to indicate that the parking spaces are arranged in a mixed fashion, 
+ * - 5-7 - reserved for future usage. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.3.1
+*/ 
+ParkingAreaArrangementType ::= INTEGER { 
+   parallelParkingSpace      (0), 
+   diagonalParkingSpace      (1), 
+   perpendicularParkingSpace (2),
+   queueParking              (3),
+   mixed                     (4),
+   unknown                   (7)   
+} (0..7)
+
+/** 
+ * This DE indicates the type of a reservation of a parking space/area.
+ *
+ * The value shall be set to:
+ * - `0` to indicate that it is reserved to disabled persons,
+ * - `1` to indicate that it is reserved to pregnant women,
+ * - `2` to indicate that it is reserved to women,
+ * - `3` to indicate that it is reserved to parents with small children,
+ * - `4` to indicate that it is reserved for loading and unloading of goods,
+ * - `5` to indicate that it is reserved for manual charging of electric vehicles,
+ * - `6` to indicate that it is reserved for automated charging of electric vehicles,
+ * - `7` to indicate that it is reserved for vehicles carrying out refrigerated transport of goods,
+ * - `8` to indicate that it is reserved for VIPs,
+ * - `9` to indicate that it is reserved for pre-booked reservations only,
+ * - `10` to indicate that it is not reserved and can still be reserved,
+ * - `11` to indicate that a reservation type is not applicable, i.e. that it cannot be reserved,
+ * - `12` to indicate that it reserved for drop-off and pick-up of vehicles for automated valet parking,
+ * - `13` to indicate that it is reserved for vehicles with a permit,
+ * - `14` to indicate that it is an (often unmarked / undesignated, but still not prohibited) space/area which is reserved for use only on occasions 
+          when all official marked parking spaces to which it blocks the access (if any), are already occupied at the moment of arrival.
+ * - 15-31  - reserved for future usage. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.3.1, value 14 assigned in V2.4.1.
+*/
+ParkingReservationType ::= INTEGER { 
+   disabled                         (0), 
+   pregnant                         (1), 
+   womenOnly                        (2), 
+   parentAndChild                   (3), 
+   loadAndOffloadGoods              (4), 
+   manualElectricVehicleCharging    (5), 
+   automatedElectricVehicleCharging (6), 
+   refriferatedTransport            (7),
+   vip                              (8),
+   preBooking                       (9), 
+   freeToBeReserved                 (10),
+   reservationNotPossible           (11),
+   automatedValetparking            (12), 
+   permit                           (13),
+   unmarked                         (14)
+}(0..31)
+
+
+/**
+ * This DE represents the recorded or estimated travel time between a position and a predefined reference position. 
+ *
+ * @unit 0,01 second
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+PathDeltaTime ::= INTEGER (1..65535, ...) 
+
+/** 
+ * This DE indicates an ordinal number that represents the position of a component in the list of @ref Traces or @ref TracesExtended. 
+ *
+ * The value shall be set to:
+ * - `0` - noPath  - if no path is identified
+ * - `1..7`        - for instances 1..7 of @ref Traces 
+ * - `8..14`       - for instances 1..7 of @ref TracesExtended. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+PathId ::= INTEGER {
+    noPath        (0),
+    path1         (1),
+    path2         (2),
+    path3         (3),
+    path4         (4),
+    path5         (5),
+    path6         (6),
+    path7         (7),
+    pathExtended1 (8),
+    pathExtended2 (9),
+    pathExtended3 (10),
+    pathExtended4 (11),
+    pathExtended5 (12),
+    pathExtended6 (13),
+    pathExtended7 (14)
+} (0..14)
+
+/**
+ * This DE represents the position of a vehicle pedal (e.g. brake or accelerator pedal).
+ *
+ * @unit: 10%
+ * @category: Vehicle information
+ * @revision: Created in V2.3.1
+*/
+PedalPositionValue::= INTEGER {
+    notPressed       (0),
+    fullyPressed     (10),
+    unavailable      (11) 
+} (0..11)
+
+/**
+ * This DE denotes the ability of an ITS-S to provide information fullfilling additional requirements.
+ * A performance class value is used to describe characteristics of data. The semantic defintion of the values are out of scope of the present document 
+ * and should be subject to profiling.
+ * 
+ *  The value shall be set to:
+ * - `0` if  the performance class is unknown,
+ * - `1` for performance class A,
+ * - `2` for performance class B,
+ * -  3-7 reserved for future use.
+ *
+ * @category: Vehicle information
+ * @revision: Editorial update in V2.1.1, description changed in V2.3.1
+ */
+PerformanceClass ::= INTEGER {
+    unavailable       (0), 
+    performanceClassA (1), 
+    performanceClassB (2)
+} (0..7)
+
+/**
+ * This DE represents a telephone number
+ * 
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+PhoneNumber ::= NumericString (SIZE(1..16))
+
+/**
+ * This DE indicates the perpendicular distance from the centre of mass of an empty load vehicle to the front line of
+ * the vehicle bounding box of the empty load vehicle.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 62`) for any aplicable value n between 0,1 metre and 6,2 metres, 
+ * - `62` for values equal to or higher than 6.1 metres,
+ * - `63`  if the information is unavailable.
+ * 
+ * @note:	The empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ *
+ * @unit 0,1 metre 
+ * @category Vehicle information
+ * @revision: description revised in V2.1.1 (the meaning of 62 has changed slightly) 
+ */
+PosCentMass ::= INTEGER {
+    tenCentimetres (1), 
+    outOfRange     (62),
+    unavailable    (63)
+} (1..63)
+
+/**
+ * This DE indicates the positioning technology being used to estimate a geographical position.
+ *
+ * The value shall be set to:
+ * - 0 `noPositioningSolution`  - no positioning solution used,
+ * - 1 `sGNSS`                  - Global Navigation Satellite System used,
+ * - 2 `dGNSS`                  - Differential GNSS used,
+ * - 3 `sGNSSplusDR`            - GNSS and dead reckoning used,
+ * - 4 `dGNSSplusDR`            - Differential GNSS and dead reckoning used,
+ * - 5 `dR`                     - dead reckoning used,
+ * - 6 `manuallyByOperator`     - position set manually by a human operator.
+ *
+ * @category: GeoReference information
+ * @revision: V1.3.1, extension with value 6 added in V2.2.1
+ */
+PositioningSolutionType ::= ENUMERATED {
+    noPositioningSolution (0), 
+    sGNSS                 (1), 
+    dGNSS                 (2), 
+    sGNSSplusDR           (3), 
+    dGNSSplusDR           (4), 
+    dR                    (5), 
+    ...,
+    manuallyByOperator    (6)
+}
+
+/**
+ * This DE indicates whether a passenger seat is occupied or whether the occupation status is detectable or not.
+ * 
+ * The number of row in vehicle seats layout is counted in rows from the driver row backwards from front to the rear
+ * of the vehicle.
+ * The left side seat of a row refers to the left hand side seen from vehicle rear to front.
+ * Additionally, a bit is reserved for each seat row, to indicate if the seat occupation of a row is detectable or not,
+ * i.e. `row1NotDetectable (3)`, `row2NotDetectable(8)`, `row3NotDetectable(13)` and `row4NotDetectable(18)`.
+ * Finally, a bit is reserved for each row seat to indicate if the seat row is present or not in the vehicle,
+ * i.e. `row1NotPresent (4)`, `row2NotPresent (9)`, `row3NotPresent(14)`, `row4NotPresent(19)`.
+ * 
+ * When a seat is detected to be occupied, the corresponding seat occupation bit shall be set to `1`.
+ * For example, when the row 1 left seat is occupied, `row1LeftOccupied(0)` bit shall be set to `1`.
+ * When a seat is detected to be not occupied, the corresponding seat occupation bit shall be set to `0`.
+ * Otherwise, the value of seat occupation bit shall be set according to the following conditions:
+ * - If the seat occupation of a seat row is not detectable, the corresponding bit shall be set to `1`.
+ *   When any seat row not detectable bit is set to `1`, all corresponding seat occupation bits of the same row
+ *   shall be set to `1`.
+ * - If the seat row is not present, the corresponding not present bit of the same row shall be set to `1`.
+ *   When any of the seat row not present bit is set to `1`, the corresponding not detectable bit for that row
+ *   shall be set to `1`, and all the corresponding seat occupation bits in that row shall be set to `0`.
+ * 
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+PositionOfOccupants ::= BIT STRING {
+    row1LeftOccupied  (0),
+    row1RightOccupied (1),
+    row1MidOccupied   (2),
+    row1NotDetectable (3),
+    row1NotPresent    (4),
+    row2LeftOccupied  (5),
+    row2RightOccupied (6),
+    row2MidOccupied   (7),
+    row2NotDetectable (8),
+    row2NotPresent    (9),
+    row3LeftOccupied  (10),
+    row3RightOccupied (11),
+    row3MidOccupied   (12),
+    row3NotDetectable (13),
+    row3NotPresent    (14),
+    row4LeftOccupied  (15),
+    row4RightOccupied (16),
+    row4MidOccupied   (17),
+    row4NotDetectable (18),
+    row4NotPresent    (19)
+} (SIZE(20))
+
+/**
+ * This DE indicates the perpendicular distance between the vehicle front line of the bounding box and the front wheel axle in 0,1 metre.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 19`) for any aplicable value between 0,1 metre and 1,9 metres,
+ * - `19` for values equal to or higher than 1.8 metres,
+ * - `20` if the information is unavailable.
+ *
+ * @category: Vehicle information
+ * @unit 0,1 metre
+ * @revision: description revised in V2.1.1 (the meaning of 19 has changed slightly) 
+ */
+PosFrontAx ::= INTEGER {
+    outOfRange (19), 
+    unavailable(20)
+} (1..20)
+
+/** 
+ * This DE represents a position along a single dimension such as the middle of a road or lane, measured as an offset from an externally defined starting point, 
+ * in direction of an externally defined reference direction.
+ * 
+ * The value shall be set to:
+ * - `n` (`n >= -8190` and `n < 0`) if the position is equal to or less than n x 1 metre and more than (n-1) x 1 metre, in opposite direction of the reference direction,
+ * - `0` if the position is at the starting point,
+ * - `n` (`n > 0` and `n < 8190`) if the position is equal to or less than n x 1 metre and more than (n-1) x 1 metre, in the same direction as the reference direction,
+ * - `8 190` if the position is out of range, i.e. equal to or greater than 8 189 m,
+ * - `8 191` if the position information is not available. 
+ *
+ * @unit 1 metre
+ * @category: GeoReference information
+ * @revision: Created in V2.2.1
+ */
+Position1d ::= INTEGER {
+    outOfRange(8190),
+    unavailable(8191)
+}(-8190..8191)
+
+/**
+ * This DE represents the distance from the centre of vehicle front bumper to the right or left longitudinal carrier of vehicle.
+ * The left/right carrier refers to the left/right as seen from a passenger sitting in the vehicle.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 126`) for any aplicable value between 0,01 metre and 1,26 metres, 
+ * - `126` for values equal to or higher than 1.25 metres,
+ * - `127` if the information is unavailable.
+ *
+ * @unit 0,01 metre 
+ * @category Vehicle information
+ * @revision: description revised in V2.1.1 (the meaning of 126 has changed slightly) 
+ */
+PosLonCarr ::= INTEGER {
+    outOfRange  (126),
+    unavailable (127)
+} (1..127)
+
+/**
+ * This DE represents the perpendicular inter-distance of neighbouring pillar axis of vehicle starting from the
+ * middle point of the front line of the vehicle bounding box.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 29`) for any aplicable value between 0,1 metre and 2,9 metres, 
+ * - `29` for values equal to or greater than 2.8 metres,
+ * - `30` if the information is unavailable.
+ * 
+ * @unit 0,1 metre 
+ * @category Vehicle information
+ * @revision: description revised in V2.1.1 (the meaning of 29 has changed slightly) 
+ */
+PosPillar ::= INTEGER {
+    outOfRange  (29),
+    unavailable (30)
+} (1..30)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `postCrash` .
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`                                               - in case further detailed information on post crash event is unavailable,
+ * - 1 `accidentWithoutECallTriggered`                             - in case no eCall has been triggered for an accident,
+ * - 2 `accidentWithECallManuallyTriggered`                        - in case eCall has been manually triggered and transmitted to eCall back end,
+ * - 3 `accidentWithECallAutomaticallyTriggered`                   - in case eCall has been automatically triggered and transmitted to eCall back end,
+ * - 4 `accidentWithECallTriggeredWithoutAccessToCellularNetwork`  - in case eCall has been triggered but cellular network is not accessible from triggering vehicle.
+ * - 5-255                                                         - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+PostCrashSubCauseCode ::= INTEGER {
+    unavailable                                              (0), 
+    accidentWithoutECallTriggered                            (1), 
+    accidentWithECallManuallyTriggered                       (2), 
+    accidentWithECallAutomaticallyTriggered                  (3), 
+    accidentWithECallTriggeredWithoutAccessToCellularNetwork (4)
+} (0..255)
+
+/**
+* This DE represent the total amount of rain falling during one hour. It is measured in mm per hour at an area of 1 square metre.  
+* 
+* The following values are specified:
+* - `n` (`n > 0` and `n < 2000`) if the amount of rain falling is equal to or less than n x 0,1 mm/h and greater than (n-1) x 0,1 mm/h,
+* - `2000` if the amount of rain falling is greater than 199.9 mm/h, 
+* - `2001` if the information is not available.
+*
+* @unit: 0,1 mm/h 
+* @category: Basic Information
+* @revision: created in V2.1.1
+*/
+PrecipitationIntensity ::= INTEGER {
+	outOfRange								(2000), 
+	unavailable								(2001) 
+} (1..2001)
+
+/**
+ * This DE represents the indentifier of a protected communication zone.
+ * 
+ * 
+ * @category: Infrastructure information, Communication information
+ * @revision: Revision in V2.1.1 (changed name from ProtectedZoneID to ProtectedZoneId)
+ */
+ProtectedZoneId ::= INTEGER (0.. 134217727)
+
+/**
+ * This DE represents the radius of a protected communication zone. 
+ * 
+ * 
+ * @unit: metre
+ * @category: Infrastructure information, Communication information
+ * @revision: V1.3.1
+ */
+ProtectedZoneRadius ::= INTEGER (1..255,...)
+
+/**
+ * This DE indicates the type of a protected communication zone, so that an ITS-S is aware of the actions to do
+ * while passing by such zone (e.g. reduce the transmit power in case of a DSRC tolling station).
+ * 
+ * The protected zone type is defined in ETSI TS 102 792 [14].
+ * 
+ * 
+ * @category: Communication information
+ * @revision: V1.3.1
+ */
+ProtectedZoneType::= ENUMERATED {
+    permanentCenDsrcTolling (0), 
+    ..., 
+    temporaryCenDsrcTolling (1) 
+}
+
+/**
+ * This DE is used for various tasks in the public transportation environment, especially for controlling traffic
+ * signal systems to prioritize and speed up public transportation in urban area (e.g. intersection "_bottlenecks_").
+ * The traffic lights may be controlled by an approaching bus or tram automatically. This permits "_In Time_" activation
+ * of the green phase, will enable the individual traffic to clear a potential traffic jam in advance. Thereby the
+ * approaching bus or tram may pass an intersection with activated green light without slowing down the speed due to
+ * traffic congestion. Other usage of the DE is the provision of information like the public transport line number
+ * or the schedule delay of a public transport vehicle.
+ * 
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+PtActivationData ::= OCTET STRING (SIZE(1..20))
+
+/**
+ * This DE indicates a certain coding type of the PtActivationData data.
+ *
+ * The folowing value are specified:
+ * - 0 `undefinedCodingType`  : undefined coding type,
+ * - 1 `r09-16CodingType`     : coding of PtActivationData conform to VDV recommendation 420 [7],
+ * - 2 `vdv-50149CodingType`  : coding of PtActivationData based on VDV recommendation 420 [7].
+ * - 3 - 255                  : reserved for alternative and future use.
+ * 
+ * @category: Vehicle information 
+ * @revision: V1.3.1
+ */
+PtActivationType ::= INTEGER {
+    undefinedCodingType (0), 
+    r09-16CodingType    (1), 
+    vdv-50149CodingType (2)
+} (0..255)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `railwayLevelCrossing` .
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`                   - in case no further detailed information on the railway level crossing status is available,
+ * - 1 `doNotCrossAbnormalSituation`   - in case when something wrong is detected by equation or sensors of the railway level crossing, 
+                                         including level crossing is closed for too long (e.g. more than 10 minutes long ; default value),
+ * - 2 `closed`                        - in case the crossing is closed or closing (barriers down),
+ * - 3 `unguarded`                     - in case the level crossing is unguarded (i.e a Saint Andrew cross level crossing without detection of train),
+ * - 4 `nominal`                       - in case the barriers are up and/or the warning systems are off,
+ * - 5 `trainApproaching`              - in case a train is approaching and the railway level crossing is without barriers.
+ * - 6-255: reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, description of value 2 and 4 changed and value 5 added in V2.3.1
+ */
+RailwayLevelCrossingSubCauseCode ::= INTEGER {
+    unavailable                 (0), 
+    doNotCrossAbnormalSituation (1), 
+    closed                      (2), 
+    unguarded                   (3), 
+    nominal                     (4),
+    trainApproaching            (5)
+} (0..255)
+
+/**
+ * This DE describes a distance of relevance for information indicated in a message.
+ *
+ * The value shall be set to:
+ * - 0 `lessThan50m`   - for distances below 50 m,
+ * - 1 `lessThan100m`  - for distances below 100 m, 
+ * - 2 `lessThan200m`  - for distances below 200 m, 
+ * - 3 `lessThan500m`  - for distances below 300 m, 
+ * - 4 `lessThan1000m` - for distances below 1 000 m, 
+ * - 5 `lessThan5km`   - for distances below 5 000 m, 
+ * - 6 `lessThan10km`  - for distances below 10 000 m, 
+ * - 7 `over10km`      - for distances over 10 000 m. 
+ * 
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref StandardLength3b instead. 
+ *
+ * @category: GeoReference information
+ * @revision: Editorial update in V2.1.1
+ */ 
+RelevanceDistance ::= ENUMERATED {
+    lessThan50m(0), 
+    lessThan100m(1), 
+    lessThan200m(2), 
+    lessThan500m(3), 
+    lessThan1000m(4), 
+    lessThan5km(5), 
+    lessThan10km(6), 
+    over10km(7)
+}
+
+/**
+ * This DE indicates a traffic direction that is relevant to information indicated in a message.
+ * 
+ * The value shall be set to:
+ * - 0 `allTrafficDirections` - for all traffic directions, 
+ * - 1 `upstreamTraffic`      - for upstream traffic, 
+ * - 2 `downstreamTraffic`    - for downstream traffic, 
+ * - 3 `oppositeTraffic`      - for traffic in the opposite direction. 
+ *
+ * The terms `upstream`, `downstream` and `oppositeTraffic` are relative to the event position.
+ *
+ * @note: Upstream traffic corresponds to the incoming traffic towards the event position,
+ * and downstream traffic to the departing traffic away from the event position.
+ *
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref TrafficDirection instead. 
+ *
+ * @category: GeoReference information
+ * @revision: Editorial update in V2.1.1
+ */
+RelevanceTrafficDirection ::= ENUMERATED {
+    allTrafficDirections(0), 
+    upstreamTraffic(1), 
+    downstreamTraffic(2), 
+    oppositeTraffic(3)
+}
+
+/**
+ * This DE indicates whether an ITS message is transmitted as request from ITS-S or a response transmitted from
+ * ITS-S after receiving request from other ITS-Ss.
+ *
+ * The value shall be set to:
+ * - 0 `request`  - for a request message, 
+ * - 1 `response` - for a response message.  
+ *
+ * @category Communication information
+ * @revision: Editorial update in V2.1.1
+ */
+RequestResponseIndication ::= ENUMERATED {
+    request  (0), 
+    response (1)
+}
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode` 
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`                         - in case further detailed information on rescue and recovery work is unavailable,
+ * - 1 `emergencyVehicles`                   - in case rescue and/or safeguarding work is ongoing by emergency vehicles, i.e. by vehicles that have the absolute right of way,
+ * - 2 `rescueHelicopterLanding`             - in case rescue helicopter is landing,
+ * - 3 `policeActivityOngoing`               - in case police activity is ongoing (only to be used if a more specific sub cause than (1) is needed),
+ * - 4 `medicalEmergencyOngoing`             - in case medical emergency recovery is ongoing (only to be used if a more specific sub cause than (1) is needed),
+ * - 5 `childAbductionInProgress-deprecated` - deprecated,
+ * - 6 `prioritizedVehicle`                  - in case rescue and/or safeguarding work is ongoing by prioritized vehicles, i.e. by vehicles that have priority but not the absolute right of way,
+ * - 7 `rescueAndRecoveryVehicle`            - in case technical rescue work is ongoing by rescue and recovery vehicles.
+ * - 8-255: reserved for future usage.
+
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, named values 6 and 7 added in V2.2.1, DE renamed and value 5 deprecated in V2.4.1
+ */
+RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode  ::= INTEGER {
+   unavailable                         (0), 
+   emergencyVehicles                   (1), 
+   rescueHelicopterLanding             (2), 
+   policeActivityOngoing               (3), 
+   medicalEmergencyOngoing             (4), 
+   childAbductionInProgress-deprecated (5),
+   prioritizedVehicle                  (6),
+   rescueAndRecoveryVehicle            (7)
+} (0..255)
+
+
+/** 
+ * This DE indicates an ordinal number that represents the position of a component in the list @ref RoadConfigurationSectionList. 
+ *
+ * The value shall be set to:
+ * - `0`     - if no road section is identified
+ * - `1..8`  - for instances 1..8 of @ref RoadConfigurationSectionList 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+ */
+
+RoadSectionId::= INTEGER (0..8, ...)
+
+/**
+ * This DE indicates the type of a road segment.
+ * 
+ * The value shall be set to:
+ * - 0 `urban-NoStructuralSeparationToOppositeLanes`       - for an urban road with no structural separation between lanes carrying traffic in opposite directions,
+ * - 1 `urban-WithStructuralSeparationToOppositeLanes`     - for an urban road with structural separation between lanes carrying traffic in opposite directions,
+ * - 2 `nonUrban-NoStructuralSeparationToOppositeLanes`    - for an non urban road with no structural separation between lanes carrying traffic in opposite directions,
+ * - 3 `nonUrban-WithStructuralSeparationToOppositeLanes`  - for an non urban road with structural separation between lanes carrying traffic in opposite directions.
+ *
+ * @category: Road Topology Information
+ * @revision: Editorial update in V2.1.1
+ */
+RoadType ::= ENUMERATED {
+    urban-NoStructuralSeparationToOppositeLanes      (0),
+    urban-WithStructuralSeparationToOppositeLanes    (1),
+    nonUrban-NoStructuralSeparationToOppositeLanes   (2),
+    nonUrban-WithStructuralSeparationToOppositeLanes (3)
+}
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `roadworks`.
+ * 
+The value shall be set to:
+ * - 0 `unavailable`                 - in case further detailed information on roadworks is unavailable,
+ * - 1 `roadOrCarriagewayClosure`    - in case roadworks are ongoing which comprise the closure of the entire road or of one entire carriageway,
+ * - 2 `roadMarkingWork-deprecated`  - deprecated since covered by 3 or 4,
+ * - 3 `movingLaneClosure`           - in case moving roadworks are ongoing, which comprise the closure of a lane,
+ * - 4 `stationaryLaneClosure`       - in case stationary roadworks are ongoing, which comprise the closure of one or multiple lanes but not of the carriageway/road,
+ * - 5 `streetCleaning-deprecated`   - deprecated since not pertinent to roadworks and already covered by SlowVehicleSubCauseCode,
+ * - 6 `winterService-deprecated`    - deprecated since not pertinent to roadworks and already covered by SlowVehicleSubCauseCode,
+ * - 7 `setupPhase`                  - in case the work zone is being setup which, may comprise the closure of one or multiple lanes but the carriageway/road is not closed, 
+ * - 8 `remodellingPhase`            - in case the work zone is being changed, which may comprise the closure of one or multiple lanes but the carriageway/road is not closed, 
+ * - 9 `dismantlingPhase`            - in case the work zone is being dismantled after finished works, which comprised the closure of one or multiple lanes 
+                                       but the carriageway/road was not closed,
+ * - 10 `carriagewayCrossover`       - in case the work zone includes lanes that are re-directed to another carriageway. 
+ * - 11-255                          - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, values 7-9 added in V2.3.1, values 1, 3, 4 renamed in V2.4.1, value 2, 5 und 6 deprecated in V2.4.1, value 10 added in V2.4.1
+ */
+RoadworksSubCauseCode ::= INTEGER {
+    unavailable                  (0), 
+    roadOrCarriagewayClosure     (1),
+    roadMarkingWork-deprecated   (2), 
+    movingLaneClosure            (3), 
+    stationaryLaneClosure        (4), 
+    streetCleaning-deprecated    (5), 
+    winterService-deprecated     (6),
+    setupPhase                   (7),
+    remodellingPhase             (8),
+    dismantlingPhase             (9),
+    carriagewayCrossover         (10)
+} (0..255)
+
+/**
+ * This DE indicates the driving automation level as defined in SAE J3016 [26].
+ *
+ * @category: Vehicle information
+ * @revision: created in V2.3.1
+*/
+SaeAutomationLevel::= INTEGER (0..5)
+
+/**
+ * This DE indicates if a distance is safe. 
+ *
+ * The value shall be set to:
+ * -  `FALSE`  if  the triple  {LaD,  LoD, VD} < {MSLaD, MSLoD, MSVD} is simultaneously  satisfied with confidence level of  90 % or  more, 
+ * -  `TRUE` otherwise. 
+ *
+ * @note: the abbreviations used are Lateral Distance (LaD),  Longitudinal Distance (LoD) and Vertical Distance (VD) 
+ * and their respective  thresholds, Minimum  Safe  Lateral  Distance (MSLaD), Minimum  Safe  Longitudinal Distance  (MSLoD),  and  Minimum  Safe Vertical Distance (MSVD).
+ *
+ * @category: Traffic information, Kinematic information
+ * @revision: Created in V2.1.1
+*/
+SafeDistanceIndicator::= BOOLEAN
+
+/**
+ * This DE indicates the horizontal position confidence value which represents the estimated absolute position accuracy, in one of the axis direction as defined in a shape of ellipse with a 
+ * confidence level of 95 %. 
+ * 
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 4 094`) if the accuracy is equal to or less than n * 0,01 metre,
+ * - `4 094` if the accuracy is out of range, i.e. greater than 4,093 m,
+ * - `4 095` if the accuracy information is unavailable.
+ *
+ * The value 0 shall not be used.
+ * 
+ * @note: The fact that a position coordinate value is received with confidence value set to `unavailable(4095)`.
+ * can be caused by several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the position coordinate value may be valid and used by the application.
+ * If a position coordinate value is received and its confidence value is set to `outOfRange(4094)`, it means that
+ * the position coordinate value is not valid and therefore cannot be trusted. Such value is not useful
+ * for the application.
+
+ * @unit 0,01 metre 
+ * @category: GeoReference Information
+ * @revision: Description revised in V2.1.1
+ */
+SemiAxisLength ::= INTEGER{
+    doNotUse    (0),
+    outOfRange  (4094), 
+    unavailable (4095)
+} (0..4095)
+
+/** 
+ * This DE indicates the type of sensor.
+ * 
+ * The value shall be set to:
+ * - 0  `undefined`         - in case the sensor type is undefined, 
+ * - 1  `radar`             - in case the sensor is a radar,
+ * - 2  `lidar`             - in case the sensor is a lidar,
+ * - 3  `monovideo`         - in case the sensor is mono video,
+ * - 4  `stereovision`      - in case the sensor is stereo vision,
+ * - 5  `nightvision`       - in case the sensor supports night vision, using e.g. infrared illumination or thermal imaging,
+ * - 6  `ultrasonic`        - in case the sensor is ultrasonic,
+ * - 7  `pmd`               - in case the sensor is photonic mixing device,
+ * - 8  `inductionLoop`     - in case the sensor is an induction loop,
+ * - 9  `sphericalCamera`   - in case the sensor is a spherical camera,
+ * - 10 `uwb`               - in case the sensor is ultra wide band,
+ * - 11 `acoustic`          - in case the sensor is acoustic,
+ * - 12 `localAggregation`  - in case the information is provided by a system that aggregates information from different local sensors. Aggregation may include fusion,
+ * - 13 `itsAggregation`    - in case the information is provided by a system that aggregates information from other received ITS messages,
+ * - 14 `rfid`              - in case the sensor is radio frequency identification using a passive or active (e.g. Bluetooth, W-LAN) technology. 
+ * - 15-31                  - are reserved for future usage.
+ *
+ * @category: Sensing Information
+ * @revision: created in V2.1.1, description of value 5 changed and value 14 added in V2.3.1
+*/
+SensorType ::= INTEGER {
+    undefined         (0),
+    radar             (1),
+    lidar             (2),
+    monovideo         (3),
+    stereovision      (4),
+    nightvision       (5),
+    ultrasonic        (6),
+    pmd               (7),
+    inductionLoop     (8),
+    sphericalCamera   (9),
+    uwb               (10),
+    acoustic          (11),
+    localAggregation  (12),
+    itsAggregation    (13),
+    rfid              (14)
+} (0..31)
+
+/** 
+ * This DE indicates the type of sensor(s).
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * 
+ * - 0  `undefined`         - in case the sensor type is undefined. 
+ * - 1  `radar`             - in case the sensor is a radar,
+ * - 2  `lidar`             - in case the sensor is a lidar,
+ * - 3  `monovideo`         - in case the sensor is mono video,
+ * - 4  `stereovision`      - in case the sensor is stereo vision,
+ * - 5  `nightvision`       - in case the sensor supports night vision, using e.g. infrared illumination or thermal imaging,
+ * - 6  `ultrasonic`        - in case the sensor is ultrasonic,
+ * - 7  `pmd`               - in case the sensor is photonic mixing device,
+ * - 8  `inductionLoop`     - in case the sensor is an induction loop,
+ * - 9  `sphericalCamera`   - in case the sensor is a spherical camera,
+ * - 10 `uwb`               - in case the sensor is ultra wide band,
+ * - 11 `acoustic`          - in case the sensor is acoustic,
+ * - 12 `localAggregation`  - in case the information is provided by a system that aggregates information from different local sensors. Aggregation may include fusion,
+ * - 13 `itsAggregation`    - in case the information is provided by a system that aggregates information from other received ITS messages,
+ * - 14 `rfid`              - in case the sensor is radio frequency identification using a passive or active (e.g. Bluetooth, W-LAN) technology. 
+ * - 15                     - reserved for future usage.
+ * 
+ * @note: If all bits are set to 0, then no sensor type is used
+ *
+ * @category: Sensing Information
+ * @revision: created in V2.2.1, description of value 5 changed and value 14 added in V2.3.1
+*/
+SensorTypes ::= BIT STRING {
+    undefined         (0),
+    radar             (1),
+    lidar             (2),
+    monovideo         (3),
+    stereovision      (4),
+    nightvision       (5),
+    ultrasonic        (6),
+    pmd               (7),
+    inductionLoop     (8),
+    sphericalCamera   (9),
+    uwb               (10),
+    acoustic          (11),
+    localAggregation  (12),
+    itsAggregation    (13),
+    rfid              (14)
+} (SIZE (16,... ))
+
+/**
+ * This DE represents a sequence number.
+ * 
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+SequenceNumber ::=  INTEGER (0..65535)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `signalViolation`.
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`               - in case further detailed information on signal violation event is unavailable,
+ * - 1 `stopSignViolation`         - in case a stop sign violation is detected,
+ * - 2 `trafficLightViolation`     - in case a traffic light violation is detected,
+ * - 3 `turningRegulationViolation`- in case a turning regulation violation is detected.
+ * - 4-255                         - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1
+ */
+SignalViolationSubCauseCode ::= INTEGER {
+    unavailable                (0), 
+    stopSignViolation          (1), 
+    trafficLightViolation      (2), 
+    turningRegulationViolation (3)
+} (0..255)
+
+/**
+ * This DE represents the sub cause codes of the @ref CauseCode "slowVehicle".
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`                            - in case further detailed information on slow vehicle driving event is unavailable,
+ * - 1 `maintenanceVehicle`                     - in case of a slow driving maintenance vehicle on the road (incl. winter maintenance without detailed status),
+ * - 2 `vehiclesSlowingToLookAtAccident`        - in case vehicle is temporally slowing down to look at accident, spot, etc.,
+ * - 3 `abnormalLoad`                           - in case an abnormal loaded vehicle is driving slowly on the road,
+ * - 4 `abnormalWideLoad`                       - in case an abnormal wide load vehicle is driving slowly on the road,
+ * - 5 `convoy`                                 - in case of slow driving convoy on the road,
+ * - 6 `winterMaintenanceSnowplough             - in case of slow driving snow plough on the road,
+ * - 7 `deicing-deprecated`                     - deprecated since covered by 8 `winterMaintenanceAdhesionImprovement`,
+ * - 8 `winterMaintenanceAdhesionImprovement`   - in case of a slow driving winter maintenance vehicle applying measures to improve the driving conditions 
+                                                  and adhesion on winter roads, including improving grip (by applying sand or grit), de-icing (by applying salt or brine),
+                                                  or anti-icing (by applying brine to prevent buildup of ice and snow). 
+ * - 9-255                                      - are reserved for future usage.
+ * 
+ * @category: Traffic information
+ * @revision: V1.3.1, value 7 deprecated and name of 6 and 8 changed and semantics of 8 refined in V2.4.1
+ */
+SlowVehicleSubCauseCode ::= INTEGER {
+    unavailable                          (0), 
+    maintenanceVehicle                   (1), 
+    vehiclesSlowingToLookAtAccident      (2), 
+    abnormalLoad                         (3), 
+    abnormalWideLoad                     (4), 
+    convoy                               (5), 
+    winterMaintenanceSnowplough          (6), 
+    deicing-deprecated                   (7), 
+    winterMaintenanceAdhesionImprovement (8)  
+} (0..255)
+
+/**
+ * The DE indicates if a vehicle is carrying goods in the special transport conditions.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 `heavyLoad`        - the vehicle is carrying goods with heavy load,
+ * - 1 `excessWidth`      - the vehicle is carrying goods in excess of width,
+ * - 2 `excessLength`     - the vehicle is carrying goods in excess of length,
+ * - 3 `excessHeight`     - the vehicle is carrying goods in excess of height.
+ *
+ * Otherwise, the corresponding bit shall be set to 0.
+ * @category Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+SpecialTransportType ::= BIT STRING {
+    heavyLoad    (0),
+    excessWidth  (1), 
+    excessLength (2), 
+    excessHeight (3)
+} (SIZE(4))
+
+/**
+ * This DE indicates the speed confidence value which represents the estimated absolute accuracy of a speed value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * 
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n * 0,01 m/s.
+ * - `126` if the confidence value is out of range, i.e. greater than 1,25 m/s,
+ * - `127` if the confidence value information is not available.
+ *  
+ * @note: The fact that a speed value is received with confidence value set to `unavailable(127)` can be caused by several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the speed value may be valid and used by the application.
+ * 
+ * @note: If a speed value is received and its confidence value is set to `outOfRange(126)`, it means that the speed value is not valid 
+ * and therefore cannot be trusted. Such is not useful for the application.
+ *
+ * @unit: 0,01 m/s
+ * @category: Vehicle information
+ * @revision: Description revised in V2.1.1 
+ */
+SpeedConfidence ::= INTEGER {
+    outOfRange  (126), 
+    unavailable (127)
+} (1..127)
+
+/**
+ * This DE represents a speed limitation applied to a geographical position, a road section or a geographical region.
+ * 
+ * @unit: km/h
+ * @category: Infrastructure information, Traffic information
+ * @revision: V1.3.1
+ */
+SpeedLimit ::= INTEGER (1..255)
+
+/**
+ * This DE represents a speed value, i.e. the magnitude of the velocity-vector. 
+ *
+ * The value shall be set to:
+ * - `0` in a standstill situation.
+ * - `n` (`n > 0` and `n < 16 382`) if the applicable value is equal to or less than n x 0,01 m/s, and greater than (n-1) x 0,01 m/s,
+ * - `16 382` for speed values greater than 163,81 m/s,
+ * - `16 383` if the speed accuracy information is not available.
+ * 
+ * @note: the definition of standstill is out of scope of the present document.
+ *
+ * @unit: 0,01 m/s
+ * @category: Kinematic information
+ * @revision: Description revised in V2.1.1 (the meaning of 16382 has changed slightly) 
+*/
+SpeedValue ::= INTEGER {
+    standstill  (0), 
+    outOfRange  (16382), 
+    unavailable (16383)
+} (0..16383)
+
+/** 
+ * This DE indicates the type of stored information.
+ *
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * 
+ * - `0` undefined        - in case the stored information type is undefined. 
+ * - `1` staticDb         - in case the stored information type is a static database.
+ * - `2` dynamicDb        - in case the stored information type is a dynamic database
+ * - `3` realTimeDb       - in case the stored information type is a real time updated database.
+ * - `4` map              - in case the stored information type is a road topology map.
+ * - Bits 5 to 7          - are reserved for future use.
+ *
+ * @note: If all bits are set to 0, then no stored information type is used
+ *
+ * @category: Basic Information
+ * @revision: created in V2.2.1
+*/
+StoredInformationType::= BIT STRING {
+    undefined       (0),
+    staticDb	    (1),    
+    dynamicDb   	(2),
+    realTimeDb  	(3),
+    map		    	(4)	
+} (SIZE (8,... )) 
+
+/** 
+ * This DE represents the value of a velocity component in a defined coordinate system.
+ *
+ * The value shall be set to:
+ * - `-16 383` if the velocity is equal to or smaller than -163,83 m/s,
+ * - `n` (`n > -16 383` and `n < 16 382`) if the applicable value is equal to or less than n x 0,01 m/s, and greater than (n-1) x 0,01 m/s,
+ * - `16 382` for velocity values equal to or greater than 163,81 m/s,
+ * - `16 383` if the velocity information is not available.
+ * 
+ * @unit: 0,01 m/s
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+*/
+VelocityComponentValue ::= INTEGER {
+    negativeOutOfRange (-16383),
+    positiveOutOfRange  (16382),
+    unavailable        (16383)
+} (-16383..16383)
+
+
+/**
+ * This DE indicates the estimated probability of a stability level and conversely also the probability of a stability loss.
+ *
+ * The value shall be set to:
+ * - `0` to indicate an estimated probability of a loss of stability of 0 %, i.e. "stable", 
+ * - `n` (`n > 0` and `n < 50`) to indicate the actual stability level,
+ * - `50` to indicate a estimated probability of a loss of stability of 100 %, i.e. "total loss of stability",
+ * - the values between 51 and 62 are reserved for future use,
+ * - `63`: this value indicates that the information is unavailable.
+ *
+ * @unit: 2 %
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+StabilityLossProbability ::= INTEGER {
+    stable                  (0), 
+    totalLossOfStability   (50), 
+    unavailable            (63) 
+} (0..63) 
+
+/**
+ * The DE represents length as a measure of distance between points or as a dimension of an object or shape. 
+ *
+ * @unit: 0,1 metre
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+StandardLength12b::= INTEGER (0..4095)
+
+/**
+ * The DE represents length as a measure of distance between points. 
+ *
+ * The value shall be set to:
+ * - 0 `lessThan50m`   - for distances below 50 m, 
+ * - 1 `lessThan100m`  - for distances below 100 m,
+ * - 2 `lessThan200m`  - for distances below 200 m, 
+ * - 3 `lessThan500m`  - for distances below 300 m, 
+ * - 4 `lessThan1000m` - for distances below 1 000 m,
+ * - 5 `lessThan5km`   - for distances below 5 000 m, 
+ * - 6 `lessThan10km`  - for distances below 10 000 m, 
+ * - 7 `over10km`      - for distances over 10 000 m.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1 from RelevanceDistance
+ */ 
+StandardLength3b ::= ENUMERATED {
+    lessThan50m   (0), 
+    lessThan100m  (1), 
+    lessThan200m  (2), 
+    lessThan500m  (3), 
+    lessThan1000m (4), 
+    lessThan5km   (5), 
+    lessThan10km  (6), 
+    over10km      (7)
+}
+
+/**
+ * The DE represents length as a measure of distance between points or as a dimension of an object. 
+ *
+ * @unit: 0,1 metre
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+StandardLength9b::= INTEGER (0..511)
+
+/**
+ * The DE represents length as a measure of distance between points or as a dimension of an object. 
+ *
+ * @unit: 0,1 metre
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+StandardLength1B::= INTEGER (0..255)
+
+/**
+ * The DE represents length as a measure of distance between points or as a dimension of an object.  
+ *
+ * @unit: 0,1 metre
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+StandardLength2B::= INTEGER (0..65535)
+
+/**
+ * This DE indicates the duration in minutes since which something is stationary.
+ * 
+ * The value shall be set to:
+ * - 0 `lessThan1Minute`         - for being stationary since less than 1 minute, 
+ * - 1 `lessThan2Minutes`        - for being stationary since less than 2 minute and for equal to or more than 1 minute,
+ * - 2 `lessThan15Minutes`       - for being stationary since less than 15 minutes and for equal to or more than 1 minute,
+ * - 3 `equalOrGreater15Minutes` - for being stationary since equal to or more than 15 minutes.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+StationarySince ::= ENUMERATED {
+    lessThan1Minute         (0), 
+    lessThan2Minutes        (1), 
+    lessThan15Minutes       (2), 
+    equalOrGreater15Minutes (3)
+}
+
+/**
+ * This DE provides the value of the sub cause codes of the @ref CauseCode "stationaryVehicle". 
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`             - in case further detailed information on stationary vehicle is unavailable,
+ * - 1 `humanProblem-deprecated` - deprecated since covered by DE HumanProblemSubCauseCode,
+ * - 2 `vehicleBreakdown`        - in case stationary vehicle is due to vehicle break down,
+ * - 3 `postCrash`               - in case stationary vehicle is caused by collision,
+ * - 4 `publicTransportStop`     - in case public transport vehicle is stationary at bus stop,
+ * - 5 `carryingDangerousGoods`  - in case the stationary vehicle is carrying dangerous goods,
+ * - 6 `vehicleOnFire`           - in case of vehicle on fire.
+ * - 7-255 reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 6 added in V2.1.1, value 1 deprecated in V2.4.1
+ */
+StationaryVehicleSubCauseCode ::= INTEGER {
+    unavailable             (0), 
+    humanProblem-deprecated (1), 
+    vehicleBreakdown        (2), 
+    postCrash               (3), 
+    publicTransportStop     (4), 
+    carryingDangerousGoods  (5), 
+    vehicleOnFire           (6)
+} (0..255)
+
+/**
+ * This DE represents the identifier of an ITS-S.
+ * The ITS-S ID may be a pseudonym. It may change over space and/or over time.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.1.1 based on @ref StationID
+ */
+StationId ::= INTEGER(0..4294967295)
+
+/**
+ * This DE represents the identifier of an ITS-S.
+ * The ITS-S ID may be a pseudonym. It may change over space and/or over time.
+ *
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref StationId instead.
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+StationID ::= INTEGER(0..4294967295)
+
+/**
+ * This DE represents the type of technical context the ITS-S is integrated in.
+ * The station type depends on the integration environment of ITS-S into vehicle, mobile devices or at infrastructure.
+ * 
+ * The value shall be set to the corresponding value of the integration environment of DE TrafficParticipantType
+ * 
+ * @category: Communication information.
+ * @revision: revised in V2.1.1 (named values 12 and 13 added and note to value 9 deleted). Deleted note and type set equal to TrafficParticipantType in V2.4.1.
+ */
+StationType ::= TrafficParticipantType
+
+/**
+ * This DE indicates the steering wheel angle confidence value which represents the estimated absolute accuracy for a  steering wheel angle value with a confidence level of 95 %.
+ * 
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n x 1,5 degrees,
+ * - `126` if the confidence value is out of range, i.e. greater than 187,5 degrees,
+ * - `127` if the confidence value is not available.
+ * 
+ * @note: The fact that a steering wheel angle value is received with confidence value set to `unavailable(127)`
+ * can be caused by several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the steering wheel angle value may be valid and used by the application.
+ * 
+ * If a steering wheel angle value is received and its confidence value is set to `outOfRange(126)`,
+ * it means that the steering wheel angle value is not valid and therefore cannot be trusted.
+ * Such value is not useful for the application.
+ * 
+ * @unit: 1,5 degree
+ * @category: Vehicle Information
+ * @revision: Description revised in V2.1.1
+*/
+SteeringWheelAngleConfidence ::= INTEGER {
+    outOfRange                      (126), 
+    unavailable                     (127)
+} (1..127)
+
+/**
+ * This DE represents the steering wheel angle of the vehicle at certain point in time.
+ * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11.
+ * 
+ * The value shall be set to:
+ * - `-511` if the steering wheel angle is equal to or greater than 511 x 1,5 degrees = 766,5 degrees to the right,
+ * - `n` (`n > -511` and `n <= 0`) if  the steering wheel angle is equal to or less than n x 1,5 degrees, and greater than (n-1) x 1,5 degrees, 
+      turning clockwise (i.e. to the right),
+ * - `n` (`n >= 1` and `n < 511`) if the steering wheel angle is equal to or less than n x 0,1 degrees, and greater than (n-1) x 0,1 degrees, 
+      turning counter-clockwise (i.e. to the left),
+ * - `511` if the steering wheel angle is greater than 510 x 1,5 degrees = 765 degrees to the left,
+ * - `512` if information is not available.
+ *
+ * @unit: 1,5 degree
+ * @revision: Description revised in V2.1.1 (meaning of value 511 has changed slightly).
+ */
+SteeringWheelAngleValue ::= INTEGER { 
+    negativeOutOfRange (-511),
+    positiveOutOfRange (511),
+    unavailable        (512)
+} (-511..512)
+
+/**
+ * This DE indicates the generic sub cause of a detected event.
+ * 
+ * @note: The sub cause code value assignment varies based on value of @ref CauseCode.
+ *
+ * @category: Traffic information
+ * @revision: Description revised in V2.1.1 (this is  the generic sub cause type)
+ */
+SubCauseCodeType ::= INTEGER (0..255)
+
+/**
+ * This DE indicates a temperature value.
+
+ * The value shall be set to:
+ * - `-60` for temperature equal to or less than -60 degrees C,
+ * - `n` (`n > -60` and `n < 67`) for the actual temperature n in degrees C,
+ * - `67` for temperature equal to or greater than 67 degrees C.
+ * 
+ * @unit: degrees Celsius
+ * @category: Basic information
+ * @revision: Editorial update in V2.1.1
+ */
+Temperature ::= INTEGER {
+    equalOrSmallerThanMinus60Deg (-60), 
+    equalOrGreaterThan67Deg(67)} (-60..67)
+
+/**
+ * This DE represents the number of elapsed (TAI) milliseconds since the ITS Epoch. 
+ * The ITS epoch is `00:00:00.000 UTC, 1 January 2004`.
+ * "Elapsed" means that the true number of milliseconds is continuously counted without interruption,
+ *  i.e. it is not altered by leap seconds, which occur in UTC.
+ * 
+ * @note: International Atomic Time (TAI) is the time reference coordinate on the basis of the readings of atomic clocks, 
+ * operated in accordance with the definition of the second, the unit of time of the International System of Units. 
+ * TAI is a continuous time scale. UTC has discontinuities, as it is occasionally adjusted by leap seconds. 
+ * As of 1 January, 2022, TimestampIts is 5 seconds ahead of UTC, because since the ITS epoch on 1 January 2004 00:00:00.000 UTC, 
+ * further 5 leap seconds have been inserted in UTC.
+ * 
+ * EXAMPLE: The value for TimestampIts for 1 January 2007 00:00:00.000 UTC is `94 694 401 000` milliseconds,
+ * which includes one leap second insertion since the ITS epoch.
+ * @unit: 0,001 s
+ * @category: Basic information
+ * @revision: Description revised in in V2.1.1
+ */
+TimestampIts ::= INTEGER (0..4398046511103)
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `trafficCondition`. 
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`                  - in case further detailed information on the traffic condition is unavailable,
+ * - 1 `increasedVolumeOfTraffic`     - in case the type of traffic condition is increased traffic volume,
+ * - 2 `trafficJamSlowlyIncreasing`   - in case the type of traffic condition is a traffic jam which volume is increasing slowly,
+ * - 3 `trafficJamIncreasing`         - in case the type of traffic condition is a traffic jam which volume is increasing,
+ * - 4 `trafficJamStronglyIncreasing` - in case the type of traffic condition is a traffic jam which volume is strongly increasing,
+ * - 5 `trafficJam`         `         - in case the type of traffic condition is a traffic jam and no further detailed information about its volume is available,
+ * - 6 `trafficJamSlightlyDecreasing` - in case the type of traffic condition is a traffic jam which volume is decreasing slowly,
+ * - 7 `trafficJamDecreasing`         - in case the type of traffic condition is a traffic jam which volume is decreasing,
+ * - 8 `trafficJamStronglyDecreasing` - in case the type of traffic condition is a traffic jam which volume is decreasing rapidly,
+ * - 9 `trafficJamStable`             - in case the traffic condition is a traffic jam with stable volume,
+ * - 10-255: reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, definition of value 0 and 1 changed in V2.2.1, name and definition of value 5 changed in V2.2.1, value 9 added in V2.2.1
+ */
+TrafficConditionSubCauseCode ::= INTEGER {
+    unavailable                  (0),
+    increasedVolumeOfTraffic     (1),
+    trafficJamSlowlyIncreasing   (2),
+    trafficJamIncreasing         (3),
+    trafficJamStronglyIncreasing (4),
+    trafficJam                   (5),
+    trafficJamSlightlyDecreasing (6),
+    trafficJamDecreasing         (7),
+    trafficJamStronglyDecreasing (8),
+    trafficJamStable             (9)
+} (0..255)
+
+/**
+ * This DE indicates a direction of traffic with respect to a reference direction, and a portion of that traffic with respect to a reference position.
+ * 
+ * The value shall be set to:
+ * - 0 `allTrafficDirections`                                    - for all directions of traffic, 
+ * - 1 `sameAsReferenceDirection-upstreamOfReferencePosition`    - for the direction of traffic according to the reference direction, and the portion of traffic upstream of the reference position, 
+ * - 2 `sameAsReferenceDirection-downstreamOfReferencePosition`  - for the direction of traffic according to the reference direction, and the portion of traffic downstream of the reference position, 
+ * - 3 `oppositeToReferenceDirection`                            - for the direction of traffic opposite to the reference direction. 
+ *
+ * @note: Upstream traffic corresponds to the incoming traffic towards the event position, and downstream traffic to the departing traffic away from the event position.
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1 from RelevanceTrafficDirection, description and naming of values changed in V2.2.1
+ *
+ */
+ TrafficDirection ::= ENUMERATED {
+    allTrafficDirections(0), 
+    sameAsReferenceDirection-upstreamOfReferencePosition(1), 
+    sameAsReferenceDirection-downstreamOfReferencePosition(2), 
+    oppositeToReferenceDirection(3)
+}
+
+/**
+ * This DE represents the type of a traffic participant.
+ * 
+ * The value shall be set to:
+ * - 0 `unknown`          - information about traffic participant is not provided,
+ * - 1 `pedestrian`       - human being not using a mechanical device for their trip (VRU profile 1),
+ * - 2 `cyclist`          - non-motorized unicycles, bicycles , tricycles, quadracycles (VRU profile 2),
+ * - 3 `moped`            - light motor vehicles with less than four wheels as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class L1, L2 (VRU Profile 3),
+ * - 4 `motorcycles`      - motor vehicles with less than four wheels as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class L3, L4, L5, L6, L7 (VRU Profile 3),
+ * - 5 `passengerCar`     - small passenger vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class M1,
+ * - 6 `bus`              - large passenger vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class M2, M3,
+ * - 7 `lightTruck`       - light Goods Vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class N1,
+ * - 8 `heavyTruck`       - Heavy Goods Vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class N2 and N3,
+ * - 9 `trailer`          - unpowered vehicle that is intended to be towed by a powered vehicle as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class O,
+ * - 10 `specialVehicles` - vehicles which have special purposes other than the above (e.g. moving road works vehicle),
+ * - 11 `tram`            - vehicle which runs on tracks along public streets,
+ * - 12 `lightVruVehicle` - human being traveling on light vehicle, incl. possible use of roller skates or skateboards (VRU profile 2),
+ * - 13 `animal`          - animal presenting a safety risk to other road users e.g. domesticated dog in a city or horse (VRU Profile 4),
+ * - 14 `agricultural`    - agricultural and forestry vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class T,
+ * - 15 `infrastructure`  - infrastructure typically positioned outside of the drivable roadway (e.g. on a gantry, on a pole, on a stationary road works trailer, 
+                            or in a traffic control center); the infrastructure is static during the entire operation period of the ITS-S (e.g. no stop and go activity),
+ * - 16-255               - are reserved for future usage.
+ * 
+ * @category: Communication information.
+ * @revision: Created in V2.1.1 based on StationType, Changed name and definition of value 15 in V2.4.1 
+ */
+TrafficParticipantType ::= INTEGER {
+    unknown         (0), 
+    pedestrian      (1), 
+    cyclist         (2), 
+    moped           (3), 
+    motorcycle      (4), 
+    passengerCar    (5), 
+    bus             (6), 
+    lightTruck      (7), 
+    heavyTruck      (8), 
+    trailer         (9), 
+    specialVehicle  (10), 
+    tram            (11), 
+    lightVruVehicle (12), 
+    animal          (13),
+    agricultural    (14), 
+    infrastructure  (15)
+} (0..255)
+
+/**
+ * This DE indicates traffic rules that apply to vehicles at a certain position.
+ *
+ * The value shall be set to:
+ * - `0` - if overtaking is prohibited for all vehicles,
+ * - `1` - if overtaking is prohibited for trucks,
+ * - `2` - if vehicles should pass to the right lane,
+ * - `3` - if vehicles should pass to the left lane.
+ * - `4` - if vehicles should pass to the left or right lane.
+ *
+ * @category: Infrastructure information, Traffic information
+ * @revision: Editorial update in V2.1.1
+ */
+TrafficRule ::= ENUMERATED {
+    noPassing          (0), 
+    noPassingForTrucks (1), 
+    passToRight        (2), 
+    passToLeft         (3), 
+    ...,
+    passToLeftOrRight   (4)
+}
+
+/**
+ * This DE provides information about the presence of a trailer. 
+ *
+ * The value shall be set to:
+ * - 0 `noTrailerPresent`                - to indicate that no trailer is present, i.e. either the vehicle is physically not enabled to tow a trailer or it has been detected that no trailer is present.
+ * - 1 `trailerPresentWithKnownLength`   - to indicate that a trailer has been detected as present and the length is included in the vehicle length value.
+ * - 2 `trailerPresentWithUnknownLength` - to indicate that a trailer has been detected as present and the length is not included in the vehicle length value.
+ * - 3 `trailerPresenceIsUnknown`        - to indicate that information about the trailer presence is unknown, i.e. the vehicle is physically enabled to tow a trailer but the detection of trailer presence/absence is not possible.
+ * - 4 `unavailable`                     - to indicate that the information about the presence of a trailer is not available, i.e. it is neither known whether the vehicle is able to tow a trailer 
+ *                                         nor the detection of trailer presence/absence is possible.
+ * 
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1 based on VehicleLengthConfidenceIndication
+*/
+TrailerPresenceInformation ::= ENUMERATED {
+    noTrailerPresent                (0), 
+    trailerPresentWithKnownLength   (1), 
+    trailerPresentWithUnknownLength (2), 
+    trailerPresenceIsUnknown        (3), 
+    unavailable                     (4)
+}
+
+/**
+ * This  DE  defines  the  probability  that the ego trajectory  intercepts  with any  other object's  trajectory  on the  road. 
+ * 
+ * The value shall be set to:
+ * - `n` (`n >= 0` and `n <= 50`) to indicate the actual probability,
+ * - the values between 51 and 62 are reserved,
+ * - `63`: to indicate that the information is unavailable. 
+ *
+ * @unit: 2 %
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+TrajectoryInterceptionProbability ::= INTEGER { 
+    unavailable (63) 
+} (0..63) 
+
+/**
+ * This DE  defines  the  confidence level of the trajectoryInterceptionProbability.
+ *
+ * The value shall be set to:
+ * - `0` - to indicate confidence level less than 50 %,
+ * - `1` - to indicate confidence level greater than or equal to 50 % and less than 70 %,
+ * - `2` - to indicate confidence level greater than or equal to 70 % and less than 90 %,
+ * - `3` - to indicate confidence level greater than or equal to 90%.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+TrajectoryInterceptionConfidence ::= INTEGER { 
+    lessthan50percent     (0), 
+    between50and70Percent (1),
+    between70and90Percent (2), 
+    above90Percent        (3) 
+} (0..3)
+
+/**
+ * This DE represents the time interval between two consecutive message transmissions.
+ * 
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref DeltaTimeMilliSecondPos instead.
+ * @unit: 0,001 s
+ * @category: Basic information
+ * @revision: V1.3.1
+ */
+TransmissionInterval::= INTEGER (1..10000)
+
+/**
+ * This DE provides the turning direction. 
+ * 
+ * The value shall be set to:
+ * - `left`  for turning to te left.
+ * - `right` for turing to the right.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+TurningDirection::= ENUMERATED {
+    left, 
+    right 
+}
+
+/**
+ * This DE represents the smallest circular turn (i.e. U-turn) that the vehicle is capable of making.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 254`) to indicate the applicable value is equal to or less than n x 0,4 metre, and greater than (n-1) x 0,4 metre,
+ * - `254` to indicate that the turning radius is  greater than 253 x 0,4 metre = 101.2 metres,
+ * - `255` to indicate that the information is unavailable.
+ * 
+ * For vehicle with tracker, the turning radius applies to the vehicle only.
+ *
+ * @category: Vehicle information
+ * @unit 0,4 metre
+ * @revision: Description revised V2.1.1 (the meaning of 254 has changed slightly)
+ */
+TurningRadius ::= INTEGER {
+    outOfRange  (254),
+    unavailable (255)
+} (1..255)
+
+/**
+ * This DE represents an indication of how a certain path or area will be used. 
+ * 
+ * The value shall be set to:
+ * - 0  - ` noIndication `     - in case it will remain free to be used,
+ * - 1  - ` specialUse `       - in case it will be physically blocked by special use,
+ * - 2  - ` rescueOperation`   - in case it is intended to be used for rescue operations,
+ * - 3  - ` railroad `         - in case it is intended to be used for rail traffic,
+ * - 4  - ` fixedRoute `       - in case it is intended to be used for fixed route traffic (e.g. bus line in service, delivery services, garbage truck in service etc.),
+ * - 5  - ` restrictedRoute `  - in case it is intended to be used for driving on restricted routes (e.g dedicated lanes/routes for heavy trucks or buses),
+ * - 6  - ` adasAd `           - in case it is intended to be used for driving with an active ADAS or AD system (see DE AccelerationControl or AutomationControl),
+ * - 7  - ` navigation `       - in case it is intended to be used for driving with an active navigation system.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.2.1, extension 3-7 added in V2.3.1
+ */
+UsageIndication ::= ENUMERATED { 
+    noIndication    (0),
+    specialUse      (1),
+    rescueOperation (2),
+    ...,
+    railroad        (3),
+    fixedRoute      (4),
+    restrictedRoute (5),
+    adasAd          (6),
+    navigation      (7)
+}
+
+/** 
+ * This DE represents the duration of a traffic event validity. 
+ *
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref DeltaTimeSecond instead.
+ * @unit: 1 s
+ * @category: Basic information
+ * @revision: V1.3.1
+*/
+ValidityDuration::= INTEGER {
+   timeOfDetection(0),
+   oneSecondAfterDetection(1)
+} (0..86400)
+
+/**
+ * This DE represents the Vehicle Descriptor Section (VDS). The values are assigned according to ISO 3779 [6].
+ * 
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+VDS ::= IA5String (SIZE(6))
+
+/**
+ * This DE represents the value of the sub cause codes of the @ref CauseCode `vehicleBreakdown`. 
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`              - in case further detailed information on cause of vehicle break down is unavailable,
+ * - 1 `lackOfFuel`               - in case vehicle break down is due to lack of fuel,
+ * - 2 `lackOfBatteryPower`       - in case vehicle break down is caused by lack of battery power,
+ * - 3 `engineProblem`            - in case vehicle break down is caused by an engine problem,
+ * - 4 `transmissionProblem`      - in case vehicle break down is caused by transmission problem,
+ * - 5 `engineCoolingProblem`     - in case vehicle break down is caused by an engine cooling problem,
+ * - 6 `brakingSystemProblem`     - in case vehicle break down is caused by a braking system problem,
+ * - 7 `steeringProblem`          - in case vehicle break down is caused by a steering problem,
+ * - 8 `tyrePuncture-deprecated`  - deprecated since covered by `tyrePressureProblem`,
+ * - 9 `tyrePressureProblem`      - in case low tyre pressure in detected,
+ * - 10 `vehicleOnFire`           - in case the vehicle is on fire.
+ * - 11-255                       - are reserved for future usage.
+ *
+ * @category: Traffic information
+ * @revision: V1.3.1, value 10 assigned in V2.1.1, value 8 deprecated in V2.4.1
+ */
+VehicleBreakdownSubCauseCode ::= INTEGER {
+    unavailable             (0), 
+    lackOfFuel              (1), 
+    lackOfBatteryPower      (2), 
+    engineProblem           (3), 
+    transmissionProblem     (4), 
+    engineCoolingProblem    (5), 
+    brakingSystemProblem    (6), 
+    steeringProblem         (7), 
+    tyrePuncture-deprecated (8), 
+    tyrePressureProblem     (9), 
+    vehicleOnFire           (10)
+} (0..255)
+
+/** 
+ * This DE represents the height of the vehicle, measured from the ground to the highest point, excluding any antennas.
+ * In case vehicles are equipped with adjustable ride heights, camper shells, and any other
+ * equipment which may result in varying height, the largest possible height shall be used.
+ *
+ * The value shall be set to:
+ * - `n` (`n >0` and `n < 127`) indicates the applicable value is equal to or less than n x 0,05 metre, and greater than (n-1) x 0,05 metre,
+ * - `127` indicates that the vehicle width is greater than 6,3 metres,
+ * - `128` indicates that the information in unavailable.
+ *
+ * @unit: 0,05 metre 
+ * @category: Vehicle information
+ * @revision: created in V2.1.1
+*/
+VehicleHeight ::= INTEGER {
+    outOfRange  (126),  
+    unavailable (127)
+}(1..128)
+
+/** 
+ * This DE represents the height of the vehicle, measured from the ground to the highest point, excluding any antennas.
+ * In case vehicles are equipped with adjustable ride heights, camper shells, and any other
+ * equipment which may result in varying height, the largest possible height shall be used.
+
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 61`) indicates the applicable value is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,
+ * - `61` indicates that the vehicle height is greater than 6,0 metres,
+ * - `62` indicates that the information in unavailable.
+ * 
+ * @unit: 0,1 metre
+ * @category: Vehicle information 
+ * @revision: created in V2.3.1 based on VehicleHeight but better aligned in unit and range with VehicleWidth.
+ */
+VehicleHeight2 ::= INTEGER {
+    outOfRange  (61),  
+    unavailable (62)
+} (1..62)
+
+/**
+ * This DE provides information about the presence of a trailer. 
+ *
+ * The value shall be set to:
+ * - 0 `noTrailerPresent`                - to indicate that no trailer is present, i.e. either the vehicle is physically not enabled to tow a trailer or it has been detected that no trailer is present,
+ * - 1 `trailerPresentWithKnownLength`   - to indicate that a trailer has been detected as present and the length is  included in the vehicle length value,
+ * - 2 `trailerPresentWithUnknownLength` - to indicate that a trailer has been detected as present and the length is not included in the vehicle length value,
+ * - 3 `trailerPresenceIsUnknown`        - to indicate that information about the trailer presence is unknown, i.e. the vehicle is physically enabled to tow a trailer but the detection of trailer presence/absence is not possible,
+ * - 4 `unavailable`                     - to indicate that the information about the presence of a trailer is not available, i.e. it is neither known whether the vehicle is able to tow a trailer, 
+ *                                        nor the detection of trailer presence/absence is possible.
+ * 
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref TrailerPresenceInformation instead. 
+ * @category: Vehicle information
+ * @revision: Description revised in V2.1.1
+*/
+VehicleLengthConfidenceIndication ::= ENUMERATED {
+    noTrailerPresent                (0), 
+    trailerPresentWithKnownLength   (1), 
+    trailerPresentWithUnknownLength (2), 
+    trailerPresenceIsUnknown        (3), 
+    unavailable                     (4)
+}
+
+/**
+ * This DE represents the length of a vehicle.
+ *
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 1022`) to indicate the applicable value n is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,
+ * - `1 022` to indicate that the vehicle length is greater than 102.1 metres,
+ * - `1 023` to indicate that the information in unavailable.
+ * 
+ * 
+ * @unit: 0,1 metre
+ * @category: Vehicle information
+ * @revision: Description updated in V2.1.1 (the meaning of 1 022 has changed slightly).
+ */
+VehicleLengthValue ::= INTEGER {
+    outOfRange(1022), 
+    unavailable(1023)
+}  (1..1023)
+
+/**
+ * This DE represents the mass of an empty loaded vehicle.
+ *
+ * The value shall be set to: 
+ * - `n` (`n > 0` and `n < 1023`) to indicate that the applicable value is equal to or less than n x 10^5 gramm, and greater than (n-1) x 10^5 gramm,
+ * - `1 023` indicates that the vehicle mass is greater than 102 200 000 g,
+ * - `1 024` indicates  the vehicle mass information is unavailable.
+ * 
+ * @note:	The empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ * 
+ * @unit: 10^5 gramm
+ * @category: Vehicle information
+ * @revision: Description updated in V2.1.1 (the meaning of 1 023 has changed slightly).
+*/
+VehicleMass ::= INTEGER {
+    outOfRange (1023), 
+    unavailable(1024)
+} (1..1024) 
+
+/**
+ * This DE indicates the role played by a vehicle at a point in time.
+ *
+ * The value shall be set to:
+ * - 0 `default`          - to indicate the default vehicle role as indicated by the vehicle type,
+ * - 1 `publicTransport`  - to indicate that the vehicle is used to operate public transport service,
+ * - 2 `specialTransport` - to indicate that the vehicle is used for special transport purpose, e.g. oversized trucks,
+ * - 3 `dangerousGoods`   - to indicate that the vehicle is used for dangerous goods transportation,
+ * - 4 `roadWork`         - to indicate that the vehicle is used to realize roadwork or road maintenance mission,
+ * - 5 `rescue`           - to indicate that the vehicle is used for rescue purpose in case of an accident, e.g. as a towing service,
+ * - 6 `emergency`        - to indicate that the vehicle is used for emergency mission, e.g. ambulance, fire brigade,
+ * - 7 `safetyCar`        - to indicate that the vehicle is used for public safety, e.g. patrol,
+ * - 8 `agriculture`      - to indicate that the vehicle is used for agriculture, e.g. farm tractor, 
+ * - 9 `commercial`       - to indicate that the vehicle is used for transportation of commercial goods,
+ * - 10 `military`        - to indicate that the vehicle is used for military purpose, 
+ * - 11 `roadOperator`    - to indicate that the vehicle is used in road operator missions,
+ * - 12 `taxi`            - to indicate that the vehicle is used to provide an authorized taxi service,
+ * - 13 `uvar`            - to indicate that the vehicle is authorized to enter a zone according to the applicable Urban Vehicle Access Restrictions.
+ * - 14 `rfu1`            - is reserved for future usage.
+ * - 15 `rfu2`            - is reserved for future usage.
+ * 
+ * @category: Vehicle Information
+ * @revision: Description updated in V2.1.1 (removed reference to CEN/TS 16157-3), value 13 assigned in V2.2.1
+ */
+VehicleRole ::= ENUMERATED {
+    default         (0), 
+    publicTransport (1), 
+    specialTransport(2), 
+    dangerousGoods  (3), 
+    roadWork        (4), 
+    rescue          (5), 
+    emergency       (6), 
+    safetyCar       (7), 
+    agriculture     (8), 
+    commercial      (9), 
+    military        (10), 
+    roadOperator    (11), 
+    taxi            (12), 
+    uvar            (13), 
+    rfu1            (14), 
+    rfu2            (15)
+}
+
+/**
+ * This DE represents the width of a vehicle, excluding side mirrors and possible similar extensions.
+
+ * The value shall be set to:
+ * - `n` (`n > 0` and `n < 61`) indicates the applicable value is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,
+ * - `61` indicates that the vehicle width is greater than 6,0 metres,
+ * - `62` indicates that the information in unavailable.
+ * 
+ * @unit: 0,1 metre
+ * @category: Vehicle information 
+ * @revision: Description updated in V2.1.1 (the meaning of 61 has changed slightly).
+ */
+VehicleWidth ::= INTEGER {
+    outOfRange  (61),  
+    unavailable (62)
+} (1..62)
+
+/**
+ * This DE represents the vehicle acceleration at vertical direction in the centre of the mass of the empty vehicle.
+ * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11.
+ *
+ * The value shall be set to:
+ * - `-160` for acceleration values equal to or less than -16 m/s^2,
+ * - `n` (`n > -160` and `n <= 0`) to indicate downwards acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `n` (`n > 0` and `n < 160`) to indicate upwards acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,
+ * - `160` for acceleration values greater than 15,9 m/s^2,
+ * - `161` when the data is unavailable.
+ * 
+ * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ *
+ * @category: Vehicle information
+ * @unit: 0,1 m/s^2
+ * @revision: Desciption updated in V2.1.1 (the meaning of 160 has changed slightly).
+ *  
+*/
+VerticalAccelerationValue ::= INTEGER {
+    negativeOutOfRange (-160),
+    positiveOutOfRange (160),
+    unavailable        (161)  
+} (-160 .. 161)
+
+/** 
+ * This DE Identifies all the VRU profile types within a cluster.
+ * It consist of a Bitmap encoding VRU profiles, to allow multiple profiles to be indicated in a single cluster (heterogeneous cluster if more than one profile).
+ * 
+ * The corresponding bit shall be set to 1 under the following conditions:
+ * - 0 `pedestrian`  - indicates that the VRU cluster contains at least one pedestrian VRU,
+ * - 1 `bicycle`     - indicates that the VRU cluster contains at least one bicycle VRU member,
+ * - 2 `motorcyclist`- indicates that the VRU cluster contains at least one motorcycle VRU member,
+ * - 3 `animal`      - indicates that the VRU cluster contains at least one animal VRU member.
+ * 
+ * Otherwise, the corresponding bit shall be set to 0.
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1
+*/
+VruClusterProfiles ::= BIT STRING {
+    pedestrian   (0),
+    bicyclist    (1),
+    motorcyclist (2),
+    animal       (3)
+} (SIZE(4))
+
+/**
+ * This DE represents the possible usage conditions of the VRU device.
+
+ * - The value shall be set to:
+ * - 0 `unavailable`      - to indicate that the usage conditions are unavailable,
+ * - 1 `other`            - to indicate that the VRU device is in a state not defined below,
+ * - 2 `idle`             - to indicate that the human is currently not interacting with the device,
+ * - 3 `listeningToAudio` - to indicate that any audio source other than calling is in use,
+ * - 4 `typing`           - to indicate that the human is texting or performaing any other manual input activity,
+ * - 5 `calling`          - to indicate that the VRU device is currently receiving a call,
+ * - 6 `playingGames`     - to indicate that the human is playing games,
+ * - 7 `reading`          - to indicate that the human is reading on the VRU device,
+ * - 8 `viewing`          - to indicate that the human is watching dynamic content, including following navigation prompts, viewing videos or other visual contents that are not static.
+ * - value 9 to 15        - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15
+ */
+VruDeviceUsage ::= INTEGER {
+    unavailable      (0), 
+    other            (1), 
+    idle             (2), 
+    listeningToAudio (3), 
+    typing           (4), 
+    calling          (5), 
+    playingGames     (6), 
+    reading          (7), 
+    viewing          (8) 
+}(0..15)
+
+/**
+ * This DE represents the possible VRU environment conditions.
+ *
+ * - The value shall be set to:
+ * - 0 `unavailable`            - to indicate that the information on the type of environment is unavailable,
+ * - 1 `intersectionCrossing`   - to indicate that the VRU is on an intersection or crossing,
+ * - 2 `zebraCrossing`          - to indicate that the VRU is on a  zebra crossing (crosswalk),
+ * - 3 `sidewalk`               - to indicate that the VRU is on a sidewalk,
+ * - 4 `onVehicleRoad`          - to indicate that the VRU is on a traffic lane,
+ * - 5 `protectedGeographicArea`- to indicate that the VRU is in a protected area.
+ * - value 6 to 15              - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15
+ */
+VruEnvironment ::= INTEGER {
+    unavailable             (0), 
+    intersectionCrossing    (1), 
+    zebraCrossing           (2), 
+    sidewalk                (3), 
+    onVehicleRoad           (4), 
+    protectedGeographicArea (5)
+}(0..15)
+
+/**
+ *  This DE indicates the status of the possible human control over a VRU vehicle.
+ *
+ * The value shall be set to:
+ * - 0 `unavailable`                 - to indicate that the information is unavailable,
+ * - 1 `braking`                     - to indicate that the VRU is braking,
+ * - 2 `hardBraking`                 - to indicate that the VRU is braking hard,
+ * - 3 `stopPedaling`                - to indicate that the VRU stopped pedaling,
+ * - 4 `brakingAndStopPedaling`      - to indicate that the VRU stopped pedaling an is braking,
+ * - 5 `hardBrakingAndStopPedaling`  - to indicate that the VRU stopped pedaling an is braking hard,
+ * - 6 `noReaction`                  - to indicate that the VRU is not changing its behavior.
+ * - 7 to 15                         - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15
+ */
+VruMovementControl ::= INTEGER {
+    unavailable                (0), 
+    braking                    (1), 
+    hardBraking                (2), 
+    stopPedaling               (3), 
+    brakingAndStopPedaling     (4), 
+    hardBrakingAndStopPedaling (5), 
+    noReaction                 (6) 
+}(0..15)
+
+/**
+ * This DE indicates the profile of a pedestrian.
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`             - to indicate that the information on is unavailable,
+ * - 1 `ordinary-pedestrian`     - to indicate a pedestrian to which no more-specific profile applies,
+ * - 2 `road-worker`             - to indicate a pedestrian with the role of a road worker,
+ * - 3 `first-responder`         - to indicate a pedestrian with the role of a first responder.
+ * - value 4 to 15               - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+ */
+VruSubProfilePedestrian ::= INTEGER {
+    unavailable         (0), 
+    ordinary-pedestrian (1),
+    road-worker         (2), 
+    first-responder     (3)
+}(0..15)
+
+/**
+ * This DE indicates the profile of a VRU and its light VRU vehicle / mounted animal. 
+ *
+ * The value shall be set to:
+ * - 0 `unavailable`           - to indicate that the information  is unavailable,
+ * - 1 `bicyclist `            - to indicate a cycle and bicyclist to which no more-specific profile applies, 
+ * - 2 `wheelchair-user`       - to indicate a wheelchair and its user,
+ * - 3 `horse-and-rider`       - to indicate a horse and rider,
+ * - 4 `rollerskater`          - to indicate a roller-skater and skater,
+ * - 5 `e-scooter`             - to indicate an e-scooter and rider,
+ * - 6 `personal-transporter`  - to indicate a personal-transporter and rider,
+ * - 7 `pedelec`               - to indicate a pedelec and rider to which no more-specific profile applies,
+ * - 8 `speed-pedelec`         - to indicate a speed-pedelec and rider.
+ * - 9 `roadbike`              - to indicate a road bicycle (or road pedelec) and rider,
+ * - 10 `childrensbike`        - to indicate a childrenÂ´s bicycle (or childrenÂ´s pedelec) and rider,
+ * - 11 `racebike`             - to indicate a race bicycle (according to local applicable regulations) and rider. 
+ * - 12 to 15                  - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, values 9 and 10 assigned in V2.2.1, value 11 assigned in V2.4.1
+ */
+VruSubProfileBicyclist ::= INTEGER {
+    unavailable          (0), 
+    bicyclist            (1), 
+    wheelchair-user      (2), 
+    horse-and-rider      (3), 
+    rollerskater         (4), 
+    e-scooter            (5), 
+    personal-transporter (6),
+    pedelec              (7), 
+    speed-pedelec        (8),
+    roadbike             (9),
+    childrensbike        (10),
+    racebike             (11)
+}(0..15)
+
+/**
+ * This DE indicates the profile of a motorcyclist and corresponding vehicle.
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable `                  - to indicate that the information  is unavailable,
+ * - 1 `moped`                         - to indicate a moped and rider,
+ * - 2 `motorcycle`                    - to indicate a motorcycle and rider,
+ * - 3 `motorcycle-and-sidecar-right`  - to indicate a motorcycle with sidecar on the right and rider,
+ * - 4 `motorcycle-and-sidecar-left`   - to indicate  a motorcycle with sidecar on the left and rider.
+ * - 5 to 15                           - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+ */
+VruSubProfileMotorcyclist ::= INTEGER { 
+    unavailable                  (0), 
+    moped                        (1), 
+    motorcycle                   (2), 
+    motorcycle-and-sidecar-right (3), 
+    motorcycle-and-sidecar-left  (4)
+}(0..15)
+
+/**
+ * This DE indicates the profile of an animal
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`     - to indicate that the information  is unavailable,
+ * - 1 `wild-animal`     - to indicate a animal living in the wildness, 
+ * - 2 `farm-animal`     - to indicate an animal beloning to a farm,
+ * - 3 `service-animal`  - to indicate an animal that supports a human being.
+ * - 4 to 15             - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+ */
+VruSubProfileAnimal ::= INTEGER {
+    unavailable    (0), 
+    wild-animal    (1), 
+    farm-animal    (2), 
+    service-animal (3)
+}(0..15)
+
+/**
+ * This DE indicates the approximate size of a VRU including the VRU vehicle used.
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`    - to indicate that there is no matched size class or due to privacy reasons in profile 1, 
+ * - 1 `low`            - to indicate that the VRU size class is low depending on the VRU profile,
+ * - 2 `medium`         - to indicate that the VRU size class is medium depending on the VRU profile,
+ * - 3 `high`           - to indicate that the VRU size class is high depending on the VRU profile.
+ * - 4 to 15            - are reserved for future usage. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1
+ */
+VruSizeClass ::= INTEGER { 
+    unavailable (0), 
+    low         (1), 
+    medium      (2), 
+    high        (3)
+}(0..15)
+
+/**
+ * This DE describes the status of the exterior light switches of a VRU.
+ *
+ * The value of each bit indicates the state of the switch, which commands the corresponding light. 
+ * The bit corresponding to a specific light shall be set to 1, when the corresponding switch is turned on, either manually by the driver or VRU 
+ * or automatically by a vehicle or VRU system: 
+ * - 0 `unavailable`     - indicates no information available, 
+ * - 1 `backFlashLight ` - indicates the status of the back flash light,
+ * - 2 `helmetLight`     - indicates the status of the helmet light,
+ * - 3 `armLight`        - indicates the status of the arm light,
+ * - 4 `legLight`        - indicates the status of the leg light,
+ * - 5 `wheelLight`      - indicates the status of the wheel light. 
+ * - Bits 6 to 8         - are reserved for future use. 
+ * The bit values do not indicate if the corresponding lamps are alight or not.
+ * If  VRU is not equipped with a certain light or if the light switch status information is not available, the corresponding bit shall be set to 0.
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1
+ */ 
+VruSpecificExteriorLights ::= BIT STRING {
+    unavailable    (0),
+    backFlashLight (1),
+    helmetLight    (2),
+    armLight       (3),
+    legLight       (4),
+    wheelLight     (5)
+} (SIZE(8))
+
+/**
+ * This DE indicates the perpendicular distance between front and rear axle of the wheel base of vehicle.
+ *
+ * The value shall be set to:
+ * - `n` (`n >= 1` and `n < 126`) if the value is equal to or less than n x 0,1 metre  and more than (n-1) x 0,1 metre,
+ * - `126` indicates that the wheel base distance is equal to or greater than 12,5 metres,
+ * - `127` indicates that the information is unavailable.
+ *
+ * @unit 0,1 metre
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+ */
+WheelBaseVehicle ::= INTEGER {
+    outOfRange  (126),
+    unavailable (127)
+} (1..127)
+
+/** 
+ * This DE indicates the angle confidence value which represents the estimated accuracy of an angle value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * 
+ * The value shall be set to:
+ * - `n` (`n >= 1` and `n < 126`) if the confidence value is equal to or less than n x 0,1 degrees and more than (n-1) x 0,1 degrees,
+ * - `126` if the confidence value is out of range, i.e. greater than 12,5 degrees,
+ * - `127` if the confidence value is not available.
+ *
+ *
+ * @unit 0,1 degrees
+ * @category: GeoReference Information
+ * @revision: Created in V2.1.1
+*/
+Wgs84AngleConfidence ::= INTEGER {
+    outOfRange  (126), 
+    unavailable (127)  
+} (1..127)
+
+
+/** 
+ * This DE represents an angle value in degrees described in the WGS84 reference system with respect to the WGS84 north.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ * When the information is not available, the DE shall be set to 3 601. The value 3600 shall not be used.
+ *
+ * @unit 0,1 degrees
+ * @category: GeoReference Information
+ * @revision: Created in V2.1.1
+*/
+Wgs84AngleValue ::= INTEGER { 
+    wgs84North  (0),
+    wgs84East   (900),
+    wgs84South  (1800),
+    wgs84West   (2700),
+    doNotUse    (3600),
+    unavailable (3601)
+} (0..3601)
+
+/**
+ * This DE indicates the actual status of the front wipers of the vehicle. 
+ *
+ * The value shall be set to:
+ * - 0 `unavailable`   - to indicate that the information is unavailable,
+ * - 1 `off`           - to indicate that the wipers are switched off,
+ * - 2 `intermittent`  - to indicate that the wipers are moving intermittently,
+ * - 3 `low`           - to indicate that the wipers are moving at low speed,
+ * - 4 `high`          - to indicate that the wipers are moving at high speed,
+ * - values 5 to 7      - are reserved for future usage. 
+ *
+ * @note:  the status can be either set manually by the driver or automatically by e.g. a rain sensor. The way the status is set does not affect the status itself. 
+ * @category: Vehicle information 
+ * @revision: created in V2.3.1
+ */
+WiperStatus ::= INTEGER {
+   unavailable         (0), 
+   off                 (1),  
+   intermittent        (2), 
+   low                 (3),
+   high                (4)
+} (0..7)
+
+/**
+ * This DE represents the World Manufacturer Identifier (WMI). The values are assigned according to ISO 3779 [6].
+ * 
+ *
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+WMInumber ::= IA5String (SIZE(1..3))
+
+/**
+ * This DE represents the sub cause codes of the @ref CauseCode `wrongWayDriving` .
+ * 
+ * The value shall be set to:
+ * - 0 `unavailable`           - in case further detailed information on wrong way driving event is unavailable,
+ * - 1 `wrongLane-deprecated`   - deprecated since not pertinent to wrong way driving,
+ * - 2 `wrongDirection`        - in case vehicle is driving in a direction that it is not allowed,
+ * - 3-255                     - reserved for future usage.
+ * 
+ * @category: Traffic information
+ * @revision: V1.3.1, value 1 deprecated in V2.4.1
+ */
+WrongWayDrivingSubCauseCode ::= INTEGER {
+    unavailable           (0), 
+    wrongLane-deprecated  (1), 
+    wrongDirection        (2)
+} (0..255)
+
+/**
+ * This DE indicates the yaw rate confidence value which represents the estimated accuracy for a yaw rate value with a default confidence level of 95 %.
+ * If required, the confidence level can be defined by the corresponding standards applying this DE.
+ * 
+ * The value shall be set to:
+ * - `0` if the confidence value is equal to or less than 0,01 degree/second,
+ * - `1` if the confidence value is equal to or less than 0,05 degrees/second or greater than 0,01 degree/second,
+ * - `2` if the confidence value is equal to or less than 0,1 degree/second or greater than 0,05 degree/second,
+ * - `3` if the confidence value is equal to or less than 1 degree/second or greater than 0,1 degree/second,
+ * - `4` if the confidence value is equal to or less than 5 degrees/second or greater than 1 degrees/second,
+ * - `5` if the confidence value is equal to or less than 10 degrees/second or greater than 5 degrees/second,
+ * - `6` if the confidence value is equal to or less than 100 degrees/second or greater than 10 degrees/second,
+ * - `7` if the confidence value is out of range, i.e. greater than 100 degrees/second,
+ * - `8` if the confidence value is unavailable.
+ * 
+ * NOTE: The fact that a yaw rate value is received with confidence value set to `unavailable(8)` can be caused by
+ * several reasons, such as:
+ * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,
+ * - the sensor cannot calculate the accuracy due to lack of variables, or
+ * - there has been a vehicle bus (e.g. CAN bus) error.
+ * In all 3 cases above, the yaw rate value may be valid and used by the application.
+ * 
+ * If a yaw rate value is received and its confidence value is set to `outOfRange(7)`, it means that the 
+ * yaw rate value is not valid and therefore cannot be trusted. Such value is not useful the application.
+ * 
+ * @category: Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+YawRateConfidence ::= ENUMERATED {
+    degSec-000-01 (0),
+    degSec-000-05 (1),
+    degSec-000-10 (2),
+    degSec-001-00 (3), 
+    degSec-005-00 (4),
+    degSec-010-00 (5),
+    degSec-100-00 (6),
+    outOfRange    (7),
+    unavailable   (8)
+}
+
+/**
+ * This DE represents the vehicle rotation around z-axis of the coordinate system centred on the centre of mass of the empty-loaded
+ * vehicle. The leading sign denotes the direction of rotation.
+ * 
+ * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11.
+ *
+ * The value shall be set to:
+ * - `-32 766` to indicate that the yaw rate is equal to or greater than 327,66 degrees/second to the right,
+ * - `n` (`n > -32 766` and `n <= 0`) to indicate that the rotation is clockwise (i.e. to the right) and is equal to or less than n x 0,01 degrees/s, 
+      and greater than (n-1) x 0,01 degrees/s,
+ * - `n` (`n > 0` and `n < 32 766`) to indicate that the rotation is anti-clockwise (i.e. to the left) and is equal to or less than n x 0,01 degrees/s, 
+      and greater than (n-1) x 0,01 degrees/s,
+ * - `32 766` to indicate that the yaw rate is greater than 327.65 degrees/second to the left,
+ * - `32 767` to indicate that the information is not available.
+ * 
+ * The reading instant should be the same as for the vehicle acceleration.
+ * 
+ * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6.
+ * 
+ * @unit: 0,01 degree per second. 
+ * @category: Vehicle Information
+ * @revision: Description revised in V2.1.1 (the meaning of 32766 has changed slightly). Requirement on raw data deleted in V2.4.1
+*/
+YawRateValue ::= INTEGER {
+    negativeOutOfRange (-32766), 
+    positiveOutOfRange (32766), 
+    unavailable        (32767)
+} (-32766..32767)
+
+----------------------------------------
+-- Specification of CDD Data Frames:
+----------------------------------------
+
+/**
+ * This DF represents an acceleration vector with associated confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field polarAcceleration: the representation of the acceleration vector in a polar or cylindrical coordinate system. 
+ * 
+ * @field cartesianAcceleration: the representation of the acceleration vector in a cartesian coordinate system.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+Acceleration3dWithConfidence::= CHOICE {
+    polarAcceleration                    AccelerationPolarWithZ,
+    cartesianAcceleration                AccelerationCartesian 
+}
+
+/**
+ * This DF represents an acceleration vector in a polar or cylindrical coordinate system.
+ 
+ * It shall include the following components: 
+ * 
+ * @field accelerationMagnitude: magnitude of the acceleration vector projected onto the reference plane, with the associated confidence value.
+ * 
+ * @field accelerationDirection: polar angle of the acceleration vector projected onto the reference plane, with the associated confidence value.
+ *
+ * @field zAcceleration: the optional z component of the acceleration vector along the reference axis of the cylindrical coordinate system, with the associated confidence value.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+AccelerationPolarWithZ::= SEQUENCE{
+    accelerationMagnitude                             AccelerationMagnitude,
+    accelerationDirection                             CartesianAngle,
+    zAcceleration                                     AccelerationComponent OPTIONAL
+}
+
+/**
+ * This DF represents a acceleration vector in a cartesian coordinate system.
+ 
+ * It shall include the following components: 
+ * 
+ * @field xAcceleration: the x component of the acceleration vector with the associated confidence value.
+ * 
+ * @field yAcceleration: the y component of the acceleration vector with the associated confidence value.
+ *
+ * @field zAcceleration: the optional z component of the acceleration vector with the associated confidence value.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+AccelerationCartesian::= SEQUENCE{
+    xAcceleration      AccelerationComponent,
+    yAcceleration      AccelerationComponent,
+    zAcceleration      AccelerationComponent OPTIONAL
+}            
+
+/** 
+ * This DF represents an acceleration component along with a confidence value.
+ *
+ * It shall include the following components: 
+ *
+ * @field value: the value of the acceleration component which can be estimated as the mean of the current distribution.
+ *
+ * @field confidence: the confidence value associated to the provided value.
+ *
+ * @category: Kinematic Information
+ * @revision: Created in V2.1.1
+ */
+AccelerationComponent ::= SEQUENCE {
+    value         AccelerationValue,
+    confidence    AccelerationConfidence
+}
+
+/** 
+ * This DF represents information associated to changes in acceleration. 
+ *
+ * It shall include the following components: 
+ *
+ * @field accelOrDecel: the indication of an acceleration change.
+ *
+ * @field actionDeltaTime: the period over which the acceleration change action is performed.
+ *
+ * @category: Kinematic Information
+ * @revision: Created in V2.1.1
+ */
+AccelerationChangeIndication ::= SEQUENCE {
+    accelOrDecel       AccelerationChange,
+    actionDeltaTime    DeltaTimeTenthOfSecond,
+    ...
+}
+
+/**
+ * This DF represents the magnitude of the acceleration vector and associated confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field accelerationMagnitudeValue: the magnitude of the acceleration vector.
+ * 
+ * @field accelerationConfidence: the confidence value of the magnitude value.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+AccelerationMagnitude::= SEQUENCE {
+    accelerationMagnitudeValue   AccelerationMagnitudeValue,
+    accelerationConfidence       AccelerationConfidence
+}
+
+/**
+ * This DF represents an identifier used to describe a protocol action taken by an ITS-S.
+ * 
+ * It shall include the following components: 
+ *
+ * @field originatingStationId: Id of the ITS-S that takes the action. 
+ * 
+ * @field sequenceNumber: a sequence number. 
+ * 
+ * @category: Communication information
+ * @revision: Created in V2.1.1 based on @ref ActionID.
+ */
+ActionId ::= SEQUENCE {
+    originatingStationId    StationId,
+    sequenceNumber          SequenceNumber
+}
+
+/**
+ * This DF represents an identifier used to describe a protocol action taken by an ITS-S.
+ * 
+ * It shall include the following components: 
+ *
+ * @field originatingStationId: Id of the ITS-S that takes the action. 
+ * 
+ * @field sequenceNumber: a sequence number. 
+ * 
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref ActionId instead. 
+ * @category: Communication information
+ * @revision: V1.3.1
+ */
+ActionID ::= SEQUENCE {
+    originatingStationId    StationID,
+    sequenceNumber          SequenceNumber
+}
+
+/**
+ * This DF shall contain a list of @ref ActionId. 
+
+ * @category: Communication Information
+ * @revision: Created in V2.1.1 based on ReferenceDenms from DENM Release 1
+*/
+ActionIdList::= SEQUENCE (SIZE(1..8, ...)) OF ActionId
+
+/**
+ * This DF provides the altitude and confidence level of an altitude information in a WGS84 coordinate system.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * It shall include the following components: 
+ *
+ * @field altitudeValue: altitude of a geographical point.
+ *
+ * @field altitudeConfidence: confidence level of the altitudeValue.
+ *
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref AltitudeWithConfidence instead. 
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1
+ */
+Altitude ::= SEQUENCE {
+    altitudeValue         AltitudeValue,
+    altitudeConfidence    AltitudeConfidence
+}
+
+/** 
+ * This DE represents a general container for usage in various types of messages.
+ *
+ * It shall include the following components: 
+ *
+ * @field stationType: the type of technical context in which the ITS-S that has generated the message is integrated in.
+ *
+ * @field referencePosition: the reference position of the station that has generated the message that contains the basic container.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+BasicContainer ::= SEQUENCE {
+	stationType          TrafficParticipantType,
+	referencePosition    ReferencePositionWithConfidence,
+	...
+}
+
+/** 
+ * This DF provides information about the configuration of a road section in terms of lanes using a list of @ref LanePositionAndType .
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+BasicLaneConfiguration::= SEQUENCE(SIZE(1..16,...)) OF BasicLaneInformation 
+
+/** 
+ * This DF provides basic information about a single lane of a road segment.
+ * It includes the following components: 
+ * 
+ * @field laneNumber: the number associated to the lane that provides a transversal identification. 
+ * 
+ * @field direction: the direction of traffic flow allowed on the lane. 
+ * 
+ * @field laneWidth: the optional width of the lane.
+ *
+ * @field connectingLane: the number of the connecting lane in the next road section, i.e. the number of the lane which the vehicle will use when travelling from one section to the next,
+ * if it does not actively change lanes. If this component is absent, the lane name number remains the same in the next section.
+ *
+ * @field connectingRoadSection: the identifier of the next road section in direction of traffic, that is connecting to the current road section. 
+ * If this component is absent, the connecting road section is the one following the instance where this DF is placed in the @ref RoadConfigurationSectionList.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+
+BasicLaneInformation::= SEQUENCE{
+  laneNumber	         LanePosition,
+  direction		         Direction,
+  laneWidth		         LaneWidth OPTIONAL,
+  connectingLane         LanePosition OPTIONAL,
+  connectingRoadSection  RoadSectionId OPTIONAL,
+  ...
+}
+((WITH COMPONENTS {..., connectingLane PRESENT}) |
+ (WITH COMPONENTS {..., connectingLane ABSENT, connectingRoadSection ABSENT}))
+
+/** 
+ * This DF represents a general Data Frame to describe an angle component along with a confidence value in a cartesian coordinate system.
+ *
+ * It shall include the following components: 
+ *
+ * @field value: The angle value which can be estimated as the mean of the current distribution.
+ *
+ * @field confidence: The confidence value associated to the provided value.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+CartesianAngle ::= SEQUENCE {
+    value         CartesianAngleValue,
+    confidence    AngleConfidence
+}
+
+/** 
+ * This DF represents an angular velocity component along with a confidence value in a cartesian coordinate system.
+ *
+ * It shall include the following components: 
+ *
+ * @field value: The angular velocity component.
+ *
+ * @field confidence: The confidence value associated to the provided value.
+ *
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+CartesianAngularVelocityComponent ::= SEQUENCE {
+    value         CartesianAngularVelocityComponentValue,
+    confidence    AngularSpeedConfidence
+}
+
+/** 
+ * This DF represents a general Data Frame to describe an angular acceleration component along with a confidence value in a cartesian coordinate system.
+ *
+ * It shall include the following components: 
+ *
+ * @field value: The angular acceleration component value.
+ *
+ * @field confidence: The confidence value associated to the provided value.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1 
+ */
+CartesianAngularAccelerationComponent ::= SEQUENCE {
+    value         CartesianAngularAccelerationComponentValue,
+    confidence    AngularAccelerationConfidence
+}
+
+/**
+ * This DF represents a coordinate along with a confidence value in a cartesian reference system.
+ *
+ * It shall include the following components: 
+ * 
+ * @field value: the coordinate value, which can be estimated as the mean of the current distribution.
+ * 
+ * @field confidence: the coordinate confidence value associated to the provided value.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+CartesianCoordinateWithConfidence ::= SEQUENCE {
+    value         CartesianCoordinateLarge,
+    confidence    CoordinateConfidence
+}
+
+/** 
+ * This DF represents a  position in a two- or three-dimensional cartesian coordinate system.
+ *
+ * It shall include the following components: 
+ *
+ * @field xCoordinate: the X coordinate value.
+ *
+ * @field yCoordinate: the Y coordinate value.
+ *
+ * @field zCoordinate: the optional Z coordinate value.
+ * 
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+CartesianPosition3d::=SEQUENCE{
+    xCoordinate    CartesianCoordinate,
+    yCoordinate    CartesianCoordinate,
+    zCoordinate    CartesianCoordinate OPTIONAL
+}
+
+/** 
+ * This DF represents a  position in a two- or three-dimensional cartesian coordinate system with an associated confidence level for each coordinate.
+ *
+ * It shall include the following components: 
+ *
+ * @field xCoordinate: the X coordinate value with the associated confidence level.
+ *
+ * @field yCoordinate: the Y coordinate value with the associated confidence level.
+ *
+ * @field zCoordinate: the optional Z coordinate value with the associated confidence level.
+ * 
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+CartesianPosition3dWithConfidence::= SEQUENCE{    
+    xCoordinate    CartesianCoordinateWithConfidence, 
+    yCoordinate    CartesianCoordinateWithConfidence, 
+    zCoordinate    CartesianCoordinateWithConfidence OPTIONAL
+}
+
+/**
+ * This DF is a representation of the cause code value of a traffic event. 
+ *
+ * It shall include the following components: 
+ *
+ * @field causeCode: the main cause of a detected event. 
+ *
+ * @field subCauseCode: the subordinate cause of a detected event. 
+ *
+ * The semantics of the entire DF are completely defined by the component causeCode. The interpretation of the subCauseCode may 
+ * provide additional information that is not strictly necessary to understand the causeCode itself, and is therefore optional.
+ *
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref CauseCodeV2 instead. 
+ *
+ * @category: Traffic information
+ * @revision: Editorial update in V2.1.1
+ */
+CauseCode ::= SEQUENCE {
+    causeCode       CauseCodeType,
+    subCauseCode    SubCauseCodeType,
+    ...
+}
+
+/**
+ * This DF is a representation of the cause code value and associated sub cause code value of a traffic event. 
+ *
+ * The following options are available:
+ * - 0                                                        - reserved for future use,
+ * - 1  - `trafficCondition1`                                 - in case the type of event is an abnormal traffic condition,
+ * - 2  - `accident2`                                         - in case the type of event is a road accident, 
+ * - 3  - `roadworks3`                                        - in case the type of event is roadwork, based on authoritative information,
+ * - 4  - `detectedRoadworks4`                                - in case the type of event is roadworks, based on non-authoritative information such as factual detections,
+ * - 5  - `impassability5`                                    - in case the  type of event is unmanaged road blocking, referring to any
+ *                                                              blocking of a road, partial or total, which has not been adequately secured and signposted,
+ * - 6  - `adhesion6`                                         - in case the  type of event is low adhesion of the road surface,
+ * - 7  - `aquaplaning7`                                      - danger of aquaplaning on the road,
+ * - 8                                                        - reserved for future usage,
+ * - 9  - `hazardousLocation-SurfaceCondition9`               - in case the type of event is abnormal road surface condition not covered by `adhesion6`, 
+ * - 10 - `hazardousLocation-ObstacleOnTheRoad10`             - in case the type of event is obstacle on the road,
+ * - 11 - `hazardousLocation-AnimalOnTheRoad11`               - in case the type of event is animal on the road,
+ * - 12 - `humanPresenceOnTheRoad`                            - in case the type of event is presence of human vulnerable road user on the road,
+ * - 13                                                       - reserved for future usage,
+ * - 14 - `wrongWayDriving14`                                 - in case the type of the event is vehicle driving in wrong way,
+ * - 15 - `rescueRecoveryAndMaintenanceWorkInProgress15`      - in case the type of event is rescue, recovery and maintenance work for accident or for a road hazard in progress,
+ * - 16                                                       - reserved for future usage,
+ * - 17 - `adverseWeatherCondition-Wind17`                    - in case the type of event is wind,
+ * - 18 - `adverseWeatherCondition-Visibility18`              - in case the type of event is low visibility,
+ * - 19 - `adverseWeatherCondition-Precipitation19`           - in case the type of event is precipitation,
+ * - 20 - `violence20`                                        - in case the the type of event is human violence on or near the road,
+ * - 21-25                                                    - reserved for future usage,
+ * - 26 - `slowVehicle26`                                     - in case the type of event is slow vehicle driving on the road,
+ * - 27 - `dangerousEndOfQueue27`                             - in case the type of event is dangerous end of vehicle queue,
+ * - 28 - `publicTransportVehicleApproaching                  - in case the type of event is a public transport vehicle approaching, with a priority defined by applicable traffic regulations,
+ * - 29-90                                                    - are reserved for future usage,
+ * - 91 - `vehicleBreakdown91`                                - in case the type of event is break down vehicle on the road,
+ * - 92 - `postCrash92`                                       - in case the type of event is a detected crash,
+ * - 93 - `humanProblem93`                                    - in case the type of event is human health problem in vehicles involved in traffic,
+ * - 94 - `stationaryVehicle94`                               - in case the type of event is stationary vehicle,
+ * - 95 - `emergencyVehicleApproaching95`                     - in case the type of event is an approaching vehicle operating on a mission for which the 
+                                                                applicable traffic regulations provide it with defined priority rights in traffic. 
+ * - 96 - `hazardousLocation-DangerousCurve96`                - in case the type of event is dangerous curve,
+ * - 97 - `collisionRisk97`                                   - in case the type of event is a collision risk,
+ * - 98 - `signalViolation98`                                 - in case the type of event is signal violation,
+ * - 99 - `dangerousSituation99`                              - in case the type of event is dangerous situation in which autonomous safety system in vehicle 
+ *                                                              is activated,
+ * - 100 - `railwayLevelCrossing100`                          - in case the type of event is a railway level crossing. 
+ * - 101-255                                                  - are reserved for future usage.
+ *
+ * @note: this DF is defined for use as part of CauseCodeV2. It is recommended to use CauseCodeV2.
+ * @category: Traffic information
+ * @revision: Created in V2.1.1, the type of impassability5 changed to ImpassabilitySubCauseCode in V2.2.1, value 28 added in V2.2.1, definition of value 12 and 95 changed in V2.2.1
+ *            name and/or definition of values 3, 6, 9, 15 and 17 changed in V2.4.1, value 4 assigned in V2.4.1
+ */
+CauseCodeChoice::= CHOICE {
+    reserved0                                          SubCauseCodeType,
+    trafficCondition1                                  TrafficConditionSubCauseCode,
+    accident2                                          AccidentSubCauseCode,
+    roadworks3                                         RoadworksSubCauseCode,
+    detectedRoadworks4                                 SubCauseCodeType,
+    impassability5                                     ImpassabilitySubCauseCode,
+    adhesion6                                          AdhesionSubCauseCode,
+    aquaplaning7                                       SubCauseCodeType,
+    reserved8                                          SubCauseCodeType,
+    hazardousLocation-SurfaceCondition9                HazardousLocation-SurfaceConditionSubCauseCode,
+    hazardousLocation-ObstacleOnTheRoad10              HazardousLocation-ObstacleOnTheRoadSubCauseCode,
+    hazardousLocation-AnimalOnTheRoad11                HazardousLocation-AnimalOnTheRoadSubCauseCode,
+    humanPresenceOnTheRoad12                           HumanPresenceOnTheRoadSubCauseCode,
+    reserved13                                         SubCauseCodeType,
+    wrongWayDriving14                                  WrongWayDrivingSubCauseCode,
+    rescueRecoveryAndMaintenanceWorkInProgress15       RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode,
+    reserved16                                         SubCauseCodeType,
+    adverseWeatherCondition-Wind17                     AdverseWeatherCondition-WindSubCauseCode,
+    adverseWeatherCondition-Visibility18               AdverseWeatherCondition-VisibilitySubCauseCode,
+    adverseWeatherCondition-Precipitation19            AdverseWeatherCondition-PrecipitationSubCauseCode,
+    violence20                                         SubCauseCodeType,
+    reserved21                                         SubCauseCodeType,
+    reserved22                                         SubCauseCodeType,
+    reserved23                                         SubCauseCodeType,
+    reserved24                                         SubCauseCodeType,
+    reserved25                                         SubCauseCodeType,
+    slowVehicle26                                      SlowVehicleSubCauseCode,
+    dangerousEndOfQueue27                              DangerousEndOfQueueSubCauseCode,
+    publicTransportVehicleApproaching28                SubCauseCodeType,
+    reserved29                                         SubCauseCodeType,
+    reserved30                                         SubCauseCodeType,
+    reserved31                                         SubCauseCodeType,
+    reserved32                                         SubCauseCodeType,
+    reserved33                                         SubCauseCodeType,
+    reserved34                                         SubCauseCodeType,
+    reserved35                                         SubCauseCodeType,
+    reserved36                                         SubCauseCodeType,
+    reserved37                                         SubCauseCodeType,
+    reserved38                                         SubCauseCodeType,
+    reserved39                                         SubCauseCodeType,
+    reserved40                                         SubCauseCodeType,
+    reserved41                                         SubCauseCodeType,
+    dontPanic42                                        SubCauseCodeType,
+    reserved43                                         SubCauseCodeType,
+    reserved44                                         SubCauseCodeType,
+    reserved45                                         SubCauseCodeType,
+    reserved46                                         SubCauseCodeType,
+    reserved47                                         SubCauseCodeType,
+    reserved48                                         SubCauseCodeType,
+    reserved49                                         SubCauseCodeType,
+    reserved50                                         SubCauseCodeType,
+    reserved51                                         SubCauseCodeType,
+    reserved52                                         SubCauseCodeType,
+    reserved53                                         SubCauseCodeType,
+    reserved54                                         SubCauseCodeType,
+    reserved55                                         SubCauseCodeType,
+    reserved56                                         SubCauseCodeType,
+    reserved57                                         SubCauseCodeType,
+    reserved58                                         SubCauseCodeType,   
+    reserved59                                         SubCauseCodeType, 
+    reserved60                                         SubCauseCodeType,
+    reserved61                                         SubCauseCodeType,
+    reserved62                                         SubCauseCodeType,
+    reserved63                                         SubCauseCodeType,
+    reserved64                                         SubCauseCodeType,
+    reserved65                                         SubCauseCodeType,
+    reserved66                                         SubCauseCodeType,    
+    reserved67                                         SubCauseCodeType,
+    reserved68                                         SubCauseCodeType,
+    reserved69                                         SubCauseCodeType,
+    reserved70                                         SubCauseCodeType,
+    reserved71                                         SubCauseCodeType,
+    reserved72                                         SubCauseCodeType,
+    reserved73                                         SubCauseCodeType,
+    reserved74                                         SubCauseCodeType,
+    reserved75                                         SubCauseCodeType,
+    reserved76                                         SubCauseCodeType,
+    reserved77                                         SubCauseCodeType,
+    reserved78                                         SubCauseCodeType,
+    reserved79                                         SubCauseCodeType,
+    reserved80                                         SubCauseCodeType,
+    reserved81                                         SubCauseCodeType,
+    reserved82                                         SubCauseCodeType,
+    reserved83                                         SubCauseCodeType,
+    reserved84                                         SubCauseCodeType,
+    reserved85                                         SubCauseCodeType,
+    reserved86                                         SubCauseCodeType,
+    reserved87                                         SubCauseCodeType,
+    reserved88                                         SubCauseCodeType,
+    reserved89                                         SubCauseCodeType,
+    reserved90                                         SubCauseCodeType,
+    vehicleBreakdown91                                 VehicleBreakdownSubCauseCode,
+    postCrash92                                        PostCrashSubCauseCode,
+    humanProblem93                                     HumanProblemSubCauseCode,
+    stationaryVehicle94                                StationaryVehicleSubCauseCode,
+    emergencyVehicleApproaching95                      EmergencyVehicleApproachingSubCauseCode,
+    hazardousLocation-DangerousCurve96                 HazardousLocation-DangerousCurveSubCauseCode,
+    collisionRisk97                                    CollisionRiskSubCauseCode,
+    signalViolation98                                  SignalViolationSubCauseCode,
+    dangerousSituation99                               DangerousSituationSubCauseCode,
+    railwayLevelCrossing100                            RailwayLevelCrossingSubCauseCode,
+    reserved101                                        SubCauseCodeType,
+    reserved102                                        SubCauseCodeType,
+    reserved103                                        SubCauseCodeType,
+    reserved104                                        SubCauseCodeType,
+    reserved105                                        SubCauseCodeType,
+    reserved106                                        SubCauseCodeType,
+    reserved107                                        SubCauseCodeType,
+    reserved108                                        SubCauseCodeType,
+    reserved109                                        SubCauseCodeType,
+    reserved110                                        SubCauseCodeType,
+    reserved111                                        SubCauseCodeType,
+    reserved112                                        SubCauseCodeType,
+    reserved113                                        SubCauseCodeType,
+    reserved114                                        SubCauseCodeType,
+    reserved115                                        SubCauseCodeType,
+    reserved116                                        SubCauseCodeType,
+    reserved117                                        SubCauseCodeType,
+    reserved118                                        SubCauseCodeType,
+    reserved119                                        SubCauseCodeType,
+    reserved120                                        SubCauseCodeType,
+    reserved121                                        SubCauseCodeType,
+    reserved122                                        SubCauseCodeType,
+    reserved123                                        SubCauseCodeType,
+    reserved124                                        SubCauseCodeType,
+    reserved125                                        SubCauseCodeType,
+    reserved126                                        SubCauseCodeType,
+    reserved127                                        SubCauseCodeType,
+    reserved128                                        SubCauseCodeType
+  }
+
+/**
+ * This DF is an alternative representation of the cause code value of a traffic event. 
+ *
+ * It shall include the following components: 
+ *
+ * @field ccAndScc: the main cause of a detected event. Each entry is of a different type and represents the sub cause code.
+
+ * The semantics of the entire DF are completely defined by the choice value which represents the cause code value. 
+ * The interpretation of the sub cause code value may provide additional information that is not strictly necessary to understand 
+ * the cause code itself, and is therefore optional.
+ *
+ * @category: Traffic information
+ * @revision: Created in V2.1.1, description amended in V2.2.1
+ */
+CauseCodeV2 ::= SEQUENCE {
+    ccAndScc    CauseCodeChoice,
+    ...
+}
+
+/**
+ * The DF describes the position of a CEN DSRC road side equipment.
+ *
+ * It shall include the following components: 
+ * 
+ * @field protectedZoneLatitude: the latitude of the CEN DSRC road side equipment.
+ * 
+ * @field protectedZoneLongitude: the latitude of the CEN DSRC road side equipment. 
+ * 
+ * @field cenDsrcTollingZoneID: the optional ID of the CEN DSRC road side equipment.
+ * 
+ * @category: Infrastructure information, Communication information
+ * @revision: revised in V2.1.1 (cenDsrcTollingZoneId is directly of type ProtectedZoneId)
+ */
+CenDsrcTollingZone ::= SEQUENCE {
+    protectedZoneLatitude     Latitude,
+    protectedZoneLongitude    Longitude,
+    cenDsrcTollingZoneId      ProtectedZoneId OPTIONAL,
+    ...
+}
+
+/** 
+ * 
+ * This DF represents the shape of a circular area or a right cylinder that is centred on the shape's reference point. 
+ *
+ * It shall include the following components: 
+ * 
+ * @field shapeReferencePoint: optional reference point that represents the centre of the circle, relative to an externally specified reference position. 
+ * If this component is absent, the externally specified reference position represents the shape's reference point. 
+ *
+ * @field radius: the radius of the circular area.
+ *
+ * @field height: the optional height, present if the shape is a right cylinder extending in the positive z-axis. 
+ *
+ * 
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+ */
+CircularShape ::= SEQUENCE {
+    shapeReferencePoint    CartesianPosition3d OPTIONAL,
+    radius                 StandardLength12b,
+    height                 StandardLength12b OPTIONAL
+}
+
+/**
+ * This DF indicates the opening/closure status of the lanes of a carriageway.
+ *
+ * It shall include the following components: 
+ * 
+ * @field innerhardShoulderStatus: this information is optional and shall be included if an inner hard shoulder is present and the information is known.
+ * It indicates the open/closing status of inner hard shoulder lanes. 
+ * 
+ * @field outerhardShoulderStatus: this information is optional and shall be included if an outer hard shoulder is present and the information is known.
+ * It indicates the open/closing status of outer hard shoulder lanes. 
+ * 
+ * @field drivingLaneStatus: this information is optional and shall be included if the information is known.
+ * It indicates the open/closing status of driving lanes. 
+ * For carriageways with more than 13 driving lanes, the drivingLaneStatus component shall not be present.
+ * 
+ * @category: Infrastructure information, Road topology information
+ * @revision: Description revised in V2.1.1
+ */
+ClosedLanes ::= SEQUENCE {
+    innerhardShoulderStatus    HardShoulderStatus OPTIONAL,
+    outerhardShoulderStatus    HardShoulderStatus OPTIONAL,
+    drivingLaneStatus          DrivingLaneStatus OPTIONAL,
+    ...
+}
+
+/**
+ * This DF provides information about the breakup of a cluster.
+ *
+ * It shall include the following components: 
+ * 
+ * @field clusterBreakupReason: indicates the reason for breakup.
+ * 
+ * @field breakupTime: indicates the time of breakup. 
+ *
+ * @category: Cluster Information
+ * @revision: Created in V2.1.1
+ */
+ClusterBreakupInfo ::= SEQUENCE {
+    clusterBreakupReason    ClusterBreakupReason,
+    breakupTime             DeltaTimeQuarterSecond,
+    ...
+}
+
+/**
+ * This DF provides information about the joining of a cluster.
+ *
+ * It shall include the following components: 
+ * 
+ * @field clusterId: indicates the identifier of the cluster.
+ * 
+ * @field joinTime: indicates the time of joining. 
+ *
+ * @category: Cluster Information
+ * @revision: Created in V2.1.1
+ */
+ClusterJoinInfo ::= SEQUENCE {
+    clusterId    Identifier1B,
+    joinTime     DeltaTimeQuarterSecond,
+    ...
+}
+
+/**
+ * The DF provides information about the leaving of a cluster.
+ *
+ * It shall include the following components: 
+ * 
+ * @field clusterId: indicates the cluster.
+ * 
+ * @field clusterLeaveReason: indicates the reason for leaving. 
+ *
+ * @category: Cluster Information
+ * @revision: Created in V2.1.1
+ */
+ClusterLeaveInfo ::= SEQUENCE {
+    clusterId             Identifier1B,
+    clusterLeaveReason    ClusterLeaveReason,
+    ...
+}
+
+/**
+* This DF shall contain a list of @ref ConfidenceLevel.
+*
+* @category: Basic information
+* @revision: created in V2.3.1 
+*/
+ConfidenceLevels ::= SEQUENCE (SIZE (1..32,...)) OF ConfidenceLevel
+
+/**
+ * This DF represents a column of a lower triangular positive semi-definite matrix and consists of a list of correlation cell values ordered by rows.
+ * Given a matrix "A" of size n x n, the number of columns to be included in the lower triangular matrix is k=n-1.
+ * Each column "i" of the lower triangular matrix then contains k-(i-1) values (ordered by rows from 1 to n-1), where "i" refers to the column number count
+ * starting at 1 from the left.
+ *
+ * @category: Sensing Information
+ * @revision: Created in V2.1.1
+*/
+CorrelationColumn ::= SEQUENCE SIZE (1..13,...) OF CorrelationCellValue  
+
+/**
+ * This DF represents the curvature of the vehicle trajectory and the associated confidence value.
+ * The curvature detected by a vehicle represents the curvature of actual vehicle trajectory.
+ *
+ * It shall include the following components: 
+ * 
+ * @field curvatureValue: Detected curvature of the vehicle trajectory.
+ * 
+ * @field curvatureConfidence: along with a confidence value of the curvature value with a predefined confidence level. 
+ * 
+ * @category: Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+Curvature ::= SEQUENCE {
+    curvatureValue         CurvatureValue,
+    curvatureConfidence    CurvatureConfidence
+}
+
+/**
+ * This DF provides a description of dangerous goods being carried by a heavy vehicle.
+ *
+ * It shall include the following components: 
+ * 
+ * @field dangerousGoodsType: Type of dangerous goods.
+ * 
+ * @field unNumber: a 4-digit number that identifies the substance of the dangerous goods as specified in
+ * United Nations Recommendations on the Transport of Dangerous Goods - Model Regulations [4],
+ * 
+ * @field elevatedTemperature: whether the carried dangerous goods are transported at high temperature.
+ * If yes, the value shall be set to TRUE,
+ * 
+ * @field tunnelsRestricted: whether the heavy vehicle carrying dangerous goods is restricted to enter tunnels.
+ * If yes, the value shall be set to TRUE,
+ * 
+ * @field limitedQuantity: whether the carried dangerous goods are packed with limited quantity.
+ * If yes, the value shall be set to TRUE,
+ * 
+ * @field emergencyActionCode: physical signage placard at the vehicle that carries information on how an emergency
+ * service should deal with an incident. This component is optional; it shall be present if the information is available.
+ * 
+ * @field phoneNumber: contact phone number of assistance service in case of incident or accident.
+ * This component is optional, it shall be present if the information is available.
+ * 
+ * @field companyName: name of company that manages the transportation of the dangerous goods.
+ * This component is optional; it shall be present if the information is available.
+ * 
+ * @category Vehicle information
+ * @revision: V1.3.1
+ */
+DangerousGoodsExtended ::= SEQUENCE {
+    dangerousGoodsType      DangerousGoodsBasic,
+    unNumber                INTEGER (0..9999),
+    elevatedTemperature     BOOLEAN,
+    tunnelsRestricted       BOOLEAN,
+    limitedQuantity         BOOLEAN,
+    emergencyActionCode     IA5String (SIZE (1..24)) OPTIONAL,
+    phoneNumber             PhoneNumber OPTIONAL,
+    companyName             UTF8String (SIZE (1..24)) OPTIONAL,
+    ...
+}
+
+/**
+* This DF defines a geographical point position as a 2 dimensional offset position to a geographical reference point.
+*
+* It shall include the following components: 
+*
+* @field deltaLatitude: A delta latitude offset with regards to the latitude value of the reference position.
+*
+* @field deltaLongitude: A delta longitude offset with regards to the longitude value of the reference position.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321
+*/
+DeltaPosition ::= SEQUENCE{
+   deltaLatitude   DeltaLatitude,
+   deltaLongitude  DeltaLongitude
+}
+
+/**
+* This DF shall contain a list of @ref DeltaPosition.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaPosition)
+*/
+DeltaPositions ::= SEQUENCE (SIZE (1..32,...,33..100)) OF DeltaPosition
+
+/**
+ * This DF defines a geographical point position as a 3 dimensional offset position to a geographical reference point.
+ *
+ * It shall include the following components: 
+ *
+ * @field deltaLatitude: A delta latitude offset with regards to the latitude value of the reference position.
+ *
+ * @field deltaLongitude: A delta longitude offset with regards to the longitude value of the reference position.
+ *
+ * @field deltaAltitude: A delta altitude offset with regards to the altitude value of the reference position.
+ *
+ * @category: GeoReference information
+ * @revision:  V1.3.1
+ */
+DeltaReferencePosition ::= SEQUENCE {
+    deltaLatitude     DeltaLatitude,
+    deltaLongitude    DeltaLongitude,
+    deltaAltitude     DeltaAltitude
+}
+
+/**
+* This DF shall contain a list of @ref DeltaReferencePosition.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaReferencePositions)
+*/
+DeltaReferencePositions ::= SEQUENCE (SIZE (1..32,...,33..100)) OF DeltaReferencePosition
+
+/**
+ * This DF represents a portion of digital map. It shall contain a list of waypoints @ref ReferencePosition.
+ * 
+ * @category: GeoReference information
+ * @revision:  V1.3.1
+ */
+DigitalMap ::= SEQUENCE (SIZE(1..256)) OF ReferencePosition 
+
+/** 
+ * 
+ * This DF represents the shape of an elliptical area or right elliptical cylinder that is centred 
+ * on the shape's reference point defined outside of the context of this DF and oriented w.r.t. a  
+ * cartesian coordinate system defined outside of the context of this DF. 
+ *
+ * It shall include the following components: 
+ * 
+ * @field shapeReferencePoint: optional reference point which represents the centre of the ellipse, 
+ * relative to an externally specified reference position. If this component is absent, the 
+ * externally specified reference position represents the shape's reference point. 
+ *
+ * @field semiMajorAxisLength: half length of the major axis of the ellipse located in the X-Y Plane.
+ * 
+ * @field semiMinorAxisLength: half length of the minor axis of the ellipse located in the X-Y Plane.
+ *
+ * @field orientation: the optional orientation of the major axis of the ellipse, measured with 
+ * positive values turning around the z-axis using the right-hand rule, starting from the X-axis.
+ * If absent, the orientation is equal to the value zero. 
+ * 
+ * @field height: the optional height, present if the shape is a right elliptical cylinder extending 
+ * in the positive Z-axis.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1, the type of the field orientation changed and the description revised in V2.2.1, added note on orientation in V2.4.1
+*/
+
+EllipticalShape  ::= SEQUENCE {
+    shapeReferencePoint    CartesianPosition3d OPTIONAL,
+    semiMajorAxisLength    StandardLength12b,
+    semiMinorAxisLength    StandardLength12b,
+    orientation            CartesianAngleValue OPTIONAL,
+    height                 StandardLength12b OPTIONAL
+}
+
+/** 
+ * This DF represents the Euler angles which describe the orientation of an object bounding box in a Cartesian coordinate system with an associated confidence level for each angle.
+ *
+ * It shall include the following components: 
+ *
+ * @field zAngle: z-angle of object bounding box at the time of measurement, with the associated confidence.
+ * The angle is measured with positive values considering the object orientation turning around the z-axis using the right-hand rule, starting from the x-axis. 
+ * This extrinsic rotation shall be applied around the centre point of the object bounding box before all other rotations.
+ *
+ * @field yAngle: optional y-angle of object bounding box at the time of measurement, with the associated confidence.
+ * The angle is measured with positive values considering the object orientation turning around the y-axis using the right-hand rule, starting from the z-axis. 
+ * This extrinsic rotation shall be applied around the centre point of the object bounding box after the rotation by zAngle and before the rotation by xAngle.
+ *
+ * @field xAngle: optional x-angle of object bounding box at the time of measurement, with the associated confidence.
+ * The angle is measured with positive values considering the object orientation turning around the x-axis using the right-hand rule, starting from the z-axis. 
+ * This extrinsic rotation shall be applied around the centre point of the object bounding box after all other rotations.
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+*/
+EulerAnglesWithConfidence ::= SEQUENCE {
+    zAngle CartesianAngle,
+    yAngle CartesianAngle OPTIONAL,
+    xAngle CartesianAngle OPTIONAL
+}
+
+/** 
+ * 
+ * This DF represents a vehicle category according to the UNECE/TRANS/WP.29/78/Rev.4 [16].
+ * The following options are available:
+ * 
+ * @field euVehicleCategoryL: indicates a vehicle in the L category.
+ *
+ * @field euVehicleCategoryM: indicates a vehicle in the M category.
+ *
+ * @field euVehicleCategoryN: indicates a vehicle in the N category.
+ *
+ * @field euVehicleCategoryO: indicates a vehicle in the O category.
+ *
+ * @field euVehicleCategoryT: indicates a vehicle in the T category.
+ *
+ * @field euVehicleCategoryG: indicates a vehicle in the G category.
+ * 
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+*/
+EuVehicleCategoryCode ::= CHOICE {
+	euVehicleCategoryL    EuVehicleCategoryL,  
+	euVehicleCategoryM    EuVehicleCategoryM,  
+	euVehicleCategoryN    EuVehicleCategoryN,   
+	euVehicleCategoryO    EuVehicleCategoryO,   
+	euVehicleCategoryT    NULL,
+	euVehicleCategoryG    NULL    
+}
+
+/**
+ * The DF shall contain a list of @ref EventPoint.  
+ *
+ * The eventPosition of each @ref EventPoint is defined with respect to the previous @ref EventPoint in the list. 
+ * Except for the first @ref EventPoint which is defined with respect to a position outside of the context of this DF.
+ *
+ * @category: GeoReference information, Traffic information
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref EventZone instead. 
+ * @revision: Generalized the semantics in V2.1.1
+ */
+EventHistory::= SEQUENCE (SIZE(1..23)) OF EventPoint
+
+/**
+ * This DF provides information related to an event at a defined position.
+ *
+ * It shall include the following components: 
+ * 
+ * @field eventPosition: offset position of a detected event point to a defined position. 
+ * 
+ * @field eventDeltaTime: optional time travelled by the detecting ITS-S since the previous detected event point.
+ * 
+ * @field informationQuality: Information quality of the detection for this event point.
+ * 
+ * @category: GeoReference information, Traffic information
+ * @revision: generalized the semantics in V2.1.1
+ */
+EventPoint ::= SEQUENCE {
+    eventPosition         DeltaReferencePosition,
+    eventDeltaTime        PathDeltaTime OPTIONAL,
+    informationQuality    InformationQuality
+}
+
+/**
+ * The DF shall contain a list of @ref EventPoint, where all @ref EventPoint either contain the COMPONENT eventDeltaTime 
+ * or do not contain the COMPONENT eventDeltaTime.  
+ *
+ * The eventPosition of each @ref EventPoint is defined with respect to the previous @ref EventPoint in the list. 
+ * Except for the first @ref EventPoint which is defined with respect to a position outside of the context of this DF.
+ *
+ * @category: GeoReference information, Traffic information
+ * @revision: created in V2.1.1 based on EventHistory
+ */
+EventZone::= EventHistory
+   ((WITH COMPONENT (WITH COMPONENTS {..., eventDeltaTime PRESENT})) |
+    (WITH COMPONENT (WITH COMPONENTS {..., eventDeltaTime ABSENT})))
+
+/** 
+ * This DF indicates a geographical position.
+ *
+ * It shall include the following components: 
+ *
+ * @field latitude: the latitude of the geographical position.
+ *
+ * @field longitude: the longitude of the geographical position.
+ *
+ * @field altitude: the altitude of the geographical position with default value unavailable.
+ *
+*/ 
+GeoPosition::= SEQUENCE{
+	latitude   Latitude,
+	longitude  Longitude,
+    altitude   AltitudeValue DEFAULT unavailable
+}
+
+/**
+* This DE indicates a geographical position with altitude.
+*
+* It shall include the following components: 
+*
+* @field latitude: the latitude of the geographical position.
+*
+* @field longitude: the longitude of the geographical position.
+*
+* @field altitude: the altitude of the geographical position.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionWAltitude)
+*/
+GeoPositionWAltitude ::= SEQUENCE{
+   latitude Latitude,
+   longitude Longitude,
+   altitude Altitude
+}
+
+/**
+* This DF shall contain a list of @ref AbsolutePositionWAltitude.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionsWAltitude)
+*/
+GeoPositionsWAltitude ::= SEQUENCE (SIZE (1..8,...)) OF GeoPositionWAltitude
+
+/**
+* This DF indicates a geographical position without altitude.
+*
+* It shall include the following components: 
+*
+* @field latitude: the latitude of the geographical position.
+*
+* @field longitude: the longitude of the geographical position.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePosition)
+*/
+GeoPositionWoAltitude ::= SEQUENCE{
+   latitude Latitude,
+   longitude Longitude
+}
+
+/**
+* This DF shall contain a list of @ref GeoPositionWoAltitude.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321 (AbsolutePositions)
+*/
+GeoPositionsWoAltitude ::= SEQUENCE (SIZE (1..8,...)) OF GeoPositionWoAltitude
+
+/**
+ * This DF represents the top-level DF to represent a lane position. A lane position is a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway.
+ *
+ * @note: This DF is the most general way to represent a lane position: it provides a complete set of information regarding a transversal (dimensionless) position on the carriageway at a specific 
+ * reference position, i.e. it provides different options and synonyms to represent the lane at which the reference position (the point) is located. A confidence is used to describe the probability 
+ * that the object is located in the provided lane. The dimension of the object or extension of an area are not considered: See @ref OccupiedLanesWithConfidence for describing the occupation of lanes, 
+ * where the dimensions of an object or the extension of an area is considered.
+ *
+ * It shall include the following components: 
+ *
+ * @field lanePositionBased: lane position information for a defined reference position.
+ * 
+ * @field mapBased: optional lane position information described in the context of a MAPEM as specified in ETSI TS 103 301 [15]. 
+ * If present, it shall describe the same reference position using the lane identification in the MAPEM. This component can be used only if a MAPEM is available for the reference position 
+ * (e.g. on an intersection): In this case it is used as a synonym to the mandatory component lanePositionBased. 
+ * 
+ * @field confidence: confidence information for expressing the probability that the object is located at the indicated lane.  
+ * If the value of the component lanePositionBased is generated directly from the absolute reference position and reference topology information, 
+ * no sensor shall be indicated in the component usedDetectionInformation of the @ref MetaInformation.
+ *
+ * @category: Road Topology information
+ * @revision: newly created in V2.2.1. The previous DF GeneralizedLanePosition is now renamed to @ref LanePositionOptions. 
+ */
+GeneralizedLanePosition ::= SEQUENCE {
+    lanePositionBased     LanePositionOptions,
+    mapBased              MapPosition OPTIONAL,
+    confidence            MetaInformation,
+    ... 
+}
+
+/**
+ * This DF represents transversal position information with respect to the road, at an externally defined reference position. It shall contain a set of up to `4` @ref GeneralizedLanePosition.
+ * Multiple entries can be used to describe several lane positions with the associated confidence, in cases where the reference position cannot be mapped to a single lane.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.2.1
+ */
+GeneralizedLanePositions ::= SEQUENCE (SIZE(1..4)) OF GeneralizedLanePosition
+
+/**
+ * This DF represents the Heading in a WGS84 co-ordinates system.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * It shall include the following components: 
+ * 
+ * @field headingValue: the heading value.
+ * 
+ * @field headingConfidence: the confidence value of the heading value with a predefined confidence level.
+ * 
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84Angle instead. 
+ * @category: Kinematic Information
+ * @revision: Description revised in V2.1.1
+ */
+Heading ::= SEQUENCE {
+    headingValue         HeadingValue,
+    headingConfidence    HeadingConfidence
+}
+
+
+/**
+ * This DF  provides  information  associated to heading  change indicators  such as  a  change  of  direction.
+ *
+ * It shall include the following components: 
+ * 
+ * @field direction: the direction of heading change value.
+ * 
+ * @field actionDeltaTime: the period over which a direction change action is performed. 
+ * 
+ * @category: Kinematic Information
+ * @revision: created in V2.1.1
+ */
+HeadingChangeIndication ::= SEQUENCE {
+    direction          TurningDirection,
+    actionDeltaTime    DeltaTimeTenthOfSecond,
+    ...
+}
+
+/**
+ * This DF represents a frequency channel 
+ *
+ * It shall include the following components: 
+ *
+ * @field centreFrequency: the centre frequency of the channel in 10^(exp+2) Hz (where exp is exponent)
+ * 
+ * @field channelWidth: width of the channel in 10^exp Hz (where exp is exponent)
+ *
+ * @field exponent: exponent of the power of 10 used in the calculation of the components above.
+ *
+ * @category: Communication information
+ * @revision: created in V2.1.1
+*/
+InterferenceManagementChannel ::= SEQUENCE {
+    centreFrequency    INTEGER (1 .. 99999),
+    channelWidth       INTEGER (0 .. 9999),
+    exponent           INTEGER (0 .. 15) 
+}
+
+/**
+ * 
+ * This DF represents a zone  inside which the ITS communication should be restricted in order to manage interference.
+ *
+ * It shall include the following components: 
+ *
+ * @field zoneDefinition: contains the geographical definition of the zone.
+ *
+ * @field managementInfo: contains interference management information applicable in the zone defined in the component zoneDefinition.
+ *
+ * @category: Communication information
+ * @revision: created in V2.1.1
+ */
+InterferenceManagementZone ::= SEQUENCE {
+	zoneDefinition    InterferenceManagementZoneDefinition,
+	managementInfo    InterferenceManagementInfo
+}
+
+/**
+ * This DF represents the geographical definition of the zone where band sharing occurs. 
+ *
+ * It shall include the following components: 
+ *
+ * @field interferenceManagementZoneLatitude: Latitude of the centre point of the interference management zone.
+ *
+ * @field interferenceManagementZoneLongitude: Longitude of the centre point of the interference management zone.
+ *
+ * @field interferenceManagementZoneId: optional identification of the interference management zone. 
+ *
+ * @field interferenceManagementZoneShape: shape of the interference management zone placed at the centre point. 
+ *
+ * @category: Communication information
+ * @revision: created in V2.1.1
+ */
+InterferenceManagementZoneDefinition::= SEQUENCE{     
+    interferenceManagementZoneLatitude     Latitude, 
+    interferenceManagementZoneLongitude    Longitude, 
+    interferenceManagementZoneId           ProtectedZoneId OPTIONAL,
+    interferenceManagementZoneShape        Shape 
+   (WITH COMPONENTS{..., radial ABSENT, radialShapes ABSENT}) OPTIONAL,
+    ...
+}
+
+/**
+ * This DF shall contain a list of up to 16 definitions containing interference management information, per affected frequency channels.
+ *  
+ * @category: Communication information.
+ * @revision: created in V2.1.1
+ */
+InterferenceManagementInfo::= SEQUENCE (SIZE(1..16,...)) OF InterferenceManagementInfoPerChannel
+
+
+/**
+ * This DF contains interference management information for one affected frequency channel.
+ *
+ * It shall include the following components: 
+ *
+ * @field interferenceManagementChannel: frequency channel for which the zone should be applied interference management 
+ *
+ * @field interferenceManagementZoneType: type of the interference management zone. 
+ *
+ * @field interferenceManagementMitigationType: optional type of the mitigation to be used in the interference management zone. 
+ * In the case where no mitigation should be applied by the ITS-S, this is indicated by the field interferenceManagementMitigationType being absent.
+ *
+ * @field expiryTime: optional time at which the validity of the interference management communication zone will expire. 
+ * This component is present when the interference management is temporarily valid
+ *
+ * @category: Communication information
+ * @revision: created in V2.1.1
+ */
+InterferenceManagementInfoPerChannel ::= SEQUENCE {
+    interferenceManagementChannel           InterferenceManagementChannel,
+    interferenceManagementZoneType          InterferenceManagementZoneType,
+    interferenceManagementMitigationType    MitigationForTechnologies OPTIONAL,
+    expiryTime                              TimestampIts OPTIONAL, 
+    ...
+}
+
+/**
+ * This DF shall contain a list of up to 16 interference  management zones.  
+ *
+ * **EXAMPLE**: An interference management communication zone may be defined around a CEN DSRC road side equipment or an urban rail operational area.
+ * 
+ * @category: Communication information
+ * @revision: created in V2.1.1
+ */
+InterferenceManagementZones ::= SEQUENCE (SIZE(1..16), ...) OF InterferenceManagementZone
+
+/**
+ * This DF represents a unique id for an intersection, in accordance with ETSI TS 103 301 [15].
+ *
+ * It shall include the following components: 
+ *
+ * @field region: the optional identifier of the entity that is responsible for the region in which the intersection is placed.
+ * It is the duty of that entity to guarantee that the @ref Id is unique within the region.
+ *
+ * @field id: the identifier of the intersection
+ *
+ * @note: when the component region is present, the IntersectionReferenceId is guaranteed to be globally unique.
+ * @category: Road topology information
+ * @revision: created in V2.1.1
+ */
+IntersectionReferenceId ::= SEQUENCE {
+    region    Identifier2B OPTIONAL,
+    id        Identifier2B
+}
+
+/**
+ * This DF shall contain  a list of waypoints @ref ReferencePosition.
+ *
+ * @category: GeoReference information
+ * @revision: Editorial update in V2.1.1
+ */
+ItineraryPath ::= SEQUENCE SIZE(1..40) OF ReferencePosition
+
+/**
+ * This DF represents a common message header for application and facilities layer messages.
+ * It is included at the beginning of an ITS message as the message header.
+ *
+ * It shall include the following components: 
+ *
+ * @field protocolVersion: version of the ITS message.
+ *
+ * @field messageId: type of the ITS message.
+ *
+ * @field stationId: the identifier of the ITS-S that generated the ITS message.
+ *
+ * @category: Communication information
+ * @revision:  update in V2.1.1: messageID and stationID changed to messageId and stationId; messageId is of type MessageId.
+ */
+ItsPduHeader ::= SEQUENCE {
+    protocolVersion    OrdinalNumber1B,
+    messageId          MessageId,
+    stationId          StationId
+}
+
+/**
+ * This DF provides the reference to the information contained in a IVIM according to ETSI TS 103 301 [15]. 
+ *
+ * It shall include the following components: 
+ * 
+ * @field serviceProviderId: identifier of the organization that provided the IVIM.
+ *
+ * @field iviIdentificationNumber: identifier of the IVIM, as assigned by the organization identified in serviceProviderId.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.2.1
+ */
+IvimReference::= SEQUENCE {
+    serviceProviderId         Provider, 
+    iviIdentificationNumber   IviIdentificationNumber
+}
+
+/**
+ * This DF shall contain a list of @ref IvimReference.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.2.1
+*/
+IvimReferences::= SEQUENCE (SIZE(1..8,...)) OF IvimReference
+
+/**
+ * This DF indicates a transversal position in resolution of lanes and other associated details.
+ *
+ * It shall include the following components: 
+ * 
+ * @field transversalPosition: the transversal position.
+ * 
+ * @field laneType: the type of the lane identified in the component transversalPosition. By default set to `traffic`.
+ *
+ * @field direction: the traffic direction for the lane position relative to a defined reference direction. By default set to `sameDirection`, i.e. following the reference direction.
+ *
+ * @category Road topology information
+ * @revision: direction added in V2.2.1
+ */
+LanePositionAndType::= SEQUENCE {
+    transversalPosition    LanePosition,
+    laneType               LaneType DEFAULT traffic,
+    direction              Direction DEFAULT sameDirection,
+    ...
+}
+
+/**
+ * This DF represents a set of options to describe a lane position and is the second level DF to represent a lane position. The top-level DFs are @ref GeneralizedLanePosition or @ref OccupiedLanesWithConfidence. 
+ * A lane position is a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway.
+ *
+ * The following options are available:
+ *
+ * @field simplelanePosition: a single lane position without any additional context information.
+ *
+ * @field simpleLaneType: a lane type, to be used when the lane position is unknown but the type of lane is known. This can be used in scenarios where a certain confidence about the used lane type is given 
+ * but no or limited knowledge about the absolute lane number is available. For example, a cyclist on a cycle-lane or vehicles on a specific lane that is unique for the part of the road (e.g. a bus lane).
+ * 
+ * @field detailedlanePosition: a single lane position with additional lane details.
+ * 
+ * @field lanePositionWithLateralDetails: a single lane position with additional details and the lateral position within the lane.
+ *
+ * @field trafficIslandPosition: a position on a traffic island, i.e. between two lanes. 
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.2.1 from the DF GeneralizedLanePosition of V2.1.1. 
+ */
+LanePositionOptions ::= CHOICE {
+    simplelanePosition                   LanePosition,
+    simpleLaneType                       LaneType,
+    detailedlanePosition                 LanePositionAndType,
+    lanePositionWithLateralDetails       LanePositionWithLateralDetails,
+    trafficIslandPosition                TrafficIslandPosition,
+    ...
+}
+
+/**
+ * This DF is a third-level DF that represents a lane position and is an extended version of @ref LanePositionAndType that adds the distances to the left and right lane border.
+ *
+ * It shall additionally include the following components: 
+ *
+ * @field distanceToLeftBorder: the distance of the transversal position to the left lane border. The real value shall be rounded to the next lower encoding-value.
+ *
+ * @field distanceToRightBorder: the distance of the transversal position to the right lane border. The real value shall be rounded to the next lower encoding-value.
+ * 
+ * @category: Road Topology information
+ * @revision: Created in V2.2.1
+ */
+LanePositionWithLateralDetails ::= SEQUENCE {
+    COMPONENTS OF               LanePositionAndType,
+    distanceToLeftBorder        StandardLength9b,
+    distanceToRightBorder       StandardLength9b,
+    ...
+}
+
+/**
+ * This DF indicates the vehicle acceleration at lateral direction and the confidence value of the lateral acceleration.
+ *
+ * It shall include the following components: 
+ * 
+ * @field lateralAccelerationValue: lateral acceleration value at a point in time.
+ * 
+ * @field lateralAccelerationConfidence: confidence value of the lateral acceleration value.
+ *
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead.
+ * @category Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+LateralAcceleration ::= SEQUENCE {
+    lateralAccelerationValue         LateralAccelerationValue,
+    lateralAccelerationConfidence    AccelerationConfidence
+}
+
+/**
+ * This DF indicates the vehicle acceleration at longitudinal direction and the confidence value of the longitudinal acceleration.
+ *
+ * It shall include the following components: 
+ *
+ * @field longitudinalAccelerationValue: longitudinal acceleration value at a point in time.
+
+ * @field longitudinalAccelerationConfidence: confidence value of the longitudinal acceleration value.
+ *
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead. 
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+LongitudinalAcceleration ::= SEQUENCE {
+    longitudinalAccelerationValue         LongitudinalAccelerationValue,
+    longitudinalAccelerationConfidence    AccelerationConfidence
+}
+
+/** 
+ * This DF represents the estimated position along the longitudinal extension of a carriageway or lane. 
+ *
+ * It shall include the following components: 
+ *
+ * @field  longitudinalLanePositionValue: the mean value of the longitudinal position along the carriageway or lane w.r.t. an externally defined start position.
+ *
+ * @field  longitudinalLanePositionConfidence: The confidence value associated to the value.
+ *
+ * @category: Road topology information
+ * @revision: created in V2.1.1, description revised in V2.2.1
+ */
+LongitudinalLanePosition ::= SEQUENCE {
+    longitudinalLanePositionValue         LongitudinalLanePositionValue,
+    longitudinalLanePositionConfidence    LongitudinalLanePositionConfidence
+}
+
+/** 
+ * This DF shall contain a list of a lower triangular positive semi-definite matrices.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+*/
+LowerTriangularPositiveSemidefiniteMatrices::= SEQUENCE SIZE (1..4) OF LowerTriangularPositiveSemidefiniteMatrix
+
+/** 
+ * This DF represents a lower triangular positive semi-definite matrix. 
+ *
+ * It shall include the following components: 
+ *
+ * @field componentsIncludedIntheMatrix: the indication of which components of a @ref PerceivedObject are included in the matrix. 
+ * This component also implicitly indicates the number n of included components which defines the size (n x n) of the full correlation matrix "A".
+ *
+ * @field matrix: the list of cells of the lower triangular positive semi-definite matrix ordered by columns and by rows. 
+ *
+ * The number of columns to be included "k" is equal to the number of included components "n" indicated by componentsIncludedIntheMatrix minus 1: k = n-1.
+ * These components shall be included in the order or their appearance in componentsIncludedIntheMatrix.
+ * Each column "i" of the lowerTriangularCorrelationMatrixColumns contains k-(i-1) values.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+*/
+LowerTriangularPositiveSemidefiniteMatrix ::= SEQUENCE{
+    componentsIncludedIntheMatrix   MatrixIncludedComponents,
+    matrix                          LowerTriangularPositiveSemidefiniteMatrixColumns
+}
+
+/** 
+ * This DF represents the columns of a lower triangular positive semi-definite matrix, each column not including the main diagonal cell of the matrix.
+ * Given a matrix "A" of size n x n, the number of @ref CorrelationColumn to be included in the lower triangular matrix is k=n-1.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1, extension indicator added in V2.2.1
+*/
+LowerTriangularPositiveSemidefiniteMatrixColumns ::= SEQUENCE SIZE (1..13,...) OF CorrelationColumn
+
+/** 
+ * This DF provides information about the configuration of a road section in terms of MAPEM lanes or connections using a list of @ref MapemExtractedElementReference. 
+
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+MapemConfiguration::= SEQUENCE(SIZE(1..16,...)) OF MapemElementReference
+
+/** 
+ * This DF provides references to an element described in a MAPEM according to ETSI TS 103 301 [i.15], such as a lane or connection at a specific intersection or road segment. 
+ * 
+ * It shall include the following components: 
+ * 
+ * @field mapReference: the optional reference to a MAPEM that describes the intersection or road segment. It is absent if the MAPEM topology is known from the context.
+ * 
+ * @field laneIds: the optional list of the identifiers of the lanes to be referenced. 
+ * 
+ * @field connectionIds: the optional list of the identifiers of the connections to be referenced. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+
+MapemElementReference::= SEQUENCE {
+  mapReference      MapReference OPTIONAL,
+  laneIds           MapemLaneList  OPTIONAL,
+  connectionIds	    MapemConnectionList  OPTIONAL,		
+  ...
+} 
+((WITH COMPONENTS {..., laneIds PRESENT}) |
+ (WITH COMPONENTS {..., connectionIds PRESENT }))
+
+/** 
+ * This DF provides references to MAPEM lanes using a list of @ref Identifier1B.
+ *
+ * @category: Road topology information
+ * @revision: Created in 2.2.1
+*/
+MapemLaneList ::=  SEQUENCE (SIZE(1..8,...)) OF Identifier1B
+
+/** 
+ * This DF provides references to MAPEM connections using a list of @ref Identifier1B.
+ * Note: connections are  allowed Ã¯Â¿Â½maneuversÃ¯Â¿Â½ (e.g. an ingress / egress relation) on an intersection.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+MapemConnectionList ::=  SEQUENCE (SIZE(1..8,...)) OF Identifier1B
+
+/**
+ * This DF indicates a position on a topology description transmitted in a MAPEM according to ETSI TS 103 301 [15].
+ *
+ * It shall include the following components: 
+ * 
+ * @field mapReference: optionally identifies the MAPEM containing the topology information.
+ * It is absent if the MAPEM topology is known from the context.
+ * 
+ * @field laneId: optionally identifies the lane in the road segment or intersection topology on which the position is located.
+ *
+ * @field connectionId: optionally identifies the connection inside the conflict area of an intersection, i.e. it identifies a trajectory for travelling through the
+ * conflict area of an intersection which connects e.g an ingress with an egress lane.
+ *
+ * @field longitudinalLanePosition: optionally indicates the longitudinal offset of the map-matched position of the object along the lane or connection measured from the start of the lane/connection, along the lane.
+ * 
+ * @category: Road topology information
+ * @revision: Created in V2.1.1, definition of longitudinalLanePosition amended in V2.2.1
+ */
+MapPosition ::= SEQUENCE {
+    mapReference                MapReference OPTIONAL,
+    laneId                      Identifier1B OPTIONAL,
+    connectionId                Identifier1B OPTIONAL, 
+    longitudinalLanePosition    LongitudinalLanePosition OPTIONAL,
+    ...
+}
+   ((WITH COMPONENTS {..., laneId PRESENT, connectionId ABSENT }) |
+    (WITH COMPONENTS {..., laneId ABSENT, connectionId PRESENT }))
+
+/**
+ * This DF provides the reference to the information contained in a MAPEM according to ETSI TS 103 301 [15]. 
+ *
+ * The following options are provided:
+ * 
+ * @field roadsegment: option that identifies the description of a road segment contained in a MAPEM.
+ * 
+ * @field intersection: option that identifies the description of an intersection contained in a MAPEM.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.1.1
+ */
+MapReference::= CHOICE {
+	roadsegment     RoadSegmentReferenceId,
+	intersection    IntersectionReferenceId
+}
+
+/**
+ * This DF shall contain a list of @ref MapReference.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+MapReferences::= SEQUENCE (SIZE(1..8,...)) OF MapReference
+
+
+/**
+ * This DF indicates a message rate.
+ *
+ * @field mantissa: indicates the mantissa.
+ *
+ * @field exponent: indicates the exponent.
+ *
+ * The specified message rate is: mantissa*(10^exponent) 
+ *
+ * @unit: Hz
+ * @category: Communication information
+ * @revision: Created in V2.1.1
+ */
+MessageRateHz::= SEQUENCE {
+    mantissa    INTEGER (1..100),
+    exponent    INTEGER (-5..2)
+}
+
+/**
+ * This DF provides information about a message with respect to the segmentation process on facility layer at the sender.
+ *
+ * It shall include the following components: 
+ * 
+ * @field totalMsgNo: indicates the total number of messages that have been assembled on the transmitter side to encode the information 
+ * during the same messsage generation process.
+ *
+ * @field thisMsgNo: indicates the position of the message within of the total set of messages generated during the same message generation process.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.1.1, description revised in V2.2.1
+ */
+MessageSegmentationInfo ::= SEQUENCE {
+    totalMsgNo  CardinalNumber3b,
+    thisMsgNo   OrdinalNumber3b
+}
+
+/** 
+ * This DF provides information about the source of and confidence in information.
+ *
+ * It shall include the following components: 
+ * 
+ * @field usedDetectionInformation: the type of sensor(s) that is used to provide the detection information.
+ * 
+ * @field usedStoredInformation: the type of source of the stored information. 
+ *
+ * @field confidenceValue: an optional confidence value associated to the information. 
+ * 
+ * @category: Basic information
+ * @revision: Created in V2.2.1
+*/
+MetaInformation::=SEQUENCE{		
+  usedDetectionInformation   SensorTypes, 
+  usedStoredInformation      StoredInformationType,
+  confidenceValue            ConfidenceLevel OPTIONAL,
+  ...
+}
+
+/**
+ * This DF shall contain a list of @ref MitigationPerTechnologyClass.
+ *
+ * @category: Communication information
+ * @revision: Created in V2.1.1
+*/
+MitigationForTechnologies ::= SEQUENCE (SIZE(1..8)) OF MitigationPerTechnologyClass 
+
+/**
+ * This DF represents a set of mitigation parameters for a specific technology, as specified in ETSI TS 103 724 [24], clause 7.
+ *
+ * It shall include the following components: 
+ *
+ * @field accessTechnologyClass:  channel access technology to which this mitigation is intended to be applied.
+ *
+ * @field lowDutyCycle: duty cycle limit.
+ * @unit: 0,01 % steps
+ *
+ * @field powerReduction: the delta value of power to be reduced.
+ * @unit: dB
+ *
+ * @field dmcToffLimit: idle time limit as defined in ETSI TS 103 175 [19].
+ * @unit: ms
+ *
+ * @field dmcTonLimit: Transmission duration limit, as defined in ETSI EN 302 571 [20].
+ * @unit: ms
+ *
+ * @note: All parameters are optional, as they may not apply to some of the technologies or
+ * interference management zone types. Specification details are in ETSI TS 103 724 [24], clause 7. 
+ *
+ * @category: Communication information
+ * @revision: Created in V2.1.1
+ */
+MitigationPerTechnologyClass ::= SEQUENCE {
+   accessTechnologyClass    AccessTechnologyClass, 
+   lowDutyCycle             INTEGER (0 .. 10000) OPTIONAL, 
+   powerReduction           INTEGER (0 .. 30) OPTIONAL,
+   dmcToffLimit             INTEGER (0 .. 1200) OPTIONAL,   
+   dmcTonLimit              INTEGER (0 .. 20) OPTIONAL,   
+   ...
+}
+
+/** 
+ * This DF indicates both the class and associated subclass that best describes an object.
+ *
+ * The following options are available:
+ *
+ * @field vehicleSubClass: the object is a road vehicle and the specific subclass is specified.
+ *
+ * @field vruSubClass: the object is a VRU and the specific subclass is specified.
+ *
+ * @field groupSubClass: the object is a VRU group or cluster and the cluster information is specified.
+ *
+ * @field otherSubClass: the object is of a different type than the above and the specific subclass is specified.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+ */
+ObjectClass ::= CHOICE {
+    vehicleSubClass      TrafficParticipantType (unknown|passengerCar..tram|agricultural),
+    vruSubClass          VruProfileAndSubprofile,
+    groupSubClass        VruClusterInformation 
+    (WITH COMPONENTS{..., clusterBoundingBoxShape ABSENT}),
+    otherSubClass        OtherSubClass,
+    ...
+}
+
+/** 
+ * This DF shall contain a list of object classes.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+*/
+ObjectClassDescription ::= SEQUENCE (SIZE(1..8)) OF ObjectClassWithConfidence
+
+/** 
+ * This DF represents the classification of a detected object together with a confidence level.
+ *
+ * It shall include the following components: 
+ *
+ * @field objectClass: the class of the object.
+ *
+ * @field Confidence: the associated confidence level.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+*/
+ObjectClassWithConfidence ::= SEQUENCE {
+    objectClass    ObjectClass,
+    confidence     ConfidenceLevel
+}
+
+/** 
+ * This DF represents a dimension of an object together with a confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field value: the object dimension value which can be estimated as the mean of the current distribution.
+ *
+ * @field confidence: the associated confidence value.
+ *
+ * @category: Sensing information
+ * @revision: Created in V2.1.1
+*/
+ObjectDimension ::= SEQUENCE {
+    value         ObjectDimensionValue,
+    confidence    ObjectDimensionConfidence
+}
+
+/**
+ * This DF represents a set of lanes which are partially or fully occupied by an object or event at an externally defined reference position. 
+ *
+ * @note: In contrast to @ref GeneralizedLanePosition, the dimension of the object or event area (width and length) is taken into account to determine the occupancy, 
+ * i.e. this DF describes the lanes which are blocked by an object or event and not the position of the object / event itself. A confidence is used to describe the 
+ * probability that exactly all the provided lanes are occupied. 
+ *
+ * It shall include the following components: 
+ *
+ * @field lanePositionBased: a set of up to `4` lanes that are partially or fully occupied by an object or event, ordered by increasing value of @ref LanePosition. 
+ * Lanes that are partially occupied can be described using the component lanePositionWithLateralDetails of @ref  Options, with the following constraints: 
+ * The distance to lane borders which are covered by the object / event shall be set to 0. Only the distances to the leftmost and/or rightmost border which are not covered by 
+ * the object / event shall be provided with values > 0. Those values shall be added to the respective instances of @ref LanePositionOptions, i.e. the first entry shall contain the component distanceToLeftBorder > 0 , 
+ * and/or the last entry shall contain the component distanceToRightBorder > 0; the respective other components of these entries shall be set to 0.
+ * 
+ * @field mapBased: optional lane information described in the context of a MAPEM as specified in ETSI TS 103 301 [15]. 
+ * If present, it shall describe the same lane(s) as listed in the component lanePositionBased, but using the lane identification of the MAPEM. This component can be used only if a 
+ * MAPEM is available for the reference position (e.g. on an intersection): In this case it is used as a synonym to the mandatory component lanePositionBased. 
+ *
+ * @field confidence: mandatory confidence information for expressing the probability that all the provided lanes are occupied. It also provides information on how the lane 
+ * information were generated. If none of the sensors were used, the lane information is assumed to be derived directly from the absolute reference position and the related dimension.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.2.1
+ */
+OccupiedLanesWithConfidence::= SEQUENCE {
+    lanePositionBased     SEQUENCE (SIZE(1..4)) OF LanePositionOptions,
+    mapBased              SEQUENCE (SIZE(1..4)) OF MapPosition  OPTIONAL,
+    confidence            MetaInformation,
+    ... 
+}
+
+/** 
+ * This DF indicates the allowed type of occupancy of a parking space/area in terms of time and/or usage.
+ *
+ * The following options are available:
+ * 
+ * @field unknown: indicates that the allowed type of occupancy is unknown.
+ *
+ * @field unlimitedOccupancy: indicates that it can be occupied without limits.
+ *
+ * @field onlyWhileCharging: indicates that it can be occupied only while charging an electric vehicle.
+ *
+ * @field limitedDuration: indicates that it can be occupied for a limited and indicated duration in minutes.
+ *
+ * @field onlyWhileChargingLimitedDuration: indicates that it can be occupied only while charging an electric vehicle and only for a limited and indicated duration in minutes.
+ *
+ * @field parkingAllowedUntil: indicates that it can be occupied only until an indicated moment in time.
+ *
+ * @field forcedParkingUntil: indicates that it can be occupied and departure is possible only after an indicated moment in time.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.3.1 
+*/
+ParkingOccupancyInfo::= CHOICE { 
+   unknown                              NULL, 
+   unlimitedOccupancy                   NULL,
+   onlyWhileCharging                    NULL,  
+   limitedDuration                      INTEGER,  
+   onlyWhileChargingLimitedDuration     INTEGER, 
+   parkingAllowedUntil                  TimestampIts,
+   forcedParkingUntil                   TimestampIts,
+   ...
+}
+
+/**
+ * This DF provides basic information about the parking capabilities and availabilities of a single parking space. 
+ *
+ * It shall include the following components: 
+ *
+ * @field id: the unqiue identifier of the parking space within the parking area.
+ *
+ * @field location: the optional location of the geometrical center of the parking space w.r.t. the location of the parking area.
+ *
+ * @field status: the actual status of the parking space.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.3.1 
+*/
+ParkingSpaceBasic ::= SEQUENCE{
+   id         Identifier2B,
+   location   DeltaReferencePosition OPTIONAL, 
+   status     ParkingSpaceStatus
+}
+
+/**
+ * This DF provides detailed information about the parking capabilities and availabilities of a single parking space. 
+ * 
+ * It is an extension of @ref ParkingSpaceBasic and it shall additionally include the following additional components: 
+ *
+ * @field arrangementType: the optional arrangement of the parking space w.r.t. other spaces.
+ * This is component, if present, overrides the common arrangementType defined in the @ref ParkingArea.
+ *
+ * @field boundary: the optional physical boundary of the parking space as a polygon w.r.t. the location of the parking space.
+ *
+ * @field orientation: the optional orientation of the parking space.
+ * This is component, if present, overrides the common orientation defined in the @ref ParkingArea.
+ *
+ * @field occupancyRule: the occupancy rule applicable to the parking space.
+ *
+ * @field chargingStationId: the optional identitfier of a charging station that serves the parking space.
+ *
+ * @field accessViaLane: the optional identifier of a lane that provides access to the parking space.
+ *
+ * @field accessViaParkingSpaces: the optional identifier(s) of a parking spaces that provide access to the parking space.
+ * 
+ * @field reservationType: the optional parking reservation type(s) associated to the parking space.
+ * This is component, if present, overrides the common reservationType defined in the @ref ParkingArea.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.3.1 
+*/
+ParkingSpaceDetailed ::= SEQUENCE{
+   COMPONENTS OF            ParkingSpaceBasic,
+   arrangementType          ParkingAreaArrangementType OPTIONAL,
+   boundary                 DeltaPositions OPTIONAL,
+   orientation              Wgs84Angle OPTIONAL,
+   occupancyRule            ParkingOccupancyInfo, 
+   chargingStationId        Identifier2B OPTIONAL,
+   accessViaLane            Identifier2B OPTIONAL,
+   accessViaParkingSpaces   SEQUENCE (SIZE(0..7)) OF Identifier2B OPTIONAL,	
+   reservationType          SEQUENCE (SIZE(1..4,...)) OF ParkingReservationType OPTIONAL,			
+   ...
+}
+
+/** 
+ * This DF indicates the status of parking space.
+ *
+ * The following options are available:
+ * 
+ * @field unknown: indicates that the status is unknown.
+ *
+ * @field free: indicates that the parking space is free and hence available to be used.
+ *
+ * @field freeUntil: indicates that the parking space is free to be used until an indicated moment in time.
+ *
+ * @field fullyOccupied: indicates that the parking space is interely occupied.
+ *
+ * @field partiallyOccupied: indicates that the parking space that allows parking of multiple vehicles is occupied by an indicated percentage.
+ *
+ * @field occupiedUntil: indicates that the parking space is entirely occupied until an indicated moment in time.
+ *
+ * @field reservedUntil: indicates that the parking space is reserved (but not necessarily occupied) until an indicated moment in time.
+ *
+ * @field accessBlocked: indicates that the parking space cannot accessed, e.g. due to obstructing vehicles.
+ *
+ * @field retrictedUsage: indicates that the parking space is available but that it is not an official parking space and that there are some phyiscal restrictions applicable, 
+ * such as parking behind or in front of other vehicles that, depending on the situation, may then have problems entering or leaving their respective parking spaces.
+ *
+ * @category: Road Topology information
+ * @revision: Created in V2.3.1 
+*/ 
+ParkingSpaceStatus::= CHOICE { 
+   unknown             NULL, 
+   free                NULL,  
+   freeUntil           TimestampIts, 
+   fullyOccupied       NULL,
+   partiallyOccupied   INTEGER(0..100), 
+   occupiedUntil       TimestampIts,
+   reservedUntil       TimestampIts, 
+   accessBlocked       NULL,
+   retrictedUsage      NULL,
+   ...
+} 
+
+/**
+ * This DF represents a path with a set of path points.
+ * It shall contain up to `40` @ref PathPoint. 
+ * 
+ * The first PathPoint presents an offset delta position with regards to an external reference position.
+ * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. 
+ *
+ * @category: GeoReference information, Vehicle information
+ * @revision: created in V2.1.1 based on PathHistory
+ */
+Path::= SEQUENCE (SIZE(0..40)) OF PathPoint
+
+/**
+ * This DF represents estimated/predicted travel time between a position and a predefined reference position. 
+ *
+ * the following options are available:
+ * 
+ * @field deltaTimeHighPrecision: delta time with precision of 0,1 s.
+ *
+ * @field deltaTimeBigRange: delta time with precision of 10 s.
+ *
+ * @field deltaTimeMidRange: delta time with precision of 1 s.
+ *
+ * @category: Basic information
+ * @revision: Created in V2.2.1, added deltaTimeMidRange extension in V2.3.1
+ */
+PathDeltaTimeChoice::= CHOICE {
+    deltaTimeHighPrecision	DeltaTimeTenthOfSecond,
+    deltaTimeBigRange	    DeltaTimeTenSeconds,
+    ...,
+    deltaTimeMidRange       DeltaTimeSecond
+}
+
+/** 
+ * This DF represents a path towards a specific point specified in the @ref EventZone.
+ *
+ * It shall include the following components: 
+ * 
+ * @field pointOfEventZone: the ordinal number of the point within the DF EventZone, i.e. within the list of EventPoints.
+ *
+ * @field path: the associated path towards the point specified in pointOfEventZone.
+ * The first PathPoint presents an offset delta position with regards to the position of that pointOfEventZone.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.2.1
+*/
+PathExtended::= SEQUENCE {
+  pointOfEventZone    INTEGER(1..23),
+  path                Path
+}
+
+/**
+ * This DF represents a path history with a set of path points.
+ * It shall contain up to `40` @ref PathPoint. 
+ * 
+ * The first PathPoint presents an offset delta position with regards to an external reference position.
+ * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. 
+ *
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref Path instead.
+ * @category: GeoReference information, Vehicle information
+ * @revision: semantics updated in V2.1.1, size corrected to 0..40 in V2.2.1
+ */
+PathHistory::= SEQUENCE (SIZE(0..40)) OF PathPoint
+
+/**
+ * This DF represents a predicted path or trajectory with a set of predicted points and optional information to generate a shape which is estimated to contain the real path. 
+ * It shall contain up to `16` @ref PathPointPredicted. 
+ * 
+ * The first PathPoint presents an offset delta position with regards to an external reference position.
+ * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. 
+ *
+ * @category: GeoReference information
+ * @revision: created in V2.1.1 , size constraint changed to SIZE(1..16, ...) in V2.2.1, size extended in V2.3.1
+ */
+PathPredicted::= SEQUENCE (SIZE(1..16,..., 17..40)) OF PathPointPredicted
+
+/** 
+ * This DF represents a predicted path, predicted trajectory or predicted path zone together with usage information and a prediction confidence.
+ *
+ * It shall include the following components: 
+ *
+ * @field pathPredicted: the predicted path (pathDeltaTime ABSENT) or trajectory (pathDeltaTime PRESENT) and/or the path zone (symmetricAreaOffset PRESENT).
+ *
+ * @field usageIndication: an indication of how the predicted path will be used. 
+ *
+ * @field confidenceLevel: the confidence that the path/trajectory in pathPredicted will occur as predicted.
+ *
+ * @category: GeoReference information
+ * @revision: created in V2.2.1 
+ */
+PathPredicted2::= SEQUENCE{
+    pathPredicted     PathPredicted
+   ((WITH COMPONENT (WITH COMPONENTS {..., pathDeltaTime ABSENT, symmetricAreaOffset ABSENT})) |
+    (WITH COMPONENT (WITH COMPONENTS {..., pathDeltaTime PRESENT, symmetricAreaOffset ABSENT})) |
+    (WITH COMPONENT (WITH COMPONENTS {..., pathDeltaTime ABSENT, symmetricAreaOffset PRESENT})) |
+    (WITH COMPONENT (WITH COMPONENTS {..., pathDeltaTime PRESENT, symmetricAreaOffset PRESENT}))),
+    usageIndication   UsageIndication,
+    confidenceLevel   ConfidenceLevel,   
+    ...
+}
+
+/**
+ * This DF represents one or more predicted paths, or trajectories or path zones (zones that include all possible paths/trajectories within its boundaries) using @ref PathPredicted2.
+ * It shall contain up to `16` @ref PathPredicted2. 
+ * 
+ * @category: GeoReference information
+ * @revision: V2.2.1
+ */
+PathPredictedList ::= SEQUENCE SIZE(1..16,...) OF PathPredicted2
+
+/**
+ * This DF defines an offset waypoint position within a path.
+ *
+ * It shall include the following components: 
+ *
+ * @field pathPosition: The waypoint position defined as an offset position with regards to a pre-defined reference position. 
+ *
+ * @field pathDeltaTime: The optional travel time separated from a waypoint to the predefined reference position.
+ *
+ * @category GeoReference information
+ * @revision: semantics updated in V2.1.1
+ */
+PathPoint ::= SEQUENCE {
+    pathPosition     DeltaReferencePosition,
+    pathDeltaTime    PathDeltaTime OPTIONAL
+}
+
+/**
+ * This DF defines a predicted offset position that can be used within a predicted path or trajectory, together with optional data to describe a path zone shape.
+ *
+ * It shall include the following components: 
+ *
+ * @field deltaLatitude: the offset latitude with regards to a pre-defined reference position. 
+ *
+ * @field deltaLongitude: the offset longitude with regards to a pre-defined reference position. 
+ * 
+ * @field horizontalPositionConfidence: the optional confidence value associated to the horizontal geographical position.
+ *
+ * @field deltaAltitude: the optional offset altitude with regards to a pre-defined reference position, with default value unavailable. 
+ *
+ * @field altitudeConfidence: the optional confidence value associated to the altitude value of the geographical position, with default value unavailable.
+ * 
+ * @field pathDeltaTime: the optional travel time to the waypoint from the predefined reference position.
+
+ * @field symmetricAreaOffset: the optional symmetric offset to generate a shape, see Annex D for details.
+ *  
+ * @field asymmetricAreaOffset: the optional asymmetric offset to generate a shape, see Annex D for details. 
+ *
+ * @category GeoReference information
+ * @revision: Created in V2.1.1, type of pathDeltaTime changed and optionality added, fields symmetricAreaOffset and asymmetricAreaOffset added in V2.2.1
+ */
+PathPointPredicted::= SEQUENCE {
+  deltaLatitude                 DeltaLatitude,      
+  deltaLongitude                DeltaLongitude, 
+  horizontalPositionConfidence  PosConfidenceEllipse OPTIONAL,   
+  deltaAltitude                 DeltaAltitude DEFAULT unavailable, 
+  altitudeConfidence            AltitudeConfidence DEFAULT unavailable,
+  pathDeltaTime                 PathDeltaTimeChoice OPTIONAL,
+  symmetricAreaOffset           StandardLength9b OPTIONAL, 
+  asymmetricAreaOffset          StandardLength9b OPTIONAL, 
+  ... 
+}
+ ((WITH COMPONENTS {..., symmetricAreaOffset   ABSENT, asymmetricAreaOffset   ABSENT}) |
+  (WITH COMPONENTS {..., symmetricAreaOffset   PRESENT, asymmetricAreaOffset   ABSENT}) |
+  (WITH COMPONENTS {..., symmetricAreaOffset   PRESENT, asymmetricAreaOffset   PRESENT}))
+
+/** 
+ * This DF represents a list of references to the components of a @ref Traces or @ref TracesExtended DF using the @ref PathId. 
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+PathReferences ::= SEQUENCE (SIZE(1..14)) OF PathId
+
+/**
+ * This DE contains information about the status of a vehicle pedal.
+ *
+ * It shall include the following components: 
+ *
+ * @field pedalPositionValue: information about the pedal position. 
+ *
+ * @category: vehicle information
+ * @revision: created in V2.3.1
+ */
+PedalStatus::= SEQUENCE { 
+    pedalPositionValue   PedalPositionValue,
+    ...
+}
+
+/** 
+ * This DF contains information about a perceived object including its kinematic state and attitude vector in a pre-defined coordinate system and with respect to a reference time.
+ * 
+ * It shall include the following components: 
+ *
+ * @field objectId: optional identifier assigned to a detected object.
+ *
+ * @field measurementDeltaTime: the time difference from a reference time to the time of the  measurement of the object. 
+ * Negative values indicate that the provided object state refers to a point in time before the reference time.
+ *
+ * @field position: the position of the geometric centre of the object's bounding box within the pre-defined coordinate system.
+ *
+ * @field velocity: the velocity vector of the object within the pre-defined coordinate system.
+ *
+ * @field acceleration: the acceleration vector of the object within the pre-defined coordinate system.
+ *
+ * @field angles: optional Euler angles of the object bounding box at the time of measurement. 
+ * 
+ * @field zAngularVelocity: optional angular velocity of the object around the z-axis at the time of measurement.
+ * The angular velocity is measured with positive values considering the object orientation turning around the z-axis using the right-hand rule.
+ *
+ * @field lowerTriangularCorrelationMatrices: optional set of lower triangular correlation matrices for selected components of the provided kinematic state and attitude vector.
+ *
+ * @field objectDimensionZ: optional z-dimension of object bounding box. 
+ * This dimension shall be measured along the direction of the z-axis after all the rotations have been applied. 
+ *
+ * @field objectDimensionY: optional y-dimension of the object bounding box. 
+ * This dimension shall be measured along the direction of the y-axis after all the rotations have been applied. 
+ *
+ * @field objectDimensionX: optional x-dimension of object bounding box.
+ * This dimension shall be measured along the direction of the x-axis after all the rotations have been applied.
+ * 
+ * @field objectAge: optional age of the detected and described object, i.e. the difference in time between the moment 
+ * it has been first detected and the reference time of the message. Value `1500` indicates that the object has been observed for more than 1.5s.
+ *
+ * @field objectPerceptionQuality: optional confidence associated to the object. 
+ *
+ * @field sensorIdList: optional list of sensor-IDs which provided the measurement data. 
+ *
+ * @field classification: optional classification of the described object
+ *
+ * @field matchedPosition: optional map-matched position of an object.
+ *
+ * @category Sensing information
+ * @revision: created in V2.1.1
+ */
+PerceivedObject ::= SEQUENCE {
+    objectId                                          Identifier2B OPTIONAL,
+    measurementDeltaTime                              DeltaTimeMilliSecondSigned,
+    position                                          CartesianPosition3dWithConfidence, 
+    velocity                                          Velocity3dWithConfidence OPTIONAL,
+    acceleration                                      Acceleration3dWithConfidence OPTIONAL,
+    angles                                            EulerAnglesWithConfidence OPTIONAL,
+    zAngularVelocity                                  CartesianAngularVelocityComponent OPTIONAL,
+    lowerTriangularCorrelationMatrices                LowerTriangularPositiveSemidefiniteMatrices OPTIONAL,
+    objectDimensionZ                                  ObjectDimension OPTIONAL,
+    objectDimensionY                                  ObjectDimension OPTIONAL,
+    objectDimensionX                                  ObjectDimension OPTIONAL,
+    objectAge                                         DeltaTimeMilliSecondSigned (0..2047) OPTIONAL,
+    objectPerceptionQuality                           ObjectPerceptionQuality OPTIONAL,
+    sensorIdList                                      SequenceOfIdentifier1B OPTIONAL,
+    classification                                    ObjectClassDescription OPTIONAL,
+    mapPosition                                       MapPosition OPTIONAL,
+    ...
+}
+
+/**
+* The data frame PolygonalLine shall contain the definition of a polygonal line (also known as polygonal chain) w.r.t. an externally defined reference position.
+*
+* The following options are available:
+* 
+* @field deltaPositions: an ordered sequence of delta geographical positions with respect to the previous position, with latitude and longitude,
+* with the first instance referring to the reference position and with the order implicitly defining a direction associated with the polygonal line.
+*
+* @field deltaPositionsWithAltitude:  an ordered sequence of delta geographical positions with respect to the previous position, with latitude, longitude and altitude,
+* with the first instance referring to the reference position and with the order implicitly defining a direction associated with the polygonal line.
+*
+* @field absolutePositions: a sequence of absolute geographical positions, with latitude and longitude.
+*
+* @field absolutePositionsWithAltitude: a sequence of absolute geographical positions, with latitude, longitude and altitude.
+*
+* @category: GeoReference information
+* @revision: created in V2.3.1 based on ISO TS 19321
+*/
+PolygonalLine ::= CHOICE {
+   deltaPositions                  DeltaPositions,
+   deltaPositionsWithAltitude      DeltaReferencePositions,
+   absolutePositions               GeoPositionsWoAltitude,
+   absolutePositionsWithAltitude   GeoPositionsWAltitude,
+
+   ...
+}
+
+/** 
+ * This DF represents the shape of a polygonal area or of a right prism.
+ *
+ * It shall include the following components: 
+ *
+ * @field shapeReferencePoint: the optional reference point used for the definition of the shape, relative to an externally specified reference position. 
+ * If this component is absent, the externally specified reference position represents the shape's reference point. 
+ *
+ * @field polygon: the polygonal area represented by a list of minimum `3` to maximum `16` @ref CartesianPosition3d.
+ * All nodes of the polygon shall be considered relative to the shape's reference point.
+ *
+ * @field height: the optional height, present if the shape is a right prism extending in the positive z-axis.
+ * 
+ * @category GeoReference information
+ * @revision: created in V2.1.1
+ *
+ */
+PolygonalShape ::= SEQUENCE {
+   shapeReferencePoint    CartesianPosition3d OPTIONAL,
+   polygon                SequenceOfCartesianPosition3d (SIZE(3..16,...)),
+   height                 StandardLength12b OPTIONAL
+}
+
+/**
+ * This DF indicates the horizontal position confidence ellipse which represents the estimated accuracy with a 
+ * confidence level of 95  %. The centre of the ellipse shape corresponds to the reference
+ * position point for which the position accuracy is evaluated.
+ *
+ * It shall include the following components: 
+ *
+ * @field semiMajorConfidence: half of length of the major axis, i.e. distance between the centre point
+ * and major axis point of the position accuracy ellipse. 
+ *
+ * @field semiMinorConfidence: half of length of the minor axis, i.e. distance between the centre point
+ * and minor axis point of the position accuracy ellipse. 
+ *
+ * @field semiMajorOrientation: orientation direction of the ellipse major axis of the position accuracy
+ * ellipse with regards to the WGS84 north. 
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ *
+ * @category GeoReference information
+ * @revision: V1.3.1
+ */
+PosConfidenceEllipse ::= SEQUENCE {
+    semiMajorConfidence     SemiAxisLength,
+    semiMinorConfidence     SemiAxisLength,
+    semiMajorOrientation    HeadingValue
+}
+
+/**
+ * This DF indicates the horizontal position confidence ellipse which represents the estimated accuracy with a 
+ * confidence level of 95 %. The centre of the ellipse shape corresponds to the reference
+ * position point for which the position accuracy is evaluated.
+ *
+ * It shall include the following components: 
+ *
+ * @field semiMajorAxisLength: half of length of the major axis, i.e. distance between the centre point
+ * and major axis point of the position accuracy ellipse. 
+ *
+ * @field semiMinorAxisLength: half of length of the minor axis, i.e. distance between the centre point
+ * and minor axis point of the position accuracy ellipse. 
+ *
+ * @field semiMajorAxisOrientation: orientation direction of the ellipse major axis of the position accuracy
+ * ellipse with regards to the WGS84 north. 
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * @category GeoReference information
+ * @revision: created in V2.1.1 based on @ref PosConfidenceEllipse
+ */
+PositionConfidenceEllipse ::= SEQUENCE {
+    semiMajorAxisLength         SemiAxisLength,
+    semiMinorAxisLength         SemiAxisLength,
+    semiMajorAxisOrientation    Wgs84AngleValue
+}
+
+/**
+ * This DF shall contain a list of distances @ref PosPillar that refer to the perpendicular distance between centre of vehicle front bumper
+ * and vehicle pillar A, between neighbour pillars until the last pillar of the vehicle.
+ *
+ * Vehicle pillars refer to the vertical or near vertical support of vehicle,
+ * designated respectively as the A, B, C or D and other pillars moving in side profile view from the front to rear.
+ * 
+ * The first value of the DF refers to the perpendicular distance from the centre of vehicle front bumper to 
+ * vehicle A pillar. The second value refers to the perpendicular distance from the centre position of A pillar
+ * to the B pillar of vehicle and so on until the last pillar.
+ *
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+PositionOfPillars ::= SEQUENCE (SIZE(1..3, ...)) OF PosPillar
+
+/**
+ * This DF describes a zone of protection inside which the ITS communication should be restricted.
+ *
+ * It shall include the following components: 
+ * 
+ * @field protectedZoneType: type of the protected zone. 
+ * 
+ * @field expiryTime: optional time at which the validity of the protected communication zone will expire.
+ * 
+ * @field protectedZoneLatitude: latitude of the centre point of the protected communication zone.
+ * 
+ * @field protectedZoneLongitude: longitude of the centre point of the protected communication zone.
+ * 
+ * @field protectedZoneRadius: optional radius of the protected communication zone in metres.
+ * 
+ * @field protectedZoneId: the optional ID of the protected communication zone.
+ * 
+ * @note: A protected communication zone may be defined around a CEN DSRC road side equipment.
+ * 
+ * @category: Infrastructure information, Communication information
+ * @revision: revised in V2.1.1 (changed protectedZoneID to protectedZoneId)
+ */
+ProtectedCommunicationZone ::= SEQUENCE {
+    protectedZoneType         ProtectedZoneType,
+    expiryTime                TimestampIts OPTIONAL,
+    protectedZoneLatitude     Latitude,
+    protectedZoneLongitude    Longitude,
+    protectedZoneRadius       ProtectedZoneRadius OPTIONAL,
+    protectedZoneId           ProtectedZoneId OPTIONAL,
+    ...
+}
+
+/**
+ * This DF shall contain a list of @ref ProtectedCommunicationZone provided by a road side ITS-S (Road Side Unit RSU).
+ *
+ * It may provide up to 16 protected communication zones information.
+ *
+ * @category: Infrastructure information, Communication information
+ * @revision: V1.3.1
+ */
+ProtectedCommunicationZonesRSU ::= SEQUENCE (SIZE(1..16)) OF ProtectedCommunicationZone 
+
+/**
+ * This DF identifies an organization.
+ *
+ * It shall include the following components: 
+ * 
+ * @field countryCode: represents the country code that identifies the country of the national registration administrator for issuers according to ISO 14816.
+ *
+ * @field providerIdentifier: identifies the organization according to the national ISO 14816 register for issuers.
+ *
+ * @note: See https://www.itsstandards.eu/registries/register-of-nra-i-cs1/ for a list of national registration administrators and their respective registers
+ * 
+ * @category: Communication information
+ * @revision: Created in V2.2.1 based on ISO 17573-3 [24]
+ */
+Provider ::= SEQUENCE {
+	countryCode		CountryCode,
+	providerIdentifier	IssuerIdentifier
+} 
+
+/**
+ * This DF represents activation data for real-time systems designed for operations control, traffic light priorities, track switches, barriers, etc.
+ * using a range of activation devices equipped in public transport vehicles.
+ *
+ * The activation of the corresponding equipment is triggered by the approach or passage of a public transport
+ * vehicle at a certain point (e.g. a beacon).
+ *
+ * @field ptActivationType: type of activation. 
+ *
+ * @field ptActicationData: data of activation. 
+ *
+ * Today there are different payload variants defined for public transport activation-data. The R09.x is one of
+ * the industry standard used by public transport vehicles (e.g. buses, trams) in Europe (e.g. Germany Austria)
+ * for controlling traffic lights, barriers, bollards, etc. This DF shall include information like route, course,
+ * destination, priority, etc.
+ * 
+ * The R09.x content is defined in VDV recommendation 420 [7]. It includes following information:
+ * - Priority Request Information (pre-request, request, ready to start)
+ * - End of Prioritization procedure
+ * - Priority request direction
+ * - Public Transport line number
+ * - Priority of public transport
+ * - Route line identifier of the public transport
+ * - Route number identification
+ * - Destination of public transport vehicle
+ *
+ * Other countries may use different message sets defined by the local administration.
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+PtActivation ::= SEQUENCE {
+    ptActivationType    PtActivationType,
+    ptActivationData    PtActivationData
+}
+
+/**
+ * This DF describes a radial shape. The circular or spherical sector is constructed by sweeping      
+ * the provided range about the reference position specified outside of the context of this DF or 
+ * about the optional shapeReferencePoint. The range is swept between a horizontal start and a 
+ * horizontal end angle in the X-Y plane of a cartesian coordinate system specified outside of the 
+ * context of this DF, in a right-hand positive angular direction w.r.t. the x-axis. 
+ * A vertical opening angle in the X-Z plane may optionally be provided in a right-hand positive 
+ * angular direction w.r.t. the x-axis. 
+ *
+ * It shall include the following components:
+ * 
+ * @field shapeReferencePoint: the optional reference point used for the definition of the shape, 
+ * relative to an externally specified reference position. If this component is absent, the  
+ * externally specified reference position represents the shape's reference point. 
+ *
+ * @field range: the radial range of the shape from the shape's reference point. 
+ *
+ * @field horizontalOpeningAngleStart: the start of the shape's horizontal opening angle. 
+ *
+ * @field horizontalOpeningAngleEnd: the end of the shape's horizontal opening angle. 
+ *
+ * @field verticalOpeningAngleStart: optional start of the shape's vertical opening angle. 
+ *
+ * @field verticalOpeningAngleEnd: optional end of the shape's vertical opening angle. 
+ *
+ * @category GeoReference information
+ * @revision: created in V2.1.1, names and types of the horizontal opening angles changed, constraint added and description revised in V2.2.1
+*/
+RadialShape ::= SEQUENCE { 
+    shapeReferencePoint                      CartesianPosition3d OPTIONAL,
+    range                                    StandardLength12b,
+    horizontalOpeningAngleStart              CartesianAngleValue, 
+    horizontalOpeningAngleEnd                CartesianAngleValue, 
+    verticalOpeningAngleStart                CartesianAngleValue OPTIONAL,
+    verticalOpeningAngleEnd                  CartesianAngleValue OPTIONAL
+}
+   ((WITH COMPONENTS {..., verticalOpeningAngleStart ABSENT, verticalOpeningAngleEnd ABSENT }) |
+    (WITH COMPONENTS {..., verticalOpeningAngleStart PRESENT, verticalOpeningAngleEnd PRESENT }))
+
+
+/**
+ * This DF describes a list of radial shapes positioned w.r.t. to an offset position defined  
+ * relative to a reference position specified outside of the context of this DF and oriented w.r.t.  
+ * a cartesian coordinate system specified outside of the context of this DF. 
+ *
+ * It shall include the following components:
+ *
+ * @field refPointId: the identification of the reference point in case of a sensor mounted to trailer. Defaults to ITS ReferencePoint (0).
+ * 
+ * @field xCoordinate: the x-coordinate of the offset position.
+ *
+ * @field yCoordinate: the y-coordinate of the offset position.
+ *
+ * @field zCoordinate: the optional z-coordinate of the offset position.
+ *
+ * @field radialShapesList: the list of radial shape details.
+ *
+ * @category: Georeference information
+ * @revision: created in V2.1.1, description revised in V2.2.1
+ */ 
+RadialShapes ::= SEQUENCE {
+    refPointId          Identifier1B,
+    xCoordinate         CartesianCoordinateSmall, 
+    yCoordinate         CartesianCoordinateSmall,
+    zCoordinate         CartesianCoordinateSmall OPTIONAL,
+    radialShapesList    RadialShapesList
+}
+
+/** 
+ * The DF contains a list of @ref RadialShapeDetails.
+ *
+ * @category: Georeference information
+ * @revision: created in V2.1.1
+ */
+
+RadialShapesList ::= SEQUENCE SIZE(1..16,...) OF RadialShapeDetails
+
+/**
+ * This DF describes radial shape details. The circular sector or cone is
+ * constructed by sweeping the provided range about the position specified outside of the  
+ * context of this DF. The range is swept between a horizontal start and a horizontal end angle in 
+ * the X-Y plane of a right-hand cartesian coordinate system specified outside of the context of 
+ * this DF, in positive angular direction w.r.t. the x-axis. A vertical opening angle in the X-Z 
+ * plane may optionally be provided in positive angular direction w.r.t. the x-axis.
+ * 
+ * It shall include the following components:
+ * 
+ * @field range: the radial range of the sensor from the reference point or sensor point offset. 
+ *
+ * @field horizontalOpeningAngleStart:  the start of the shape's horizontal opening angle.
+ *
+ * @field horizontalOpeningAngleEnd: the end of the shape's horizontal opening angle. 
+ *
+ * @field verticalOpeningAngleStart: optional start of the shape's vertical opening angle. 
+ *
+ * @field verticalOpeningAngleEnd: optional end of the shape's vertical opening angle. 
+ *
+ * @category: Georeference information
+ * @revision: created in V2.1.1, description revised and constraint added in V2.2.1
+ */
+RadialShapeDetails ::= SEQUENCE {
+    range                          StandardLength12b,
+    horizontalOpeningAngleStart    CartesianAngleValue,
+    horizontalOpeningAngleEnd      CartesianAngleValue,
+    verticalOpeningAngleStart      CartesianAngleValue OPTIONAL,
+    verticalOpeningAngleEnd        CartesianAngleValue OPTIONAL
+}
+   ((WITH COMPONENTS {..., verticalOpeningAngleStart ABSENT, verticalOpeningAngleEnd ABSENT }) |
+    (WITH COMPONENTS {..., verticalOpeningAngleStart PRESENT, verticalOpeningAngleEnd PRESENT }))
+
+/** 
+ * This DF represents the shape of a rectangular area or a right rectangular prism that is centred 
+ * on a reference position defined outside of the context of this DF and oriented w.r.t. a cartesian    
+ * coordinate system defined outside of the context of this DF. 
+ *
+ * It shall include the following components: 
+ * 
+ * @field shapeReferencePoint: represents an optional offset point which the rectangle is centred on with 
+ * respect to the reference position. If this component is absent, the externally specified  
+ * reference position represents the shape's reference point. 
+ *
+ * @field semiLength: represents half the length of the rectangle located in the X-Y Plane.
+ * 
+ * @field semiBreadth: represents half the breadth of the rectangle located in the X-Y Plane.
+ *
+ * @field orientation: represents the optional orientation of the longer side of the rectangle, 
+ * measured with positive values turning around the Z-axis using the right-hand rule, starting from
+ * the X-axis. If absent, the orientation is equal to the value zero.
+ *
+ * @field height: represents the optional height, present if the shape is a right rectangular prism 
+ * with height extending in the positive Z-axis.
+ *
+ * @category GeoReference information
+ * @revision: created in V2.1.1, centerPoint renamed to shapeReferencePoint, the type of the field orientation changed 
+ *            and description revised in V2.2.1, added sentence on absence in V2.4.1
+ */
+RectangularShape ::= SEQUENCE { 
+    shapeReferencePoint   CartesianPosition3d OPTIONAL,
+    semiLength            StandardLength12b,
+    semiBreadth           StandardLength12b,
+    orientation           CartesianAngleValue OPTIONAL,
+    height                StandardLength12b OPTIONAL
+}
+
+/**
+ * A position within a geographic coordinate system together with a confidence ellipse. 
+ *
+ * It shall include the following components: 
+ *
+ * @field latitude: the latitude of the geographical point.
+ *
+ * @field longitude: the longitude of the geographical point.
+ *
+ * @field positionConfidenceEllipse: the confidence ellipse associated to the geographical position.
+ *
+ * @field altitude: the altitude and an altitude accuracy of the geographical point.
+ *
+ * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref ReferencePositionWithConfidence instead. 
+ * @category: GeoReference information
+ * @revision: description updated in V2.1.1
+ */
+ReferencePosition ::= SEQUENCE {
+    latitude                     Latitude,
+    longitude                    Longitude,
+    positionConfidenceEllipse    PosConfidenceEllipse,
+    altitude                     Altitude
+}
+
+/**
+ * A position within a geographic coordinate system together with a confidence ellipse. 
+ *
+ * It shall include the following components: 
+ *
+ * @field latitude: the latitude of the geographical point.
+ *
+ * @field longitude: the longitude of the geographical point.
+ *
+ * @field positionConfidenceEllipse: the confidence ellipse associated to the geographical position.
+ *
+ * @field altitude: the altitude and an altitude accuracy of the geographical point.
+ *
+ * @category: GeoReference information
+ * @revision: created in V2.1.1 based on @ref ReferencePosition but using @ref PositionConfidenceEllipse.
+ */
+ReferencePositionWithConfidence ::= SEQUENCE {
+    latitude                     Latitude,
+    longitude                    Longitude,
+    positionConfidenceEllipse    PositionConfidenceEllipse,
+    altitude                     Altitude
+}
+
+/**
+ * This DF shall contain a list of @ref StationType. to which a certain traffic restriction, e.g. the speed limit, applies.
+ * 
+ * @category: Infrastructure information, Traffic information
+ * @revision: V1.3.1
+ */
+RestrictedTypes ::= SEQUENCE (SIZE(1..3, ...)) OF StationType
+
+/** 
+ * This DF provides configuration information about a road section.
+ *
+ * It shall include the following components: 
+ *
+ * @field roadSectionDefinition: the topological definition of the road section for which the information in the other components applies throughout its entire length.
+ * 
+ * @field roadType: the optional type of road on which the section is located.
+ * 
+ * @field laneConfiguration: the optional configuration of the road section in terms of basic information per lane.
+ *
+ * @field mapemConfiguration: the optional configuration of the road section in terms of MAPEM lanes or connections.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+
+RoadConfigurationSection ::= SEQUENCE {
+  roadSectionDefinition  RoadSectionDefinition,
+  roadType               RoadType OPTIONAL, 
+  laneConfiguration      BasicLaneConfiguration OPTIONAL,
+  mapemConfiguration     MapemConfiguration OPTIONAL,
+  ...
+} 
+  ((WITH COMPONENTS {..., laneConfiguration PRESENT}) |
+   (WITH COMPONENTS {..., mapemConfiguration PRESENT})) 
+
+/**
+ * This DF shall contain a list of @ref RoadConfigurationSection.
+ * 
+ * @category: Road Topology information
+ * @revision: Created in V2.2.1
+ */
+RoadConfigurationSectionList::=  SEQUENCE (SIZE(1..8,...))  OF RoadConfigurationSection
+
+/** 
+ * This DF provides the basic topological definition of a road section.
+ *
+ * It shall include the following components: 
+ * 
+ * @field startingPointSection: the position of the starting point of the section. 
+ * 
+ * @field lengthOfSection: the optional length of the section along the road profile (i.e. including curves).
+ * 
+ * @field endingPointSection: the optional position of the ending point of the section. 
+ * If this component is absent, the ending position is implicitly defined by other means, e.g. the starting point of the next RoadConfigurationSection, or the sectionÃ¯Â¿Â½s length.
+ *
+ * @field connectedPaths: the identifier(s) of the path(s) having one or an ordered subset of waypoints located upstream of the RoadConfigurationSectionÃ¯Â¿Â½ starting point. 
+ * 
+ * @field includedPaths: the identifier(s) of the path(s) that covers (either with all its length or with a part of it) a RoadConfigurationSection. 
+ *
+ * @field isEventZoneIncluded: indicates, if set to TRUE, that the @ref EventZone incl. its reference position covers a RoadConfigurationSection (either with all its length or with a part of it). 
+ * 
+ * @field isEventZoneConnected: indicates, if set to TRUE, that the @ref EventZone incl. its reference position has one or an ordered subset of waypoints located upstream of the RoadConfigurationSectionÃ¯Â¿Â½ starting point.
+ *
+ * @category: Road topology information
+ * @revision: Created in V2.2.1
+*/
+RoadSectionDefinition::= SEQUENCE {
+  startingPointSection      GeoPosition,
+  lengthOfSection	  	    StandardLength2B OPTIONAL,
+  endingPointSection       	GeoPosition OPTIONAL, 
+  connectedPaths		    PathReferences,	
+  includedPaths          	PathReferences,
+  isEventZoneIncluded       BOOLEAN,  
+  isEventZoneConnected      BOOLEAN,
+  ...
+}  
+
+/**
+ * This DF represents a unique id for a road segment
+ *
+ * It shall include the following components: 
+ *
+ * @field region: the optional identifier of the entity that is responsible for the region in which the road segment is placed.
+ * It is the duty of that entity to guarantee that the @ref Id is unique within the region.
+ *
+ * @field id: the identifier of the road segment.
+ *
+ * @note: when the component region is present, the RoadSegmentReferenceId is guaranteed to be globally unique.
+ * @category: GeoReference information
+ * @revision: created in V2.1.1
+ */
+RoadSegmentReferenceId ::= SEQUENCE {
+    region    Identifier2B OPTIONAL,
+    id        Identifier2B
+}
+
+/**
+ * This DF provides the safe distance indication of a traffic participant with other traffic participant(s).
+ *
+ * It shall include the following components: 
+ * 
+ * @field subjectStation: optionally indicates one "other" traffic participant identified by its ITS-S.
+ *  
+ * @field safeDistanceIndicator: indicates whether the distance between the ego ITS-S and the traffic participant(s) is safe.
+ * If subjectStation is present then it indicates whether the distance between the ego ITS-S and the traffic participant indicated in the component subjectStation is safe. 
+ *
+ * @field timeToCollision: optionally indicated the time-to-collision calculated as sqrt(LaDi^2 + LoDi^2 + VDi^2/relative speed 
+ * and represented in  the  nearest 100  ms. This component may be present only if subjectStation is present. 
+ *
+ * @note: the abbreviations used are Lateral Distance (LaD),  Longitudinal Distance (LoD) and Vertical Distance (VD) 
+ * and their respective  thresholds, Minimum  Safe  Lateral  Distance (MSLaD), Minimum  Safe  Longitudinal Distance  (MSLoD),  and  Minimum  Safe Vertical Distance (MSVD).
+ *
+ * @category: Traffic information, Kinematic information
+ * @revision: created in V2.1.1
+ */
+SafeDistanceIndication ::= SEQUENCE {
+    subjectStation           StationId OPTIONAL,
+    safeDistanceIndicator    SafeDistanceIndicator,
+    timeToCollision          DeltaTimeTenthOfSecond OPTIONAL,
+    ...
+}
+
+/** 
+ * This DF shall contain a list of DF @ref CartesianPosition3d.
+ * 
+ * @category: GeoReference information
+ * @revision: created in V2.1.1
+ */
+SequenceOfCartesianPosition3d ::= SEQUENCE (SIZE(1..16, ...)) OF CartesianPosition3d
+
+/** 
+ * The DF contains a list of DE @ref Identifier1B.
+ *
+ * @category: Basic information
+ * @revision: created in V2.1.1
+*/
+SequenceOfIdentifier1B ::= SEQUENCE SIZE(1..128, ...) OF Identifier1B
+
+/**
+ * The DF contains a list of DF @ref SafeDistanceIndication.
+ *
+ * @category: Traffic information, Kinematic information
+ * @revision: created in V2.1.1
+*/
+SequenceOfSafeDistanceIndication ::= SEQUENCE(SIZE(1..8,...)) OF SafeDistanceIndication
+
+/**
+ * The DF shall contain a list of DF @ref TrajectoryInterceptionIndication.
+ *
+ * @category: Traffic information, Kinematic information
+ * @revision: created in V2.1.1
+*/
+SequenceOfTrajectoryInterceptionIndication ::=  SEQUENCE (SIZE(1..8,...)) OF TrajectoryInterceptionIndication
+
+/**
+ * This DF provides the definition of a geographical area or volume, based on different options.
+ *
+ * It is a choice of the following components: 
+ *
+ * @field rectangular: definition of an rectangular area or a right rectangular prism (with a rectangular base) also called a cuboid, or informally a rectangular box.
+ *
+ * @field circular: definition of an area of circular shape or a right circular cylinder.
+ *
+ * @field polygonal: definition of an area of polygonal shape or a right prism.
+ *
+ * @field elliptical: definition of an area of elliptical shape or a right elliptical cylinder.
+ *
+ * @field radial: definition of a radial shape.
+ *
+ * @field radialList: definition of list of radial shapes.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+ */
+Shape::= CHOICE {
+   rectangular       RectangularShape,
+   circular          CircularShape, 
+   polygonal         PolygonalShape,
+   elliptical        EllipticalShape,
+   radial            RadialShape,
+   radialShapes      RadialShapes,
+   ...
+}
+
+/**
+ * This DF represents the speed and associated confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field speedValue: the speed value.
+ * 
+ * @field speedConfidence: the confidence value of the speed value.
+ *
+ * @category: Kinematic information
+ * @revision: V1.3.1
+ */
+Speed ::= SEQUENCE {
+    speedValue         SpeedValue,
+    speedConfidence    SpeedConfidence
+}
+
+/**
+ * This DF  provides the  indication of  change in stability.
+ *
+ * It shall include the following components: 
+ * 
+ * @field lossProbability: the probability of stability loss. 
+ * 
+ * @field actionDeltaTime: the period over which the the probability of stability loss is estimated. 
+ *
+ * @category: Kinematic information
+ * @revision: V2.1.1
+ */
+StabilityChangeIndication ::= SEQUENCE {
+    lossProbability     StabilityLossProbability,
+    actionDeltaTime     DeltaTimeTenthOfSecond,
+    ...
+}
+
+/**
+ * This DF represents the steering wheel angle of the vehicle at certain point in time.
+ *
+ * It shall include the following components: 
+ * 
+ * @field steeringWheelAngleValue: steering wheel angle value.
+ * 
+ * @field steeringWheelAngleConfidence: confidence value of the steering wheel angle value.
+ * 
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+ */
+SteeringWheelAngle ::= SEQUENCE {
+    steeringWheelAngleValue         SteeringWheelAngleValue,
+    steeringWheelAngleConfidence    SteeringWheelAngleConfidence
+}
+
+/**
+ * This DF represents one or more paths using @ref Path.
+ * 
+ * @category: GeoReference information
+ * @revision: Description revised in V2.1.1. Is is now based on Path and not on PathHistory
+ */
+Traces ::= SEQUENCE SIZE(1..7) OF Path
+
+/**
+ * This DF represents one or more paths using @ref PathExtended.
+ * 
+ * @category: GeoReference information
+ * @revision: Created in V2.2.1
+ */
+TracesExtended ::= SEQUENCE SIZE(1..7) OF PathExtended
+
+/**
+ * Ths DF represents the a position on a traffic island between two lanes. 
+ *
+ * It shall include the following components: 
+ *
+ * @field oneSide: represents one lane.
+ * 
+ * @field otherSide: represents the other lane.
+ * 
+ * @category: Road Topology information
+ * @revision: Created in V2.1.1
+ */
+TrafficIslandPosition ::= SEQUENCE {
+    oneSide      LanePositionAndType,
+    otherSide    LanePositionAndType,
+    ...
+}
+
+/** 
+ * This DF provides detailed information about an attached trailer.
+ *
+ * It shall include the following components: 
+ *
+ * @field refPointId: identifier of the reference point of the trailer.
+ *
+ * @field hitchPointOffset: optional position of the hitch point in negative x-direction (according to ISO 8855) from the
+ * vehicle Reference Point.
+ *
+ * @field frontOverhang: optional length of the trailer overhang in the positive x direction (according to ISO 8855) from the
+ * trailer Reference Point indicated by the refPointID. The value defaults to 0 in case the trailer
+ * is not overhanging to the front with respect to the trailer reference point.
+ *
+ * @field rearOverhang: optional length of the trailer overhang in the negative x direction (according to ISO 8855) from the
+ * trailer Reference Point indicated by the refPointID.
+ *
+ * @field trailerWidth: optional width of the trailer.
+ *
+ * @field hitchAngle: optional Value and confidence value of the angle between the trailer orientation (corresponding to the x
+ * direction of the ISO 8855 [21] coordinate system centered on the trailer) and the direction of
+ * the segment having as end points the reference point of the trailer and the reference point of
+ * the pulling vehicle, which can be another trailer or a vehicle looking on the horizontal plane
+ * xy, described in the local Cartesian coordinate system of the trailer. The
+ * angle is measured with negative values considering the trailer orientation turning clockwise
+ * starting from the segment direction. The angle value accuracy is provided with the
+ * confidence level of 95 %.
+ *
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+*/
+TrailerData ::= SEQUENCE { 
+    refPointId          Identifier1B,
+    hitchPointOffset    StandardLength1B, 
+    frontOverhang       StandardLength1B OPTIONAL, 
+    rearOverhang        StandardLength1B OPTIONAL, 
+    trailerWidth        VehicleWidth OPTIONAL,
+    hitchAngle          CartesianAngle,
+    ...
+}
+
+/**
+ * This DF  provides the trajectory  interception  indication  of  ego-VRU  ITS-S  with another ITS-Ss. 
+ *
+ * It shall include the following components: 
+ * 
+ * @field subjectStation: indicates the subject station.
+ * 
+ * @field trajectoryInterceptionProbability: indicates the propbability of the interception of the subject station trajectory 
+ * with the trajectory of the station indicated in the component subjectStation.
+ *
+ * @field trajectoryInterceptionConfidence: indicates the confidence of interception of the subject station trajectory 
+ * with the trajectory of the station indicated in the component subjectStation.
+ * 
+ * @category: Vehicle information
+ * @revision: Created in V2.1.1
+ */
+TrajectoryInterceptionIndication  ::= SEQUENCE {
+   subjectStation                     StationId OPTIONAL, 
+   trajectoryInterceptionProbability  TrajectoryInterceptionProbability,
+   trajectoryInterceptionConfidence   TrajectoryInterceptionConfidence OPTIONAL,
+        ... 
+}
+
+/**
+ * This DF together with its sub DFs Ext1, Ext2 and the DE Ext3 provides the custom (i.e. not ASN.1 standard) definition of an integer with variable lenght, that can be used for example to encode the ITS-AID. 
+ *
+ * @category: Basic information
+ * @revision: Created in V2.1.1
+ */
+VarLengthNumber::=CHOICE{
+	content	    [0] INTEGER(0..127), -- one octet length
+	extension	[1]	Ext1
+	}
+Ext1::=CHOICE{
+	content	    [0]	INTEGER(128..16511), -- two octets length
+	extension	[1]	Ext2
+}
+Ext2::=CHOICE{
+	content	    [0]	INTEGER(16512..2113663), -- three octets length
+	extension	[1]	Ext3
+	}
+Ext3::= INTEGER(2113664..270549119,...) -- four and more octets length
+
+/**
+ * This DF indicates the vehicle acceleration at vertical direction and the associated confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field verticalAccelerationValue: vertical acceleration value at a point in time.
+ * 
+ * @field verticalAccelerationConfidence: confidence value of the vertical acceleration value with a predefined confidence level.
+ * 
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead.
+ * @category Vehicle information
+ * @revision: Description revised in V2.1.1
+ */
+VerticalAcceleration ::= SEQUENCE {
+    verticalAccelerationValue         VerticalAccelerationValue,
+    verticalAccelerationConfidence    AccelerationConfidence
+}
+
+/**
+ * This DF provides information related to the identification of a vehicle.
+ *
+ * It shall include the following components: 
+ * 
+ * @field wMInumber: World Manufacturer Identifier (WMI) code.
+ * 
+ * @field vDS: Vehicle Descriptor Section (VDS). 
+ * 
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+VehicleIdentification ::= SEQUENCE {
+    wMInumber    WMInumber OPTIONAL,
+    vDS          VDS OPTIONAL,
+    ...
+}
+
+/**
+ * This DF represents the length of vehicle and accuracy indication information.
+ *
+ * It shall include the following components: 
+ * 
+ * @field vehicleLengthValue: length of vehicle. 
+ * 
+ * @field vehicleLengthConfidenceIndication: indication of the length value confidence.
+ * 
+ * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref VehicleLengthV2 instead.
+ * @category: Vehicle information
+ * @revision: V1.3.1
+ */
+VehicleLength ::= SEQUENCE {
+    vehicleLengthValue                   VehicleLengthValue,
+    vehicleLengthConfidenceIndication    VehicleLengthConfidenceIndication
+}
+
+/**
+ * This DF represents the length of vehicle and accuracy indication information.
+ *
+ * It shall include the following components: 
+ * 
+ * @field vehicleLengthValue: length of vehicle. 
+ * 
+ * @field trailerPresenceInformation: information about the trailer presence.
+ * 
+ * @category: Vehicle information
+ * @revision: created in V2.1.1 based on @ref VehicleLength but using @ref TrailerPresenceInformation.
+ */
+VehicleLengthV2 ::= SEQUENCE {
+    vehicleLengthValue            VehicleLengthValue,
+    trailerPresenceInformation    TrailerPresenceInformation
+}
+
+/**
+ * This DF provides information about the status of the vehicleÂ´s movement control mechanisms. 
+ *
+ * It shall include the following components: 
+ *
+ * @field accelerationPedalStatus: information about the status of the acceleration pedal. 
+ * 
+ * @field brakePedalPostionStatus information about the status of the brake pedal. 
+ *
+ * @field saeAutomationLevel: optional information about the level of driving automation. 
+ *
+ * @field automationControl: optional information about the controlling mechanism for lateral, or combined lateral and longitudinal movement.
+ *
+ * @field accelerationControl: optional information about the controlling mechanism for longitudinal movement. 
+ *
+ * @field accelerationControlExtension: optional extended information about the controlling mechanism for longitudinal movement. 
+ *
+ * @category: Vehicle information
+ * @revision: created in V2.3.1
+ */
+VehicleMovementControl::= SEQUENCE {    
+	accelerationPedalStatus          PedalStatus,
+	brakePedalStatus                 PedalStatus,
+	saeAutomationLevel               SaeAutomationLevel OPTIONAL,
+	automationControl                AutomationControl OPTIONAL,
+	accelerationControl              AccelerationControl OPTIONAL,
+	accelerationControlExtension     AccelerationControlExtension OPTIONAL,
+	...
+}
+
+/**
+ * This DF represents a velocity vector with associated confidence value.
+ *
+ * The following options are available:
+ * 
+ * @field polarVelocity: the representation of the velocity vector in a polar or cylindrical coordinate system. 
+ * 
+ * @field cartesianVelocity: the representation of the velocity vector in a cartesian coordinate system.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+Velocity3dWithConfidence::= CHOICE{
+    polarVelocity          VelocityPolarWithZ, 
+    cartesianVelocity      VelocityCartesian
+}
+
+/**
+ * This DF represents a velocity vector in a cartesian coordinate system.
+ 
+ * It shall include the following components: 
+ * 
+ * @field xVelocity: the x component of the velocity vector with the associated confidence value.
+ * 
+ * @field yVelocity: the y component of the velocity vector with the associated confidence value.
+ *
+ * @field zVelocity: the optional z component of the velocity vector with the associated confidence value.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+VelocityCartesian::= SEQUENCE {
+    xVelocity   VelocityComponent,
+    yVelocity   VelocityComponent,
+    zVelocity   VelocityComponent OPTIONAL
+}
+
+/**
+ * This DF represents a component of the velocity vector and the associated confidence value.
+ *
+ * It shall include the following components: 
+ * 
+ * @field value: the value of the component.
+ * 
+ * @field confidence: the confidence value of the value.
+ *
+ * @category: Kinematic information
+ * @revision: V2.1.1
+ */
+VelocityComponent ::= SEQUENCE {
+    value         VelocityComponentValue,
+    confidence    SpeedConfidence
+}
+
+/**
+ * This DF represents a velocity vector in a polar or cylindrical coordinate system.
+ *
+ * It shall include the following components: 
+ * 
+ * @field velocityMagnitude: magnitude of the velocity vector on the reference plane, with the associated confidence value.
+ * 
+ * @field velocityDirection: polar angle of the velocity vector on the reference plane, with the associated confidence value.
+ *
+ * @field zVelocity: the optional z component of the velocity vector along the reference axis of the cylindrical coordinate system, with the associated confidence value.
+ * 
+ * @category: Kinematic information
+ * @revision: Created in V2.1.1
+ */
+VelocityPolarWithZ::= SEQUENCE {
+    velocityMagnitude    Speed, 
+    velocityDirection    CartesianAngle,
+    zVelocity            VelocityComponent OPTIONAL
+}
+
+/** 
+ * This DF provides information about a VRU cluster.
+ *
+ * It shall include the following components: 
+ *
+ * @field clusterId: optional identifier of a VRU cluster.
+ *
+ * @field clusterBoundingBoxShape: optionally indicates the shape of the cluster bounding box, per default inside an East-North-Up coordinate system 
+ * centered around a reference point defined outside of the context of this DF.
+ *
+ * @field clusterCardinalitySize: indicates an estimation of the number of VRUs in the group, e.g. the known members in the cluster + 1 (for the cluster leader) .
+ *
+ * @field clusterProfiles: optionally identifies all the VRU profile types that are estimated to be within the cluster.
+ * if this component is absent it means that the information is unavailable. 
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1, description revised in V2.2.1
+*/
+VruClusterInformation ::= SEQUENCE { 
+   clusterId                  Identifier1B OPTIONAL,
+   clusterBoundingBoxShape    Shape (WITH COMPONENTS{..., elliptical ABSENT, radial ABSENT, radialShapes ABSENT}) OPTIONAL,
+   clusterCardinalitySize     CardinalNumber1B,
+   clusterProfiles            VruClusterProfiles OPTIONAL,
+   ...
+}
+
+/**
+ * This DF represents the status of the exterior light switches of a VRU.
+ * This DF is an extension of the vehicular DE @ref ExteriorLights.
+ *
+ * It shall include the following components: 
+ * 
+ * @field vehicular:  represents the status of the exterior light switches of a road vehicle.
+ * 
+ * @field vruSpecific: represents the status of the exterior light switches of a VRU.
+ *
+ * @category: VRU information
+ * @revision: created in V2.1.1
+ */
+VruExteriorLights ::= SEQUENCE {
+   vehicular      ExteriorLights, 
+   vruSpecific    VruSpecificExteriorLights,
+   ...
+}
+
+/**
+ * This DF indicates the profile of a VRU including sub-profile information
+ * It identifies four options corresponding to the four types of VRU profiles specified in ETSI TS 103 300-2 [18]:
+ *
+ * @field pedestrian: VRU Profile 1 - Pedestrian.
+ *
+ * @field bicyclistAndLightVruVehicle: VRU Profile  2 - Bicyclist.
+ *
+ * @field motorcyclist: VRU Profile 3  - Motorcyclist.
+ *
+ * @field animal: VRU Profile  4 -  Animal.
+ *
+ * @category: VRU information
+ * @revision: Created in V2.1.1
+ */
+VruProfileAndSubprofile ::= CHOICE {
+   pedestrian                     VruSubProfilePedestrian,
+   bicyclistAndLightVruVehicle    VruSubProfileBicyclist,
+   motorcyclist                   VruSubProfileMotorcyclist,
+   animal                         VruSubProfileAnimal,
+   ...
+}
+
+/** 
+ * This DF represents an angular component along with a confidence value in the WGS84 coordinate system.
+ * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE.
+ *
+ * It shall include the following components: 
+ *
+ * @field value: the angle value, which can be estimated as the mean of the current distribution.
+ *
+ * @field confidence: the confidence value associated to the angle value.
+ *
+ * @category: GeoReference information
+ * @revision: Created in V2.1.1
+*/
+Wgs84Angle ::= SEQUENCE {
+    value         Wgs84AngleValue,
+    confidence    Wgs84AngleConfidence
+}
+
+
+/**
+ * This DF represents a yaw rate of vehicle at a point in time.
+ *
+ * It shall include the following components: 
+ * 
+ * @field yawRateValue: yaw rate value at a point in time.
+ * 
+ * @field yawRateConfidence: confidence value associated to the yaw rate value.
+ * 
+ * @category: Vehicle Information
+ * @revision: V1.3.1
+ */
+YawRate::= SEQUENCE {
+    yawRateValue         YawRateValue,
+    yawRateConfidence    YawRateConfidence
+}
+
+------------------------------------------
+/** 
+ * ## References:
+ * 1.   ETSI TS 103 900: "Intelligent Transport Systems (ITS); Vehicular Communications; Basic Set of Applications; Part 2: Specification of Cooperative Awareness Basic Service; Release 2".
+ * 2.   ETSI TS 103 831: "Intelligent Transport Systems (ITS); Vehicular Communications; Basic Set of Applications; Part 3: Specifications of Decentralized Environmental Notification Basic Service"; Release 2.
+ * 3.   [European Agreement (Applicable as from 1 January 2011): "Concerning the International Carriage of Dangerous Goods by Road"](http://www.unece.org/trans/danger/publi/adr/adr2011/11ContentsE.html).
+ * 4.   [United Nations: "Recommendations on the Transport of Dangerous Goods - Model Regulations", Twelfth revised edition](http://www.unece.org/trans/danger/publi/unrec/12_e.html).
+ * 5.   ETSI TS 101 539-1: "Intelligent Transport Systems (ITS); V2X Applications; Part 1: Road Hazard Signalling (RHS) application requirements specification".
+ * 6.   ISO 3779 (2011-07): "Road vehicles - Vehicle identification number (VIN) Content and structure".
+ * 7.   VDV recommendation 420 (1992): "Technical Requirements for Automatic Vehicle Location / Control Systems - Radio Data Transmission (BON Version) with Supplement 1 and Supplement 2".
+ * 8.   ISO 1176:1990: "Road vehicles - Masses - Vocabulary and codes".
+ * 9.   ETSI TS 103 916 "Intelligent Transport Systems (ITS); Parking Availability Service Specification; Release 2"
+ * 10.  ETSI TS 103 324 "Intelligent Transport System (ITS); Vehicular Communications; Basic Set of Applications; Collective Perception Service; Release 2"
+ * 11.  ETSI TS 103 882 "Intelligent Transport Systems (ITS); Automated Vehicle Marshalling (AVM); Release 2" 
+ * 12.  ETSI TS 103 300-3: "Intelligent Transport Systems (ITS);  Vulnerable Road Users (VRU) awareness;  Part 3: Specification of VRU awareness basic service; Release 2"
+ * 13.  ETSI TS 103 724: "Intelligent Transport Systems (ITS); Facilities layer  function; Interference Management Zone Message (IMZM); Release 2"
+ * 14.	ETSI TS 102 792: "Intelligent Transport Systems (ITS); Mitigation techniques to avoid interference between European CEN Dedicated Short Range Communication (CEN DSRC) equipment and Intelligent Transport Systems (ITS) operating in the 5 GHz frequency range".
+ * 15.	ETSI TS 103 301: "Intelligent Transport Systems (ITS); Vehicular Communications; Basic Set of Applications; Facilities layer protocols and communication requirements for infrastructure services; Release 2".
+ * 16.	UNECE/TRANS/WP.29/78/Rev.4: "Consolidated Resolution on the Construction of Vehicles (R.E.3)".
+ * 17.	ETSI EN 302 890-1: "Intelligent Transport Systems (ITS); Facilities layer function; Part 1: Services Announcement (SA) specification".
+ * 18.	ETSI TS 103 300-2 "Intelligent Transport System (ITS); Vulnerable Road Users (VRU) awareness; Part 2: Functional  Architecture and Requirements definition; Release 2"
+ * 19.	ETSI TS 103 175: "Intelligent Transport Systems (ITS); Cross  Layer DCC Management  Entity for operation in  the ITS G5A  and ITS G5B medium"
+ * 20.	ETSI EN 302 571: "Intelligent Transport Systems (ITS); Radiocommunications equipment operating in the 5 855 MHz to 5 925 MHz frequency  band; Harmonised Standard  covering  the essential  requirements of article 3.2 of  Directive 2014/53/EU"
+ * 21.	ISO 8855: "Road vehicles - Vehicle dynamics and road-holding ability - Vocabulary".
+ * 22.  ISO 3833: "Road vehicles - Types - Terms and definitions".
+ * 23.  ISO 14816:2015 + Amd1:2019: " Road transport and traffic telematics Ã¯Â¿Â½ Automatic vehicle and equipment identification Ã¯Â¿Â½ Numbering and data structure"
+ * 24.  ISO 17573-3: "Electronic fee collection Ã¯Â¿Â½ System architecture for vehicle-related tolling Ã¯Â¿Â½ Part 3: Data dictionary"
+ * 25.  ISO 3166-1: "Codes for the representation of names of countries and their subdivisions Ã¯Â¿Â½ Part 1: Country code" 
+ * 26.  SAE J3016: "Taxonomy and Definitions for Terms Related to Driving Automation Systems for On-Road Motor Vehicles"
+*/
+
+END
+

--- a/standards/its/src/ts102894_2/mod.rs
+++ b/standards/its/src/ts102894_2/mod.rs
@@ -1,0 +1,8842 @@
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod etsi_its_cdd {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = " Specification of CDD Data Frames:"]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = "*"]
+    #[doc = " * This DF represents an acceleration vector with associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field polarAcceleration: the representation of the acceleration vector in a polar or cylindrical coordinate system. "]
+    #[doc = " * "]
+    #[doc = " * @field cartesianAcceleration: the representation of the acceleration vector in a cartesian coordinate system."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum Acceleration3dWithConfidence {
+        polarAcceleration(AccelerationPolarWithZ),
+        cartesianAcceleration(AccelerationCartesian),
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a acceleration vector in a cartesian coordinate system."]
+    #[doc = " "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field xAcceleration: the x component of the acceleration vector with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @field yAcceleration: the y component of the acceleration vector with the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * @field zAcceleration: the optional z component of the acceleration vector with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct AccelerationCartesian {
+        #[rasn(identifier = "xAcceleration")]
+        pub x_acceleration: AccelerationComponent,
+        #[rasn(identifier = "yAcceleration")]
+        pub y_acceleration: AccelerationComponent,
+        #[rasn(identifier = "zAcceleration")]
+        pub z_acceleration: Option<AccelerationComponent>,
+    }
+    impl AccelerationCartesian {
+        pub fn new(
+            x_acceleration: AccelerationComponent,
+            y_acceleration: AccelerationComponent,
+            z_acceleration: Option<AccelerationComponent>,
+        ) -> Self {
+            Self {
+                x_acceleration,
+                y_acceleration,
+                z_acceleration,
+            }
+        }
+    }
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = " Specification of CDD Data Elements: "]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = "* "]
+    #[doc = " * This DE indicates a change of acceleration."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `accelerate` - if the magnitude of the horizontal velocity vector increases."]
+    #[doc = " * - 1 - `decelerate` - if the magnitude of the horizontal velocity vector decreases."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum AccelerationChange {
+        accelerate = 0,
+        decelerate = 1,
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents information associated to changes in acceleration. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field accelOrDecel: the indication of an acceleration change."]
+    #[doc = " *"]
+    #[doc = " * @field actionDeltaTime: the period over which the acceleration change action is performed."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AccelerationChangeIndication {
+        #[rasn(identifier = "accelOrDecel")]
+        pub accel_or_decel: AccelerationChange,
+        #[rasn(identifier = "actionDeltaTime")]
+        pub action_delta_time: DeltaTimeTenthOfSecond,
+    }
+    impl AccelerationChangeIndication {
+        pub fn new(
+            accel_or_decel: AccelerationChange,
+            action_delta_time: DeltaTimeTenthOfSecond,
+        ) -> Self {
+            Self {
+                accel_or_decel,
+                action_delta_time,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents an acceleration component along with a confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field value: the value of the acceleration component which can be estimated as the mean of the current distribution."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: the confidence value associated to the provided value."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct AccelerationComponent {
+        pub value: AccelerationValue,
+        pub confidence: AccelerationConfidence,
+    }
+    impl AccelerationComponent {
+        pub fn new(value: AccelerationValue, confidence: AccelerationConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the acceleration confidence value which represents the estimated absolute accuracy of an acceleration value with a default confidence level of 95 %. "]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 101`) if the confidence value is equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `101` if the confidence value is out of range i.e. greater than 10 m/s^2,"]
+    #[doc = " * - `102` if the confidence value is unavailable."]
+    #[doc = " *"]
+    #[doc = " * The value 0 shall not be used."]
+    #[doc = " *"]
+    #[doc = " * @note: The fact that an acceleration value is received with confidence value set to `unavailable(102)` can be caused by several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the acceleration value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * @note: If an acceleration value is received and its confidence value is set to `outOfRange(101)`, it means that the value is not valid and therefore cannot be trusted. Such value is not useful for the application."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 m/s^2"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=102"))]
+    pub struct AccelerationConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the status of the controlling mechanisms for longitudinal movement of the vehicle."]
+    #[doc = " * The data may be provided via the in-vehicle network. It indicates whether a specific in-vehicle"]
+    #[doc = " * acceleration control system is engaged or not. "]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 - `brakePedalEngaged`      - Driver is stepping on the brake pedal,"]
+    #[doc = " * - 1 - `gasPedalEngaged`        - Driver is stepping on the gas pedal,"]
+    #[doc = " * - 2 - `emergencyBrakeEngaged`  - emergency brake system is engaged,"]
+    #[doc = " * - 3 - `collisionWarningEngaged`- collision warning system is engaged,"]
+    #[doc = " * - 4 - `accEngaged`             - ACC is engaged,"]
+    #[doc = " * - 5 - `cruiseControlEngaged`   - cruise control is engaged,"]
+    #[doc = " * - 6 - `speedLimiterEngaged`    - speed limiter is engaged."]
+    #[doc = " *"]
+    #[doc = " * Otherwise (for example when the corresponding system is not available due to non equipped system"]
+    #[doc = " * or information is unavailable), the corresponding bit shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @note: The system engagement condition is OEM specific and therefore out of scope of the present document."]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1, description revised in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AccelerationControl(pub FixedBitString<7usize>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the extension of DE AccelerationControl and should only be used together with DE AccelerationControl."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0  - `rearCrossTrafficAlertEngaged`       - rear cross traffic alert system is engaged"]
+    #[doc = " * - 1  - `emergencyBrakeRearEngaged`          - emergency brake system for rear driving is engaged"]
+    #[doc = " * - 2  - `assistedParkingLongitudinalEngaged` - assisted parking system (longitudinal control) is engaged"]
+    #[doc = " *"]
+    #[doc = " * Otherwise (for example when the corresponding system is not available due to non-equipped system "]
+    #[doc = " * or information is unavailable), the corresponding bit shall be set to 0. "]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("3", extensible))]
+    pub struct AccelerationControlExtension(pub BitString);
+    #[doc = "*"]
+    #[doc = " * This DF represents the magnitude of the acceleration vector and associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field accelerationMagnitudeValue: the magnitude of the acceleration vector."]
+    #[doc = " * "]
+    #[doc = " * @field accelerationConfidence: the confidence value of the magnitude value."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct AccelerationMagnitude {
+        #[rasn(identifier = "accelerationMagnitudeValue")]
+        pub acceleration_magnitude_value: AccelerationMagnitudeValue,
+        #[rasn(identifier = "accelerationConfidence")]
+        pub acceleration_confidence: AccelerationConfidence,
+    }
+    impl AccelerationMagnitude {
+        pub fn new(
+            acceleration_magnitude_value: AccelerationMagnitudeValue,
+            acceleration_confidence: AccelerationConfidence,
+        ) -> Self {
+            Self {
+                acceleration_magnitude_value,
+                acceleration_confidence,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents the magnitude of the acceleration vector in a defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` to indicate no acceleration,"]
+    #[doc = " * - `n` (`n > 0` and `n < 160`) to indicate acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `160` for acceleration values greater than 15,9 m/s^2,"]
+    #[doc = " * - `161` when the data is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 m/s^2"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=161"))]
+    pub struct AccelerationMagnitudeValue(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents an acceleration vector in a polar or cylindrical coordinate system."]
+    #[doc = " "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field accelerationMagnitude: magnitude of the acceleration vector projected onto the reference plane, with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @field accelerationDirection: polar angle of the acceleration vector projected onto the reference plane, with the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * @field zAcceleration: the optional z component of the acceleration vector along the reference axis of the cylindrical coordinate system, with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct AccelerationPolarWithZ {
+        #[rasn(identifier = "accelerationMagnitude")]
+        pub acceleration_magnitude: AccelerationMagnitude,
+        #[rasn(identifier = "accelerationDirection")]
+        pub acceleration_direction: CartesianAngle,
+        #[rasn(identifier = "zAcceleration")]
+        pub z_acceleration: Option<AccelerationComponent>,
+    }
+    impl AccelerationPolarWithZ {
+        pub fn new(
+            acceleration_magnitude: AccelerationMagnitude,
+            acceleration_direction: CartesianAngle,
+            z_acceleration: Option<AccelerationComponent>,
+        ) -> Self {
+            Self {
+                acceleration_magnitude,
+                acceleration_direction,
+                z_acceleration,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents the value of an acceleration component in a defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-160` for acceleration values equal to or less than -16 m/s^2,"]
+    #[doc = " * - `n` (`n > -160` and `n <= 0`) to indicate negative acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `n` (`n > 0` and `n < 160`) to indicate positive acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `160` for acceleration values greater than 15,9 m/s^2,"]
+    #[doc = " * - `161` when the data is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @note: the formula for values > -160 and <160 results in rounding up to the next value. Zero acceleration is indicated using n=0."]
+    #[doc = " * @unit 0,1 m/s^2"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-160..=161"))]
+    pub struct AccelerationValue(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DE indicates an access technology."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0`: in case of any access technology class,"]
+    #[doc = " * - `1`: in case of ITS-G5 access technology class,"]
+    #[doc = " * - `2`: in case of LTE-V2X access technology class,"]
+    #[doc = " * - `3`: in case of NR-V2X access technology class."]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum AccessTechnologyClass {
+        any = 0,
+        itsg5Class = 1,
+        ltev2xClass = 2,
+        nrv2xClass = 3,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `accident`."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                        - in case the information on the sub cause of the accident is unavailable,"]
+    #[doc = " * - 1 - `multiVehicleAccident`               - in case more than two vehicles are involved in accident,"]
+    #[doc = " * - 2 - `heavyAccident`                      - in case the airbag of the vehicle involved in the accident is triggered, "]
+    #[doc = " *                                              the accident requires important rescue and/or recovery work,"]
+    #[doc = " * - 3 - `accidentInvolvingLorry`             - in case the accident involves a lorry,"]
+    #[doc = " * - 4 - `accidentInvolvingBus`               - in case the accident involves a bus,"]
+    #[doc = " * - 5 - `accidentInvolvingHazardousMaterials`- in case the accident involves hazardous material,"]
+    #[doc = " * - 6 - `accidentOnOppositeLane-deprecated`  - deprecated,"]
+    #[doc = " * - 7 - `unsecuredAccident`                  - in case the accident is not secured,"]
+    #[doc = " * - 8 - `assistanceRequested`                - in case rescue and assistance are requested,"]
+    #[doc = " * - 9-255                                    - reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 6 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct AccidentSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents an identifier used to describe a protocol action taken by an ITS-S."]
+    #[doc = " * "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field originatingStationId: Id of the ITS-S that takes the action. "]
+    #[doc = " * "]
+    #[doc = " * @field sequenceNumber: a sequence number. "]
+    #[doc = " * "]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref ActionId instead. "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ActionID {
+        #[rasn(identifier = "originatingStationId")]
+        pub originating_station_id: StationID,
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: SequenceNumber,
+    }
+    impl ActionID {
+        pub fn new(originating_station_id: StationID, sequence_number: SequenceNumber) -> Self {
+            Self {
+                originating_station_id,
+                sequence_number,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents an identifier used to describe a protocol action taken by an ITS-S."]
+    #[doc = " * "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field originatingStationId: Id of the ITS-S that takes the action. "]
+    #[doc = " * "]
+    #[doc = " * @field sequenceNumber: a sequence number. "]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1 based on @ref ActionID."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ActionId {
+        #[rasn(identifier = "originatingStationId")]
+        pub originating_station_id: StationId,
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: SequenceNumber,
+    }
+    impl ActionId {
+        pub fn new(originating_station_id: StationId, sequence_number: SequenceNumber) -> Self {
+            Self {
+                originating_station_id,
+                sequence_number,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref ActionId. "]
+    #[doc = ""]
+    #[doc = " * @category: Communication Information"]
+    #[doc = " * @revision: Created in V2.1.1 based on ReferenceDenms from DENM Release 1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct ActionIdList(pub SequenceOf<ActionId>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `adhesion`. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`     - in case information on the cause of the low road adhesion is unavailable,"]
+    #[doc = " * - 1 - `heavyFrostOnRoad`- in case the low road adhesion is due to heavy frost on the road,"]
+    #[doc = " * - 2 - `fuelOnRoad`      - in case the low road adhesion is due to fuel on the road,"]
+    #[doc = " * - 3 - `mudOnRoad`       - in case the low road adhesion is due to mud on the road,"]
+    #[doc = " * - 4 - `snowOnRoad`      - in case the low road adhesion is due to snow on the road,"]
+    #[doc = " * - 5 - `iceOnRoad`       - in case the low road adhesion is due to ice on the road,"]
+    #[doc = " * - 6 - `blackIceOnRoad`  - in case the low road adhesion is due to black ice on the road,"]
+    #[doc = " * - 7 - `oilOnRoad`       - in case the low road adhesion is due to oil on the road,"]
+    #[doc = " * - 8 - `looseChippings`  - in case the low road adhesion is due to loose gravel or stone fragments on the road,"]
+    #[doc = " * - 9 - `instantBlackIce` - in case the low road adhesion is due to instant black ice on the road surface,"]
+    #[doc = " * - 10 - `roadsSalted`    - when the low road adhesion is due to salted road,"]
+    #[doc = " * - 11 - `flooding`       - in case low road adhesion is due to flooding of the road,"]
+    #[doc = " * - 12 - `waterOnRoad`    - in case low road adhesion is due to a shallow layer of standing water on the road (not flooding). "]
+    #[doc = " * - 12-255                - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, name changed to AdhesionSubCauseCode in V2.4.1, value 11 moved from hazardousLocation-SurfaceCondition to this DE and value 12 added in V2.4.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct AdhesionSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Precipitation`. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`   - in case information on the type of precipitation is unavailable,"]
+    #[doc = " * - 1 - `rain`          - in case the type of precipitation is rain,"]
+    #[doc = " * - 2 - `snowfall`      - in case the type of precipitation is snowfall,"]
+    #[doc = " * - 3 - `hail`          - in case the type of precipitation is hail."]
+    #[doc = " * - 4-255               - are reserved for future usage"]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, values 1,2,3 renamed in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "AdverseWeatherCondition-PrecipitationSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct AdverseWeatherConditionPrecipitationSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Visibility`."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`    - in case information on the cause of low visibility is unavailable,"]
+    #[doc = " * - 1 - `fog`            - in case the cause of low visibility is fog,"]
+    #[doc = " * - 2 - `smoke`          - in case the cause of low visibility is smoke,"]
+    #[doc = " * - 3 - `snowfall`       - in case the cause of low visibility is snow fall,"]
+    #[doc = " * - 4 - `rain`           - in case the cause of low visibility is rain,"]
+    #[doc = " * - 5 - `hail`           - in case the cause of low visibility is hail,"]
+    #[doc = " * - 6 - `lowSunGlare`    - in case the cause of low visibility is sun glare,"]
+    #[doc = " * - 7 - `sandstorms`     - in case the cause of low visibility is sand storm,"]
+    #[doc = " * - 8 - `swarmsOfInsects`- in case the cause of low visibility is swarm of insects."]
+    #[doc = " * - 9-255                - are reserved for future usage"]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, values 3, 4, 5 renamed in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "AdverseWeatherCondition-VisibilitySubCauseCode",
+        value("0..=255")
+    )]
+    pub struct AdverseWeatherConditionVisibilitySubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `adverseWeatherCondition-Wind`."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`             - in case information on the type of wind is unavailable,"]
+    #[doc = " * - 1 - `strongWinds`             - in case the type of wind is strong wind such as gale or storm (e.g. Beaufort scale number 9-11),"]
+    #[doc = " * - 2 - `damagingHail-deprecated` - deprecated since not representing a wind related event,"]
+    #[doc = " * - 3 - `hurricane`               - in case the type of storm is hurricane (e.g. Beaufort scale number 12),"]
+    #[doc = " * - 4 - `thunderstorm`            - in case the type of storm is thunderstorm,"]
+    #[doc = " * - 5 - `tornado`                 - in case the type of storm is tornado,"]
+    #[doc = " * - 6 - `blizzard`                - in case the type of storm is blizzard."]
+    #[doc = " * - 7-255                         - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, DE renamed in V2.4.1, value 2 deprecated, description of value 1 and 3  amended in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "AdverseWeatherCondition-WindSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct AdverseWeatherConditionWindSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the air humidity in tenths of percent."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 1001`) indicates that the applicable value is equal to or less than n x 0,1 percent and greater than (n-1) x 0,1 percent."]
+    #[doc = " * - `1001` indicates that the air humidity is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @unit: 0,1 % "]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=1001"))]
+    pub struct AirHumidity(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF provides the altitude and confidence level of an altitude information in a WGS84 coordinate system."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field altitudeValue: altitude of a geographical point."]
+    #[doc = " *"]
+    #[doc = " * @field altitudeConfidence: confidence level of the altitudeValue."]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref AltitudeWithConfidence instead. "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Altitude {
+        #[rasn(identifier = "altitudeValue")]
+        pub altitude_value: AltitudeValue,
+        #[rasn(identifier = "altitudeConfidence")]
+        pub altitude_confidence: AltitudeConfidence,
+    }
+    impl Altitude {
+        pub fn new(altitude_value: AltitudeValue, altitude_confidence: AltitudeConfidence) -> Self {
+            Self {
+                altitude_value,
+                altitude_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the altitude confidence value which represents the estimated absolute accuracy of an altitude value of a geographical point with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " *   - 0  - `alt-000-01`   - if the confidence value is equal to or less than 0,01 metre,"]
+    #[doc = " *   - 1  - `alt-000-02`   - if the confidence value is equal to or less than 0,02 metre and greater than 0,01 metre,"]
+    #[doc = " *   - 2  - `alt-000-05`   - if the confidence value is equal to or less than 0,05 metre and greater than 0,02 metre,            "]
+    #[doc = " *   - 3  - `alt-000-10`   - if the confidence value is equal to or less than 0,1 metre and greater than 0,05 metre,            "]
+    #[doc = " *   - 4  - `alt-000-20`   - if the confidence value is equal to or less than 0,2 metre and greater than 0,1 metre,            "]
+    #[doc = " *   - 5  - `alt-000-50`   - if the confidence value is equal to or less than 0,5 metre and greater than 0,2 metre,             "]
+    #[doc = " *   - 6  - `alt-001-00`   - if the confidence value is equal to or less than 1 metre and greater than 0,5 metre,             "]
+    #[doc = " *   - 7  - `alt-002-00`   - if the confidence value is equal to or less than 2 metres and greater than 1 metre,             "]
+    #[doc = " *   - 8  - `alt-005-00`   - if the confidence value is equal to or less than 5 metres and greater than 2 metres,              "]
+    #[doc = " *   - 9  - `alt-010-00`   - if the confidence value is equal to or less than 10 metres and greater than 5 metres,             "]
+    #[doc = " *   - 10 - `alt-020-00`   - if the confidence value is equal to or less than 20 metres and greater than 10 metres,            "]
+    #[doc = " *   - 11 - `alt-050-00`   - if the confidence value is equal to or less than 50 metres and greater than 20 metres,            "]
+    #[doc = " *   - 12 - `alt-100-00`   - if the confidence value is equal to or less than 100 metres and greater than 50 metres,           "]
+    #[doc = " *   - 13 - `alt-200-00`   - if the confidence value is equal to or less than 200 metres and greater than 100 metres,           "]
+    #[doc = " *   - 14 - `outOfRange`   - if the confidence value is out of range, i.e. greater than 200 metres,"]
+    #[doc = " *   - 15 - `unavailable`  - if the confidence value is unavailable.       "]
+    #[doc = " *"]
+    #[doc = " * @note: The fact that an altitude value is received with confidence value set to `unavailable(15)` can be caused"]
+    #[doc = " * by several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the altitude value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * @note: If an altitude value is received and its confidence value is set to `outOfRange(14)`, it means that the  "]
+    #[doc = " * altitude value is not valid and therefore cannot be trusted. Such value is not useful for the application.             "]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum AltitudeConfidence {
+        #[rasn(identifier = "alt-000-01")]
+        alt_000_01 = 0,
+        #[rasn(identifier = "alt-000-02")]
+        alt_000_02 = 1,
+        #[rasn(identifier = "alt-000-05")]
+        alt_000_05 = 2,
+        #[rasn(identifier = "alt-000-10")]
+        alt_000_10 = 3,
+        #[rasn(identifier = "alt-000-20")]
+        alt_000_20 = 4,
+        #[rasn(identifier = "alt-000-50")]
+        alt_000_50 = 5,
+        #[rasn(identifier = "alt-001-00")]
+        alt_001_00 = 6,
+        #[rasn(identifier = "alt-002-00")]
+        alt_002_00 = 7,
+        #[rasn(identifier = "alt-005-00")]
+        alt_005_00 = 8,
+        #[rasn(identifier = "alt-010-00")]
+        alt_010_00 = 9,
+        #[rasn(identifier = "alt-020-00")]
+        alt_020_00 = 10,
+        #[rasn(identifier = "alt-050-00")]
+        alt_050_00 = 11,
+        #[rasn(identifier = "alt-100-00")]
+        alt_100_00 = 12,
+        #[rasn(identifier = "alt-200-00")]
+        alt_200_00 = 13,
+        outOfRange = 14,
+        unavailable = 15,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the altitude value in a WGS84 coordinate system."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `-100 000` if the altitude is equal to or less than -1 000 m,"]
+    #[doc = " * - `n` (`n > -100 000` and `n < 800 000`) if the altitude is equal to or less than n  x 0,01 metre and greater than (n-1) x 0,01 metre,"]
+    #[doc = " * - `800 000` if the altitude  greater than 7 999,99 m,"]
+    #[doc = " * - `800 001` if the information is not available."]
+    #[doc = " *"]
+    #[doc = " * @note: the range of this DE does not use the full binary encoding range, but all reasonable values are covered. In order to cover all possible altitude ranges a larger encoding would be necessary."]
+    #[doc = " * @unit: 0,01 metre"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (definition of 800 000 has slightly changed) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-100000..=800001"))]
+    pub struct AltitudeValue(pub i32);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the angle confidence value which represents the estimated absolute accuracy of an angle value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `n` (`n > 0` and `n < 126`)  if the accuracy is equal to or less than n * 0,1 degrees and greater than (n-1) x * 0,1 degrees,"]
+    #[doc = " * - `126` if the  accuracy is out of range, i.e. greater than 12,5 degrees,"]
+    #[doc = " * - `127` if the accuracy information is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 degrees"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct AngleConfidence(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the angular acceleration confidence value which represents the estimated accuracy of an angular acceleration value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * For correlation computation, maximum interval levels shall be assumed."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `degSecSquared-01` - if the accuracy is equal to or less than 1 degree/second^2,"]
+    #[doc = " * - 1 - `degSecSquared-02` - if the accuracy is equal to or less than 2 degrees/second^2 and greater than 1 degree/second^2,"]
+    #[doc = " * - 2 - `degSecSquared-05` - if the accuracy is equal to or less than 5 degrees/second^2 and greater than 1 degree/second^2,"]
+    #[doc = " * - 3 - `degSecSquared-10` - if the accuracy is equal to or less than 10 degrees/second^2 and greater than 5 degrees/second^2,"]
+    #[doc = " * - 4 - `degSecSquared-20` - if the accuracy is equal to or less than 20 degrees/second^2 and greater than 10 degrees/second^2,"]
+    #[doc = " * - 5 - `degSecSquared-50` - if the accuracy is equal to or less than 50 degrees/second^2 and greater than 20 degrees/second^2,"]
+    #[doc = " * - 6 - `outOfRange`       - if the accuracy is out of range, i.e. greater than 50 degrees/second^2,"]
+    #[doc = " * - 7 - `unavailable`      - if the accuracy information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum AngularAccelerationConfidence {
+        #[rasn(identifier = "degSecSquared-01")]
+        degSecSquared_01 = 0,
+        #[rasn(identifier = "degSecSquared-02")]
+        degSecSquared_02 = 1,
+        #[rasn(identifier = "degSecSquared-05")]
+        degSecSquared_05 = 2,
+        #[rasn(identifier = "degSecSquared-10")]
+        degSecSquared_10 = 3,
+        #[rasn(identifier = "degSecSquared-20")]
+        degSecSquared_20 = 4,
+        #[rasn(identifier = "degSecSquared-50")]
+        degSecSquared_50 = 5,
+        outOfRange = 6,
+        unavailable = 7,
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates the angular speed confidence value which represents the estimated absolute accuracy of an angular speed value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * For correlation computation, maximum interval levels can be assumed."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `degSec-01`   - if the accuracy is equal to or less than 1 degree/second,"]
+    #[doc = " * - 1 - `degSec-02`   - if the accuracy is equal to or less than 2 degrees/second and greater than 1 degree/second,"]
+    #[doc = " * - 2 - `degSec-05`   - if the accuracy is equal to or less than 5 degrees/second and greater than 2 degrees/second,"]
+    #[doc = " * - 3 - `degSec-10`   - if the accuracy is equal to or less than 10 degrees/second and greater than 5 degrees/second,"]
+    #[doc = " * - 4 - `degSec-20`   - if the accuracy is equal to or less than 20 degrees/second and greater than 10 degrees/second,"]
+    #[doc = " * - 5 - `degSec-50`   - if the accuracy is equal to or less than 50 degrees/second and greater than 20 degrees/second,"]
+    #[doc = " * - 6 - `outOfRange`  - if the accuracy is out of range, i.e. greater than 50 degrees/second,"]
+    #[doc = " * - 7 - `unavailable` - if the accuracy information is unavailable."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum AngularSpeedConfidence {
+        #[rasn(identifier = "degSec-01")]
+        degSec_01 = 0,
+        #[rasn(identifier = "degSec-02")]
+        degSec_02 = 1,
+        #[rasn(identifier = "degSec-05")]
+        degSec_05 = 2,
+        #[rasn(identifier = "degSec-10")]
+        degSec_10 = 3,
+        #[rasn(identifier = "degSec-20")]
+        degSec_20 = 4,
+        #[rasn(identifier = "degSec-50")]
+        degSec_50 = 5,
+        outOfRange = 6,
+        unavailable = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the status of the controlling mechanisms for the lateral and combined lateral and longitudinal movements of the vehicle."]
+    #[doc = " * The data may be provided via the in-vehicle network. It indicates whether a specific in-vehicle"]
+    #[doc = " * acceleration control system combined with steering of the direction of the vehicle is engaged or not. "]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0  - `emergencySteeringSystemEngaged`       - emergency steering system is engaged,"]
+    #[doc = " * - 1  - `autonomousEmergencySteeringEngaged`   - autonomous emergency steering system is engaged,"]
+    #[doc = " * - 2  - `automaticLaneChangeEngaged`           - automatic lane change system is engaged,"]
+    #[doc = " * - 3  - `laneKeepingAssistEngaged`             - lane keeping assist is engaged,"]
+    #[doc = " * - 4  - `assistedParkingLateralEngaged`        - assisted parking system (lateral  control) is engaged,"]
+    #[doc = " * - 5  - `emergencyAssistEngaged`               - emergency assist (lateral and longitudinal control) is engaged."]
+    #[doc = " *"]
+    #[doc = " * Otherwise (for example when the corresponding system is not available due to non-equipped system or information is unavailable), "]
+    #[doc = " * the corresponding bit shall be set to 0. "]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("6", extensible))]
+    pub struct AutomationControl(pub BitString);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the number of axles of a passing train."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 2` and `n < 1001`) indicates that the train has n x axles,"]
+    #[doc = " * - `1001`indicates that the number of axles is out of range,"]
+    #[doc = " * - `1002` the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * "]
+    #[doc = " * @unit: Number of axles"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("2..=1002"))]
+    pub struct AxlesCount(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the measured uncompensated atmospheric pressure."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `2999` indicates that the applicable value is less than 29990 Pa,"]
+    #[doc = " * - `n` (`n > 2999` and `n <= 12000`) indicates that the applicable value is equal to or less than n x 10 Pa and greater than (n-1) x 10 Pa, "]
+    #[doc = " * - `12001` indicates that the values is greater than 120000 Pa,"]
+    #[doc = " * - `12002` indicates that the information is not available."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @unit: 10 Pascal"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("2999..=12002"))]
+    pub struct BarometricPressure(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DE represents a general container for usage in various types of messages."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field stationType: the type of technical context in which the ITS-S that has generated the message is integrated in."]
+    #[doc = " *"]
+    #[doc = " * @field referencePosition: the reference position of the station that has generated the message that contains the basic container."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct BasicContainer {
+        #[rasn(identifier = "stationType")]
+        pub station_type: TrafficParticipantType,
+        #[rasn(identifier = "referencePosition")]
+        pub reference_position: ReferencePositionWithConfidence,
+    }
+    impl BasicContainer {
+        pub fn new(
+            station_type: TrafficParticipantType,
+            reference_position: ReferencePositionWithConfidence,
+        ) -> Self {
+            Self {
+                station_type,
+                reference_position,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF provides information about the configuration of a road section in terms of lanes using a list of @ref LanePositionAndType ."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct BasicLaneConfiguration(pub SequenceOf<BasicLaneInformation>);
+    #[doc = "* "]
+    #[doc = " * This DF provides basic information about a single lane of a road segment."]
+    #[doc = " * It includes the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field laneNumber: the number associated to the lane that provides a transversal identification. "]
+    #[doc = " * "]
+    #[doc = " * @field direction: the direction of traffic flow allowed on the lane. "]
+    #[doc = " * "]
+    #[doc = " * @field laneWidth: the optional width of the lane."]
+    #[doc = " *"]
+    #[doc = " * @field connectingLane: the number of the connecting lane in the next road section, i.e. the number of the lane which the vehicle will use when travelling from one section to the next,"]
+    #[doc = " * if it does not actively change lanes. If this component is absent, the lane name number remains the same in the next section."]
+    #[doc = " *"]
+    #[doc = " * @field connectingRoadSection: the identifier of the next road section in direction of traffic, that is connecting to the current road section. "]
+    #[doc = " * If this component is absent, the connecting road section is the one following the instance where this DF is placed in the @ref RoadConfigurationSectionList."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct BasicLaneInformation {
+        #[rasn(identifier = "laneNumber")]
+        pub lane_number: LanePosition,
+        pub direction: Direction,
+        #[rasn(identifier = "laneWidth")]
+        pub lane_width: Option<LaneWidth>,
+        #[rasn(identifier = "connectingLane")]
+        pub connecting_lane: Option<LanePosition>,
+        #[rasn(identifier = "connectingRoadSection")]
+        pub connecting_road_section: Option<RoadSectionId>,
+    }
+    impl BasicLaneInformation {
+        pub fn new(
+            lane_number: LanePosition,
+            direction: Direction,
+            lane_width: Option<LaneWidth>,
+            connecting_lane: Option<LanePosition>,
+            connecting_road_section: Option<RoadSectionId>,
+        ) -> Self {
+            Self {
+                lane_number,
+                direction,
+                lane_width,
+                connecting_lane,
+                connecting_road_section,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the cardinal number of bogies of a train."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `n` (`n > 1` and `n < 100`) indicates that the train has n x bogies,"]
+    #[doc = " * - `100`indicates that the number of bogies is out of range, "]
+    #[doc = " * - `101` the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: Number of bogies"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("2..=101"))]
+    pub struct BogiesCount(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the status of the vehicleÂ´s brake control system during an externally defined period of time. "]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 `abs`        - the anti-lock braking system is engaged or has been engaged,"]
+    #[doc = " * - 1 `tcs`        - the traction control system is engaged or has been engaged,"]
+    #[doc = " * - 2 `esc`        - the electronic stability control system is engaged or has been engaged."]
+    #[doc = " *"]
+    #[doc = " * Otherwise (for example when the corresponding system is not available due to non equipped system"]
+    #[doc = " * or information is unavailable), the corresponding bit shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information "]
+    #[doc = " * @revision: created in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("3", extensible))]
+    pub struct BrakeControl(pub BitString);
+    #[doc = "*"]
+    #[doc = " * The DE represents a cardinal number that counts the size of a set. "]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct CardinalNumber1B(pub u8);
+    #[doc = "*"]
+    #[doc = " * The DE represents a cardinal number that counts the size of a set. "]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=8"))]
+    pub struct CardinalNumber3b(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DF represents a general Data Frame to describe an angle component along with a confidence value in a cartesian coordinate system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field value: The angle value which can be estimated as the mean of the current distribution."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: The confidence value associated to the provided value."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianAngle {
+        pub value: CartesianAngleValue,
+        pub confidence: AngleConfidence,
+    }
+    impl CartesianAngle {
+        pub fn new(value: CartesianAngleValue, confidence: AngleConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents an angle value described in a local Cartesian coordinate system, per default counted positive in"]
+    #[doc = " * a right-hand local coordinate system from the abscissa."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `n` (`n >= 0` and `n < 3600`) if the angle is equal to or less than n x 0,1 degrees, and greater than (n-1) x 0,1 degrees,"]
+    #[doc = " * - `3601` if the information is not available."]
+    #[doc = " *"]
+    #[doc = " * The value 3600 shall not be used. "]
+    #[doc = " * "]
+    #[doc = " * @unit 0,1 degrees"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1, description and value for 3601 corrected in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=3601"))]
+    pub struct CartesianAngleValue(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DF represents a general Data Frame to describe an angular acceleration component along with a confidence value in a cartesian coordinate system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field value: The angular acceleration component value."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: The confidence value associated to the provided value."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianAngularAccelerationComponent {
+        pub value: CartesianAngularAccelerationComponentValue,
+        pub confidence: AngularAccelerationConfidence,
+    }
+    impl CartesianAngularAccelerationComponent {
+        pub fn new(
+            value: CartesianAngularAccelerationComponentValue,
+            confidence: AngularAccelerationConfidence,
+        ) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents an angular acceleration value described in a local Cartesian coordinate system, per default counted positive in"]
+    #[doc = " * a right-hand local coordinate system from the abscissa."]
+    #[doc = " *"]
+    #[doc = "  * The value shall be set to: "]
+    #[doc = " * - `-255` if the acceleration is equal to or less than -255 degrees/s^2,"]
+    #[doc = " * - `n` (`n > -255` and `n < 255`) if the acceleration is equal to or less than n x 1 degree/s^2,"]
+    #[doc = "      and greater than `(n-1)` x 0,01 degree/s^2,"]
+    #[doc = " * - `255` if the acceleration is greater than 254 degrees/s^2,"]
+    #[doc = " * - `256` if the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit:  degree/s^2 (degrees per second squared)"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-255..=256"))]
+    pub struct CartesianAngularAccelerationComponentValue(pub i16);
+    #[doc = "* "]
+    #[doc = " * This DF represents an angular velocity component along with a confidence value in a cartesian coordinate system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field value: The angular velocity component."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: The confidence value associated to the provided value."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianAngularVelocityComponent {
+        pub value: CartesianAngularVelocityComponentValue,
+        pub confidence: AngularSpeedConfidence,
+    }
+    impl CartesianAngularVelocityComponent {
+        pub fn new(
+            value: CartesianAngularVelocityComponentValue,
+            confidence: AngularSpeedConfidence,
+        ) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents an angular velocity component described in a local Cartesian coordinate system, per default counted positive in"]
+    #[doc = " * a right-hand local coordinate system from the abscissa."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `-255` if the velocity is equal to or less than -255 degrees/s,"]
+    #[doc = " * - `n` (`n > -255` and `n < 255`) if the velocity is equal to or less than n x 1 degree/s, and greater than (n-1) x 1 degree/s,"]
+    #[doc = " * - `255` if the velocity is greater than 254 degrees/s,"]
+    #[doc = " * - `256` if the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: degree/s"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-255..=256"))]
+    pub struct CartesianAngularVelocityComponentValue(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DF represents the value of a cartesian coordinate with a range of -327,68 metres to +327,66 metres."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-32 768` if the longitudinal offset is out of range, i.e. less than or equal to -327,68 metres,"]
+    #[doc = " * - `n` (`n > -32 768` and `n < 32 767`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,"]
+    #[doc = " * - `32 767` if the longitudinal offset is out of range, i.e. greater than + 327,66 metres."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 m"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-32768..=32767"))]
+    pub struct CartesianCoordinate(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DF represents the value of a cartesian coordinate with a range of -1 310,72 metres to +1 310,70 metres."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-131072` if the longitudinal offset is out of range, i.e. less than or equal to -1 310,72 metres,"]
+    #[doc = " * - `n` (`n > 131 072` and `n < 131 071`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,"]
+    #[doc = " * - `131 071` if the longitudinal offset is out of range, i.e. greater than + 1 310,70 metres."]
+    #[doc = " *  "]
+    #[doc = " * @unit 0,01 m"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-131072..=131071"))]
+    pub struct CartesianCoordinateLarge(pub i32);
+    #[doc = "*"]
+    #[doc = " * This DF represents the value of a cartesian coordinate with a range of -30,94 metres to +10,00 metres."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `3094` if the longitudinal offset is out of range, i.e. less than or equal to -30,94 metres,"]
+    #[doc = " * - `n` (`n > -3 094` and `n < 1 001`) if the longitudinal offset information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,"]
+    #[doc = " * - `1001` if the longitudinal offset is out of range, i.e. greater than 10 metres."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 m"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-3094..=1001"))]
+    pub struct CartesianCoordinateSmall(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DF represents a coordinate along with a confidence value in a cartesian reference system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field value: the coordinate value, which can be estimated as the mean of the current distribution."]
+    #[doc = " * "]
+    #[doc = " * @field confidence: the coordinate confidence value associated to the provided value."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianCoordinateWithConfidence {
+        pub value: CartesianCoordinateLarge,
+        pub confidence: CoordinateConfidence,
+    }
+    impl CartesianCoordinateWithConfidence {
+        pub fn new(value: CartesianCoordinateLarge, confidence: CoordinateConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents a  position in a two- or three-dimensional cartesian coordinate system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field xCoordinate: the X coordinate value."]
+    #[doc = " *"]
+    #[doc = " * @field yCoordinate: the Y coordinate value."]
+    #[doc = " *"]
+    #[doc = " * @field zCoordinate: the optional Z coordinate value."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianPosition3d {
+        #[rasn(identifier = "xCoordinate")]
+        pub x_coordinate: CartesianCoordinate,
+        #[rasn(identifier = "yCoordinate")]
+        pub y_coordinate: CartesianCoordinate,
+        #[rasn(identifier = "zCoordinate")]
+        pub z_coordinate: Option<CartesianCoordinate>,
+    }
+    impl CartesianPosition3d {
+        pub fn new(
+            x_coordinate: CartesianCoordinate,
+            y_coordinate: CartesianCoordinate,
+            z_coordinate: Option<CartesianCoordinate>,
+        ) -> Self {
+            Self {
+                x_coordinate,
+                y_coordinate,
+                z_coordinate,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents a  position in a two- or three-dimensional cartesian coordinate system with an associated confidence level for each coordinate."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field xCoordinate: the X coordinate value with the associated confidence level."]
+    #[doc = " *"]
+    #[doc = " * @field yCoordinate: the Y coordinate value with the associated confidence level."]
+    #[doc = " *"]
+    #[doc = " * @field zCoordinate: the optional Z coordinate value with the associated confidence level."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CartesianPosition3dWithConfidence {
+        #[rasn(identifier = "xCoordinate")]
+        pub x_coordinate: CartesianCoordinateWithConfidence,
+        #[rasn(identifier = "yCoordinate")]
+        pub y_coordinate: CartesianCoordinateWithConfidence,
+        #[rasn(identifier = "zCoordinate")]
+        pub z_coordinate: Option<CartesianCoordinateWithConfidence>,
+    }
+    impl CartesianPosition3dWithConfidence {
+        pub fn new(
+            x_coordinate: CartesianCoordinateWithConfidence,
+            y_coordinate: CartesianCoordinateWithConfidence,
+            z_coordinate: Option<CartesianCoordinateWithConfidence>,
+        ) -> Self {
+            Self {
+                x_coordinate,
+                y_coordinate,
+                z_coordinate,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF is a representation of the cause code value of a traffic event. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field causeCode: the main cause of a detected event. "]
+    #[doc = " *"]
+    #[doc = " * @field subCauseCode: the subordinate cause of a detected event. "]
+    #[doc = " *"]
+    #[doc = " * The semantics of the entire DF are completely defined by the component causeCode. The interpretation of the subCauseCode may "]
+    #[doc = " * provide additional information that is not strictly necessary to understand the causeCode itself, and is therefore optional."]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref CauseCodeV2 instead. "]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CauseCode {
+        #[rasn(identifier = "causeCode")]
+        pub cause_code: CauseCodeType,
+        #[rasn(identifier = "subCauseCode")]
+        pub sub_cause_code: SubCauseCodeType,
+    }
+    impl CauseCode {
+        pub fn new(cause_code: CauseCodeType, sub_cause_code: SubCauseCodeType) -> Self {
+            Self {
+                cause_code,
+                sub_cause_code,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF is a representation of the cause code value and associated sub cause code value of a traffic event. "]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " * - 0                                                        - reserved for future use,"]
+    #[doc = " * - 1  - `trafficCondition1`                                 - in case the type of event is an abnormal traffic condition,"]
+    #[doc = " * - 2  - `accident2`                                         - in case the type of event is a road accident, "]
+    #[doc = " * - 3  - `roadworks3`                                        - in case the type of event is roadwork, based on authoritative information,"]
+    #[doc = " * - 4  - `detectedRoadworks4`                                - in case the type of event is roadworks, based on non-authoritative information such as factual detections,"]
+    #[doc = " * - 5  - `impassability5`                                    - in case the  type of event is unmanaged road blocking, referring to any"]
+    #[doc = " *                                                              blocking of a road, partial or total, which has not been adequately secured and signposted,"]
+    #[doc = " * - 6  - `adhesion6`                                         - in case the  type of event is low adhesion of the road surface,"]
+    #[doc = " * - 7  - `aquaplaning7`                                      - danger of aquaplaning on the road,"]
+    #[doc = " * - 8                                                        - reserved for future usage,"]
+    #[doc = " * - 9  - `hazardousLocation-SurfaceCondition9`               - in case the type of event is abnormal road surface condition not covered by `adhesion6`, "]
+    #[doc = " * - 10 - `hazardousLocation-ObstacleOnTheRoad10`             - in case the type of event is obstacle on the road,"]
+    #[doc = " * - 11 - `hazardousLocation-AnimalOnTheRoad11`               - in case the type of event is animal on the road,"]
+    #[doc = " * - 12 - `humanPresenceOnTheRoad`                            - in case the type of event is presence of human vulnerable road user on the road,"]
+    #[doc = " * - 13                                                       - reserved for future usage,"]
+    #[doc = " * - 14 - `wrongWayDriving14`                                 - in case the type of the event is vehicle driving in wrong way,"]
+    #[doc = " * - 15 - `rescueRecoveryAndMaintenanceWorkInProgress15`      - in case the type of event is rescue, recovery and maintenance work for accident or for a road hazard in progress,"]
+    #[doc = " * - 16                                                       - reserved for future usage,"]
+    #[doc = " * - 17 - `adverseWeatherCondition-Wind17`                    - in case the type of event is wind,"]
+    #[doc = " * - 18 - `adverseWeatherCondition-Visibility18`              - in case the type of event is low visibility,"]
+    #[doc = " * - 19 - `adverseWeatherCondition-Precipitation19`           - in case the type of event is precipitation,"]
+    #[doc = " * - 20 - `violence20`                                        - in case the the type of event is human violence on or near the road,"]
+    #[doc = " * - 21-25                                                    - reserved for future usage,"]
+    #[doc = " * - 26 - `slowVehicle26`                                     - in case the type of event is slow vehicle driving on the road,"]
+    #[doc = " * - 27 - `dangerousEndOfQueue27`                             - in case the type of event is dangerous end of vehicle queue,"]
+    #[doc = " * - 28 - `publicTransportVehicleApproaching                  - in case the type of event is a public transport vehicle approaching, with a priority defined by applicable traffic regulations,"]
+    #[doc = " * - 29-90                                                    - are reserved for future usage,"]
+    #[doc = " * - 91 - `vehicleBreakdown91`                                - in case the type of event is break down vehicle on the road,"]
+    #[doc = " * - 92 - `postCrash92`                                       - in case the type of event is a detected crash,"]
+    #[doc = " * - 93 - `humanProblem93`                                    - in case the type of event is human health problem in vehicles involved in traffic,"]
+    #[doc = " * - 94 - `stationaryVehicle94`                               - in case the type of event is stationary vehicle,"]
+    #[doc = " * - 95 - `emergencyVehicleApproaching95`                     - in case the type of event is an approaching vehicle operating on a mission for which the "]
+    #[doc = "                                                                applicable traffic regulations provide it with defined priority rights in traffic. "]
+    #[doc = " * - 96 - `hazardousLocation-DangerousCurve96`                - in case the type of event is dangerous curve,"]
+    #[doc = " * - 97 - `collisionRisk97`                                   - in case the type of event is a collision risk,"]
+    #[doc = " * - 98 - `signalViolation98`                                 - in case the type of event is signal violation,"]
+    #[doc = " * - 99 - `dangerousSituation99`                              - in case the type of event is dangerous situation in which autonomous safety system in vehicle "]
+    #[doc = " *                                                              is activated,"]
+    #[doc = " * - 100 - `railwayLevelCrossing100`                          - in case the type of event is a railway level crossing. "]
+    #[doc = " * - 101-255                                                  - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is defined for use as part of CauseCodeV2. It is recommended to use CauseCodeV2."]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Created in V2.1.1, the type of impassability5 changed to ImpassabilitySubCauseCode in V2.2.1, value 28 added in V2.2.1, definition of value 12 and 95 changed in V2.2.1"]
+    #[doc = " *            name and/or definition of values 3, 6, 9, 15 and 17 changed in V2.4.1, value 4 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum CauseCodeChoice {
+        reserved0(SubCauseCodeType),
+        trafficCondition1(TrafficConditionSubCauseCode),
+        accident2(AccidentSubCauseCode),
+        roadworks3(RoadworksSubCauseCode),
+        detectedRoadworks4(SubCauseCodeType),
+        impassability5(ImpassabilitySubCauseCode),
+        adhesion6(AdhesionSubCauseCode),
+        aquaplaning7(SubCauseCodeType),
+        reserved8(SubCauseCodeType),
+        #[rasn(identifier = "hazardousLocation-SurfaceCondition9")]
+        hazardousLocation_SurfaceCondition9(HazardousLocationSurfaceConditionSubCauseCode),
+        #[rasn(identifier = "hazardousLocation-ObstacleOnTheRoad10")]
+        hazardousLocation_ObstacleOnTheRoad10(HazardousLocationObstacleOnTheRoadSubCauseCode),
+        #[rasn(identifier = "hazardousLocation-AnimalOnTheRoad11")]
+        hazardousLocation_AnimalOnTheRoad11(HazardousLocationAnimalOnTheRoadSubCauseCode),
+        humanPresenceOnTheRoad12(HumanPresenceOnTheRoadSubCauseCode),
+        reserved13(SubCauseCodeType),
+        wrongWayDriving14(WrongWayDrivingSubCauseCode),
+        rescueRecoveryAndMaintenanceWorkInProgress15(
+            RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode,
+        ),
+        reserved16(SubCauseCodeType),
+        #[rasn(identifier = "adverseWeatherCondition-Wind17")]
+        adverseWeatherCondition_Wind17(AdverseWeatherConditionWindSubCauseCode),
+        #[rasn(identifier = "adverseWeatherCondition-Visibility18")]
+        adverseWeatherCondition_Visibility18(AdverseWeatherConditionVisibilitySubCauseCode),
+        #[rasn(identifier = "adverseWeatherCondition-Precipitation19")]
+        adverseWeatherCondition_Precipitation19(AdverseWeatherConditionPrecipitationSubCauseCode),
+        violence20(SubCauseCodeType),
+        reserved21(SubCauseCodeType),
+        reserved22(SubCauseCodeType),
+        reserved23(SubCauseCodeType),
+        reserved24(SubCauseCodeType),
+        reserved25(SubCauseCodeType),
+        slowVehicle26(SlowVehicleSubCauseCode),
+        dangerousEndOfQueue27(DangerousEndOfQueueSubCauseCode),
+        publicTransportVehicleApproaching28(SubCauseCodeType),
+        reserved29(SubCauseCodeType),
+        reserved30(SubCauseCodeType),
+        reserved31(SubCauseCodeType),
+        reserved32(SubCauseCodeType),
+        reserved33(SubCauseCodeType),
+        reserved34(SubCauseCodeType),
+        reserved35(SubCauseCodeType),
+        reserved36(SubCauseCodeType),
+        reserved37(SubCauseCodeType),
+        reserved38(SubCauseCodeType),
+        reserved39(SubCauseCodeType),
+        reserved40(SubCauseCodeType),
+        reserved41(SubCauseCodeType),
+        dontPanic42(SubCauseCodeType),
+        reserved43(SubCauseCodeType),
+        reserved44(SubCauseCodeType),
+        reserved45(SubCauseCodeType),
+        reserved46(SubCauseCodeType),
+        reserved47(SubCauseCodeType),
+        reserved48(SubCauseCodeType),
+        reserved49(SubCauseCodeType),
+        reserved50(SubCauseCodeType),
+        reserved51(SubCauseCodeType),
+        reserved52(SubCauseCodeType),
+        reserved53(SubCauseCodeType),
+        reserved54(SubCauseCodeType),
+        reserved55(SubCauseCodeType),
+        reserved56(SubCauseCodeType),
+        reserved57(SubCauseCodeType),
+        reserved58(SubCauseCodeType),
+        reserved59(SubCauseCodeType),
+        reserved60(SubCauseCodeType),
+        reserved61(SubCauseCodeType),
+        reserved62(SubCauseCodeType),
+        reserved63(SubCauseCodeType),
+        reserved64(SubCauseCodeType),
+        reserved65(SubCauseCodeType),
+        reserved66(SubCauseCodeType),
+        reserved67(SubCauseCodeType),
+        reserved68(SubCauseCodeType),
+        reserved69(SubCauseCodeType),
+        reserved70(SubCauseCodeType),
+        reserved71(SubCauseCodeType),
+        reserved72(SubCauseCodeType),
+        reserved73(SubCauseCodeType),
+        reserved74(SubCauseCodeType),
+        reserved75(SubCauseCodeType),
+        reserved76(SubCauseCodeType),
+        reserved77(SubCauseCodeType),
+        reserved78(SubCauseCodeType),
+        reserved79(SubCauseCodeType),
+        reserved80(SubCauseCodeType),
+        reserved81(SubCauseCodeType),
+        reserved82(SubCauseCodeType),
+        reserved83(SubCauseCodeType),
+        reserved84(SubCauseCodeType),
+        reserved85(SubCauseCodeType),
+        reserved86(SubCauseCodeType),
+        reserved87(SubCauseCodeType),
+        reserved88(SubCauseCodeType),
+        reserved89(SubCauseCodeType),
+        reserved90(SubCauseCodeType),
+        vehicleBreakdown91(VehicleBreakdownSubCauseCode),
+        postCrash92(PostCrashSubCauseCode),
+        humanProblem93(HumanProblemSubCauseCode),
+        stationaryVehicle94(StationaryVehicleSubCauseCode),
+        emergencyVehicleApproaching95(EmergencyVehicleApproachingSubCauseCode),
+        #[rasn(identifier = "hazardousLocation-DangerousCurve96")]
+        hazardousLocation_DangerousCurve96(HazardousLocationDangerousCurveSubCauseCode),
+        collisionRisk97(CollisionRiskSubCauseCode),
+        signalViolation98(SignalViolationSubCauseCode),
+        dangerousSituation99(DangerousSituationSubCauseCode),
+        railwayLevelCrossing100(RailwayLevelCrossingSubCauseCode),
+        reserved101(SubCauseCodeType),
+        reserved102(SubCauseCodeType),
+        reserved103(SubCauseCodeType),
+        reserved104(SubCauseCodeType),
+        reserved105(SubCauseCodeType),
+        reserved106(SubCauseCodeType),
+        reserved107(SubCauseCodeType),
+        reserved108(SubCauseCodeType),
+        reserved109(SubCauseCodeType),
+        reserved110(SubCauseCodeType),
+        reserved111(SubCauseCodeType),
+        reserved112(SubCauseCodeType),
+        reserved113(SubCauseCodeType),
+        reserved114(SubCauseCodeType),
+        reserved115(SubCauseCodeType),
+        reserved116(SubCauseCodeType),
+        reserved117(SubCauseCodeType),
+        reserved118(SubCauseCodeType),
+        reserved119(SubCauseCodeType),
+        reserved120(SubCauseCodeType),
+        reserved121(SubCauseCodeType),
+        reserved122(SubCauseCodeType),
+        reserved123(SubCauseCodeType),
+        reserved124(SubCauseCodeType),
+        reserved125(SubCauseCodeType),
+        reserved126(SubCauseCodeType),
+        reserved127(SubCauseCodeType),
+        reserved128(SubCauseCodeType),
+    }
+    #[doc = "*"]
+    #[doc = " *The DE represents the value of the cause code of an event. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0                                                     - reserved for future use,"]
+    #[doc = " * - 1  - `trafficCondition`                               - in case the type of event is an abnormal traffic condition,"]
+    #[doc = " * - 2  - `accident`                                       - in case the type of event is a road accident,"]
+    #[doc = " * - 3  - `roadworks`                                      - in case the type of event is roadworks, based on authoritative information,"]
+    #[doc = " * - 4  - `detectedRoadworks`                              - in case the type of event is roadworks, based on non-authoritative information such as factual detections, "]
+    #[doc = " * - 5  - `impassability`                                  - in case the  type of event is unmanaged road blocking, referring to any"]
+    #[doc = " *                                                           blocking of a road, partial or total, which has not been adequately"]
+    #[doc = " *                                                           secured and signposted,"]
+    #[doc = " * - 6  - `adhesion`                                       - in case the  type of event is low adhesion of the road surface,"]
+    #[doc = " * - 7  - `aquaplaning`                                    - danger of aquaplaning on the road,"]
+    #[doc = " * - 8                                                     - reserved for future usage,"]
+    #[doc = " * - 9  - `hazardousLocation-SurfaceCondition`             - in case the type of event is abnormal road surface condition not covered by `adhesion`"]
+    #[doc = " * - 10 - `hazardousLocation-ObstacleOnTheRoad`            - in case the type of event is obstacle on the road,"]
+    #[doc = " * - 11 - `hazardousLocation-AnimalOnTheRoad`              - in case the type of event is animal on the road,"]
+    #[doc = " * - 12 - `humanPresenceOnTheRoad`                         - in case the type of event is presence of human vulnerable road user on the road,"]
+    #[doc = " * - 13                                                    - reserved for future usage,"]
+    #[doc = " * - 14 - `wrongWayDriving`                                - in case the type of the event is vehicle driving in wrong way,"]
+    #[doc = " * - 15 - `rescueRecoveryAndMaintenanceWorkInProgress`     - in case the type of event is rescue, recovery and maintenance work for accident or for a road hazard in progress,"]
+    #[doc = " * - 16                                                    - reserved for future usage,"]
+    #[doc = " * - 17 - `adverseWeatherCondition-Wind                   `- in case the type of event is wind,"]
+    #[doc = " * - 18 - `adverseWeatherCondition-Visibility`             - in case the type of event is low visibility,"]
+    #[doc = " * - 19 - `adverseWeatherCondition-Precipitation`          - in case the type of event is precipitation,"]
+    #[doc = " * - 20 - `violence`                                       - in case the the type of event is human violence on or near the road,"]
+    #[doc = " * - 21-25                                                 - reserved for future usage,"]
+    #[doc = " * - 26 - `slowVehicle`                                    - in case the type of event is slow vehicle driving on the road,"]
+    #[doc = " * - 27 - `dangerousEndOfQueue`                            - in case the type of event is dangerous end of vehicle queue,"]
+    #[doc = " * - 28 - `publicTransportVehicleApproaching               - in case the type of event is a public transport vehicle approaching, with a priority defined by applicable traffic regulations,"]
+    #[doc = " * - 29-90                                                 - are reserved for future usage,"]
+    #[doc = " * - 91 - `vehicleBreakdown`                               - in case the type of event is break down vehicle on the road,"]
+    #[doc = " * - 92 - `postCrash`                                      - in case the type of event is a detected crash,"]
+    #[doc = " * - 93 - `humanProblem`                                   - in case the type of event is human health problem in vehicles involved in traffic,"]
+    #[doc = " * - 94 - `stationaryVehicle`                              - in case the type of event is stationary vehicle,"]
+    #[doc = " * - 95 - `emergencyVehicleApproaching`                    - in case the type of event is an approaching vehicle operating on a mission for which the applicable "]
+    #[doc = "                                                             traffic regulations provide it with defined priority rights in traffic. "]
+    #[doc = " * - 96 - `hazardousLocation-DangerousCurve`               - in case the type of event is dangerous curve,"]
+    #[doc = " * - 97 - `collisionRisk`                                  - in case the type of event is a collision risk,"]
+    #[doc = " * - 98 - `signalViolation`                                - in case the type of event is signal violation,"]
+    #[doc = " * - 99 - `dangerousSituation`                             - in case the type of event is dangerous situation in which autonomous safety system in vehicle "]
+    #[doc = " *                                                             is activated,"]
+    #[doc = " * - 100 - `railwayLevelCrossing`                          - in case the type of event is a railway level crossing. "]
+    #[doc = " * - 101-255                                               - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 20 and 100 added in V2.1.1, value 28 added in V2.2.1, definition of values 12 and 95 changed in V2.2.1,"]
+    #[doc = " *            name and/or definition of values 3, 6, 9, 15 and 17 changed in V2.4.1, value 4 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct CauseCodeType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF is an alternative representation of the cause code value of a traffic event. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field ccAndScc: the main cause of a detected event. Each entry is of a different type and represents the sub cause code."]
+    #[doc = ""]
+    #[doc = " * The semantics of the entire DF are completely defined by the choice value which represents the cause code value. "]
+    #[doc = " * The interpretation of the sub cause code value may provide additional information that is not strictly necessary to understand "]
+    #[doc = " * the cause code itself, and is therefore optional."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Created in V2.1.1, description amended in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CauseCodeV2 {
+        #[rasn(identifier = "ccAndScc")]
+        pub cc_and_scc: CauseCodeChoice,
+    }
+    impl CauseCodeV2 {
+        pub fn new(cc_and_scc: CauseCodeChoice) -> Self {
+            Self { cc_and_scc }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * The DF describes the position of a CEN DSRC road side equipment."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneLatitude: the latitude of the CEN DSRC road side equipment."]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneLongitude: the latitude of the CEN DSRC road side equipment. "]
+    #[doc = " * "]
+    #[doc = " * @field cenDsrcTollingZoneID: the optional ID of the CEN DSRC road side equipment."]
+    #[doc = " * "]
+    #[doc = " * @category: Infrastructure information, Communication information"]
+    #[doc = " * @revision: revised in V2.1.1 (cenDsrcTollingZoneId is directly of type ProtectedZoneId)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CenDsrcTollingZone {
+        #[rasn(identifier = "protectedZoneLatitude")]
+        pub protected_zone_latitude: Latitude,
+        #[rasn(identifier = "protectedZoneLongitude")]
+        pub protected_zone_longitude: Longitude,
+        #[rasn(identifier = "cenDsrcTollingZoneId")]
+        pub cen_dsrc_tolling_zone_id: Option<ProtectedZoneId>,
+    }
+    impl CenDsrcTollingZone {
+        pub fn new(
+            protected_zone_latitude: Latitude,
+            protected_zone_longitude: Longitude,
+            cen_dsrc_tolling_zone_id: Option<ProtectedZoneId>,
+        ) -> Self {
+            Self {
+                protected_zone_latitude,
+                protected_zone_longitude,
+                cen_dsrc_tolling_zone_id,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the ID of a CEN DSRC tolling zone. "]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " * @note: this DE is deprecated and shall not be used anymore.  "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct CenDsrcTollingZoneID(pub ProtectedZoneId);
+    #[doc = "* "]
+    #[doc = " * "]
+    #[doc = " * This DF represents the shape of a circular area or a right cylinder that is centred on the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field shapeReferencePoint: optional reference point that represents the centre of the circle, relative to an externally specified reference position. "]
+    #[doc = " * If this component is absent, the externally specified reference position represents the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field radius: the radius of the circular area."]
+    #[doc = " *"]
+    #[doc = " * @field height: the optional height, present if the shape is a right cylinder extending in the positive z-axis. "]
+    #[doc = " *"]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CircularShape {
+        #[rasn(identifier = "shapeReferencePoint")]
+        pub shape_reference_point: Option<CartesianPosition3d>,
+        pub radius: StandardLength12b,
+        pub height: Option<StandardLength12b>,
+    }
+    impl CircularShape {
+        pub fn new(
+            shape_reference_point: Option<CartesianPosition3d>,
+            radius: StandardLength12b,
+            height: Option<StandardLength12b>,
+        ) -> Self {
+            Self {
+                shape_reference_point,
+                radius,
+                height,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF indicates the opening/closure status of the lanes of a carriageway."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field innerhardShoulderStatus: this information is optional and shall be included if an inner hard shoulder is present and the information is known."]
+    #[doc = " * It indicates the open/closing status of inner hard shoulder lanes. "]
+    #[doc = " * "]
+    #[doc = " * @field outerhardShoulderStatus: this information is optional and shall be included if an outer hard shoulder is present and the information is known."]
+    #[doc = " * It indicates the open/closing status of outer hard shoulder lanes. "]
+    #[doc = " * "]
+    #[doc = " * @field drivingLaneStatus: this information is optional and shall be included if the information is known."]
+    #[doc = " * It indicates the open/closing status of driving lanes. "]
+    #[doc = " * For carriageways with more than 13 driving lanes, the drivingLaneStatus component shall not be present."]
+    #[doc = " * "]
+    #[doc = " * @category: Infrastructure information, Road topology information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClosedLanes {
+        #[rasn(identifier = "innerhardShoulderStatus")]
+        pub innerhard_shoulder_status: Option<HardShoulderStatus>,
+        #[rasn(identifier = "outerhardShoulderStatus")]
+        pub outerhard_shoulder_status: Option<HardShoulderStatus>,
+        #[rasn(identifier = "drivingLaneStatus")]
+        pub driving_lane_status: Option<DrivingLaneStatus>,
+    }
+    impl ClosedLanes {
+        pub fn new(
+            innerhard_shoulder_status: Option<HardShoulderStatus>,
+            outerhard_shoulder_status: Option<HardShoulderStatus>,
+            driving_lane_status: Option<DrivingLaneStatus>,
+        ) -> Self {
+            Self {
+                innerhard_shoulder_status,
+                outerhard_shoulder_status,
+                driving_lane_status,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF provides information about the breakup of a cluster."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field clusterBreakupReason: indicates the reason for breakup."]
+    #[doc = " * "]
+    #[doc = " * @field breakupTime: indicates the time of breakup. "]
+    #[doc = " *"]
+    #[doc = " * @category: Cluster Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClusterBreakupInfo {
+        #[rasn(identifier = "clusterBreakupReason")]
+        pub cluster_breakup_reason: ClusterBreakupReason,
+        #[rasn(identifier = "breakupTime")]
+        pub breakup_time: DeltaTimeQuarterSecond,
+    }
+    impl ClusterBreakupInfo {
+        pub fn new(
+            cluster_breakup_reason: ClusterBreakupReason,
+            breakup_time: DeltaTimeQuarterSecond,
+        ) -> Self {
+            Self {
+                cluster_breakup_reason,
+                breakup_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the reason why a cluster leader intends to break up the cluster."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `notProvided`                          - if the information is not provided,"]
+    #[doc = " * - 1 - `clusteringPurposeCompleted`           - if the cluster purpose has been completed,"]
+    #[doc = " * - 2 - `leaderMovedOutOfClusterBoundingBox`   - if the leader moved out of the cluster's bounding box,"]
+    #[doc = " * - 3 - `joiningAnotherCluster`                - if the cluster leader is about to join another cluster,"]
+    #[doc = " * - 4 - `enteringLowRiskAreaBasedOnMaps`       - if the cluster is entering an area idenrified as low risk based on the use of maps,"]
+    #[doc = " * - 5 - `receptionOfCpmContainingCluster`      - if the leader received a Collective Perception Message containing information about the same cluster. "]
+    #[doc = " * - 6 to 15                                    - are reserved for future use.                                    "]
+    #[doc = " *"]
+    #[doc = " * @category: Cluster information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct ClusterBreakupReason(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF provides information about the joining of a cluster."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field clusterId: indicates the identifier of the cluster."]
+    #[doc = " * "]
+    #[doc = " * @field joinTime: indicates the time of joining. "]
+    #[doc = " *"]
+    #[doc = " * @category: Cluster Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClusterJoinInfo {
+        #[rasn(identifier = "clusterId")]
+        pub cluster_id: Identifier1B,
+        #[rasn(identifier = "joinTime")]
+        pub join_time: DeltaTimeQuarterSecond,
+    }
+    impl ClusterJoinInfo {
+        pub fn new(cluster_id: Identifier1B, join_time: DeltaTimeQuarterSecond) -> Self {
+            Self {
+                cluster_id,
+                join_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * The DF provides information about the leaving of a cluster."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field clusterId: indicates the cluster."]
+    #[doc = " * "]
+    #[doc = " * @field clusterLeaveReason: indicates the reason for leaving. "]
+    #[doc = " *"]
+    #[doc = " * @category: Cluster Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClusterLeaveInfo {
+        #[rasn(identifier = "clusterId")]
+        pub cluster_id: Identifier1B,
+        #[rasn(identifier = "clusterLeaveReason")]
+        pub cluster_leave_reason: ClusterLeaveReason,
+    }
+    impl ClusterLeaveInfo {
+        pub fn new(cluster_id: Identifier1B, cluster_leave_reason: ClusterLeaveReason) -> Self {
+            Self {
+                cluster_id,
+                cluster_leave_reason,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the reason why a cluster participant is leaving the cluster."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `notProvided `                 - if the information is not provided,"]
+    #[doc = " * - 1 - `clusterLeaderLost`            - if the cluster leader cannot be found anymore,   "]
+    #[doc = " * - 2 - `clusterDisbandedByLeader`     - if the cluster has been disbanded by the leader,"]
+    #[doc = " * - 3 - `outOfClusterBoundingBox`      - if the participants moved out of the cluster's bounding box,"]
+    #[doc = " * - 4 - `outOfClusterSpeedRange`       - if the cluster speed moved out of a defined range, "]
+    #[doc = " * - 5 - `joiningAnotherCluster`        - if the participant is joining another cluster,"]
+    #[doc = " * - 6 - `cancelledJoin`                - if the participant is cancelling a joining procedure,"]
+    #[doc = " * - 7 - `failedJoin`                   - if the participant failed to join the cluster,"]
+    #[doc = " * - 8 - `safetyCondition`              - if a safety condition applies."]
+    #[doc = " * - 9 to 15                            - are reserved for future use                             "]
+    #[doc = " *"]
+    #[doc = " * @category: Cluster information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct ClusterLeaveReason(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the sub cause codes of the @ref CauseCode `collisionRisk`."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                    - in case information on the type of collision risk is unavailable,"]
+    #[doc = " * - 1 - `longitudinalCollisionRisk`      - in case the type of detected collision risk is longitudinal collision risk, "]
+    #[doc = " *                                          e.g. forward collision or face to face collision,"]
+    #[doc = " * - 2 - `crossingCollisionRisk`          - in case the type of detected collision risk is crossing collision risk,"]
+    #[doc = " * - 3 - `lateralCollisionRisk`           - in case the type of detected collision risk is lateral collision risk,"]
+    #[doc = " * - 4 - `vulnerableRoadUser`             - in case the type of detected collision risk involves vulnerable road users"]
+    #[doc = " *                                          e.g. pedestrians or bicycles."]
+    #[doc = " * - 5 - `collisionRiskWithPedestrian`    - in case the type of detected collision risk involves at least one pedestrian, "]
+    #[doc = " * - 6 - `collisionRiskWithCyclist`       - in case the type of detected collision risk involves at least one cyclist (and no pedestrians),"]
+    #[doc = " * - 7 - `collisionRiskWithMotorVehicle`  - in case the type of detected collision risk involves at least one motor vehicle (and no pedestrians or cyclists),"]
+    #[doc = " * - 8 - `erraticDriving`                 - in case the collision risk is due a vehicle exhibiting inconsistent and unpredictable actions like swerving, abrupt lane changes, and inconsistent speed."]
+    #[doc = " * - 9 - `recklessDriving`                - in case the collision risk is due a vehicle exhibiting aggressive manoeuvres like tailgating and sudden lane changes and which ignores traffic rules. "]
+    #[doc = " * - 10-255                               - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, values 5-7 assigned in V2.2.1, values 8-9 added in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct CollisionRiskSubCauseCode(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents a confidence level in percentage."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 101`) : for the confidence level in %,"]
+    #[doc = " * - `101`                   : in case the confidence level is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit Percent "]
+    #[doc = " * @category: Basic information "]
+    #[doc = " * @revision: Created in V2.1.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=101"))]
+    pub struct ConfidenceLevel(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DF shall contain a list of @ref ConfidenceLevel."]
+    #[doc = "*"]
+    #[doc = "* @category: Basic information"]
+    #[doc = "* @revision: created in V2.3.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32", extensible))]
+    pub struct ConfidenceLevels(pub SequenceOf<ConfidenceLevel>);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the coordinate confidence value which represents the estimated absolute accuracy of a position coordinate with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `n` (`n > 0` and `n < 4095`) if the confidence value is is equal to or less than n x 0,01 metre, and greater than (n-1) x 0,01 metre,"]
+    #[doc = " * - `4095` if the confidence value is greater than 40,94 metres,"]
+    #[doc = " * - `4096` if the confidence value is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 m"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4096"))]
+    pub struct CoordinateConfidence(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DE represents the Bravais-Pearson correlation value for each cell of a lower triangular correlation matrix."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `-100` in case of full negative correlation,"]
+    #[doc = " * - `n` (`n > -100` and `n < 0`) if the correlation is negative and equal to n/100,"]
+    #[doc = " * - `0` in case of no correlation,"]
+    #[doc = " * - `n` (`n > 0` and `n < 100`) if the correlation is positive and equal to n/100,"]
+    #[doc = " * - `100` in case of full positive correlation,"]
+    #[doc = " * - `101` in case the correlation information is unavailable. "]
+    #[doc = " *"]
+    #[doc = " * @unit: the value is scaled by 100"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1, corrected the value to n/100 on V2.4.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-100..=101"))]
+    pub struct CorrelationCellValue(pub i8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a column of a lower triangular positive semi-definite matrix and consists of a list of correlation cell values ordered by rows."]
+    #[doc = " * Given a matrix \"A\" of size n x n, the number of columns to be included in the lower triangular matrix is k=n-1."]
+    #[doc = " * Each column \"i\" of the lower triangular matrix then contains k-(i-1) values (ordered by rows from 1 to n-1), where \"i\" refers to the column number count"]
+    #[doc = " * starting at 1 from the left."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=13", extensible))]
+    pub struct CorrelationColumn(pub SequenceOf<CorrelationCellValue>);
+    #[doc = "* "]
+    #[doc = " * This DE represents an ISO 3166-1 [25] country code encoded using ITA-2 encoding."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1 based on ISO 14816 [23]"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct CountryCode(pub FixedBitString<10usize>);
+    #[doc = "*"]
+    #[doc = " * This DF represents the curvature of the vehicle trajectory and the associated confidence value."]
+    #[doc = " * The curvature detected by a vehicle represents the curvature of actual vehicle trajectory."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field curvatureValue: Detected curvature of the vehicle trajectory."]
+    #[doc = " * "]
+    #[doc = " * @field curvatureConfidence: along with a confidence value of the curvature value with a predefined confidence level. "]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Curvature {
+        #[rasn(identifier = "curvatureValue")]
+        pub curvature_value: CurvatureValue,
+        #[rasn(identifier = "curvatureConfidence")]
+        pub curvature_confidence: CurvatureConfidence,
+    }
+    impl Curvature {
+        pub fn new(
+            curvature_value: CurvatureValue,
+            curvature_confidence: CurvatureConfidence,
+        ) -> Self {
+            Self {
+                curvature_value,
+                curvature_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * The DE describes whether the yaw rate is used to calculate the curvature for a curvature value."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `yawRateUsed`    - if the yaw rate is used,"]
+    #[doc = " * - 1 - `yawRateNotUsed` - if the yaw rate is not used,"]
+    #[doc = " * - 2 - `unavailable`    - if the information of curvature calculation mode is unknown."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum CurvatureCalculationMode {
+        yawRateUsed = 0,
+        yawRateNotUsed = 1,
+        unavailable = 2,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the acceleration confidence value which represents the estimated absolute accuracy range of a curvature value with a confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `onePerMeter-0-00002` - if the confidence value is less than or equal to 0,00002 m-1,"]
+    #[doc = " * - 1 - `onePerMeter-0-0001`  - if the confidence value is less than or equal to 0,0001 m-1 and greater than 0,00002 m-1,"]
+    #[doc = " * - 2 - `onePerMeter-0-0005`  - if the confidence value is less than or equal to 0,0005 m-1 and greater than 0,0001 m-1,"]
+    #[doc = " * - 3 - `onePerMeter-0-002`   - if the confidence value is less than or equal to 0,002 m-1 and greater than 0,0005 m-1,"]
+    #[doc = " * - 4 - `nePerMeter-0-01`     - if the confidence value is less than or equal to 0,01 m-1 and greater than 0,002 m-1,"]
+    #[doc = " * - 5 - `nePerMeter-0-1`      - if the confidence value is less than or equal to 0,1 m-1  and greater than 0,01 m-1,"]
+    #[doc = " * - 6 - `outOfRange`          - if the confidence value is out of range, i.e. greater than 0,1 m-1,"]
+    #[doc = " * - 7 - `unavailable`         - if the confidence value is not available."]
+    #[doc = " * "]
+    #[doc = " * @note:\tThe fact that a curvature value is received with confidence value set to `unavailable(7)` can be caused by"]
+    #[doc = " * several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the curvature value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * @note: If a curvature value is received and its confidence value is set to `outOfRange(6)`, it means that the curvature value is not valid "]
+    #[doc = " * and therefore cannot be trusted. Such value is not useful for the application."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum CurvatureConfidence {
+        #[rasn(identifier = "onePerMeter-0-00002")]
+        onePerMeter_0_00002 = 0,
+        #[rasn(identifier = "onePerMeter-0-0001")]
+        onePerMeter_0_0001 = 1,
+        #[rasn(identifier = "onePerMeter-0-0005")]
+        onePerMeter_0_0005 = 2,
+        #[rasn(identifier = "onePerMeter-0-002")]
+        onePerMeter_0_002 = 3,
+        #[rasn(identifier = "onePerMeter-0-01")]
+        onePerMeter_0_01 = 4,
+        #[rasn(identifier = "onePerMeter-0-1")]
+        onePerMeter_0_1 = 5,
+        outOfRange = 6,
+        unavailable = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE describes vehicle turning curve with the following information:"]
+    #[doc = " * ```"]
+    #[doc = " *     Value = 1 / Radius * 10000"]
+    #[doc = " * ```"]
+    #[doc = " * wherein radius is the vehicle turning curve radius in metres. "]
+    #[doc = " * "]
+    #[doc = " * Positive values indicate a turning curve to the left hand side of the driver."]
+    #[doc = " * It corresponds to the vehicle coordinate system as defined in ISO 8855 [21]."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-1023` for  values smaller than -1023,"]
+    #[doc = " * - `n` (`n > -1023` and `n < 0`) for negative values equal to or less than `n`, and greater than `(n-1)`,"]
+    #[doc = " * - `0` when the vehicle is moving straight,"]
+    #[doc = " * - `n` (`n > 0` and `n < 1022`) for positive values equal to or less than `n`, and greater than `(n-1)`,"]
+    #[doc = " * - `1022`, for values  greater than 1021,"]
+    #[doc = " * - `1023`, if the information is not available."]
+    #[doc = " * "]
+    #[doc = " * @note: The present DE is limited to vehicle types as defined in ISO 8855 [21]."]
+    #[doc = " * "]
+    #[doc = " * @unit: 1 over 10 000 metres"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: description revised in V2.1.1 (the definition of value 1022 has changed slightly)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-1023..=1023"))]
+    pub struct CurvatureValue(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `dangerousEndOfQueue`. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`     - in case information on the type of dangerous queue is unavailable,"]
+    #[doc = " * - 1 - `suddenEndOfQueue`- in case a sudden end of queue is detected, e.g. due to accident or obstacle,"]
+    #[doc = " * - 2 - `queueOverHill`   - in case the dangerous end of queue is detected on the road hill,"]
+    #[doc = " * - 3 - `queueAroundBend` - in case the dangerous end of queue is detected around the road bend,"]
+    #[doc = " * - 4 - `queueInTunnel`   - in case queue is detected in tunnel,"]
+    #[doc = " * - 5-255                 - reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct DangerousEndOfQueueSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the type of the dangerous goods being carried by a heavy vehicle."]
+    #[doc = " * The value is assigned according to `class` and `division` definitions of dangerous goods as specified in part II,"]
+    #[doc = " * chapter 2.1.1.1 of European Agreement concerning the International Carriage of Dangerous Goods by Road [3]."]
+    #[doc = " * "]
+    #[doc = " * "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum DangerousGoodsBasic {
+        explosives1 = 0,
+        explosives2 = 1,
+        explosives3 = 2,
+        explosives4 = 3,
+        explosives5 = 4,
+        explosives6 = 5,
+        flammableGases = 6,
+        nonFlammableGases = 7,
+        toxicGases = 8,
+        flammableLiquids = 9,
+        flammableSolids = 10,
+        substancesLiableToSpontaneousCombustion = 11,
+        substancesEmittingFlammableGasesUponContactWithWater = 12,
+        oxidizingSubstances = 13,
+        organicPeroxides = 14,
+        toxicSubstances = 15,
+        infectiousSubstances = 16,
+        radioactiveMaterial = 17,
+        corrosiveSubstances = 18,
+        miscellaneousDangerousSubstances = 19,
+    }
+    #[doc = "*"]
+    #[doc = " * This DF provides a description of dangerous goods being carried by a heavy vehicle."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field dangerousGoodsType: Type of dangerous goods."]
+    #[doc = " * "]
+    #[doc = " * @field unNumber: a 4-digit number that identifies the substance of the dangerous goods as specified in"]
+    #[doc = " * United Nations Recommendations on the Transport of Dangerous Goods - Model Regulations [4],"]
+    #[doc = " * "]
+    #[doc = " * @field elevatedTemperature: whether the carried dangerous goods are transported at high temperature."]
+    #[doc = " * If yes, the value shall be set to TRUE,"]
+    #[doc = " * "]
+    #[doc = " * @field tunnelsRestricted: whether the heavy vehicle carrying dangerous goods is restricted to enter tunnels."]
+    #[doc = " * If yes, the value shall be set to TRUE,"]
+    #[doc = " * "]
+    #[doc = " * @field limitedQuantity: whether the carried dangerous goods are packed with limited quantity."]
+    #[doc = " * If yes, the value shall be set to TRUE,"]
+    #[doc = " * "]
+    #[doc = " * @field emergencyActionCode: physical signage placard at the vehicle that carries information on how an emergency"]
+    #[doc = " * service should deal with an incident. This component is optional; it shall be present if the information is available."]
+    #[doc = " * "]
+    #[doc = " * @field phoneNumber: contact phone number of assistance service in case of incident or accident."]
+    #[doc = " * This component is optional, it shall be present if the information is available."]
+    #[doc = " * "]
+    #[doc = " * @field companyName: name of company that manages the transportation of the dangerous goods."]
+    #[doc = " * This component is optional; it shall be present if the information is available."]
+    #[doc = " * "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DangerousGoodsExtended {
+        #[rasn(identifier = "dangerousGoodsType")]
+        pub dangerous_goods_type: DangerousGoodsBasic,
+        #[rasn(value("0..=9999"), identifier = "unNumber")]
+        pub un_number: u16,
+        #[rasn(identifier = "elevatedTemperature")]
+        pub elevated_temperature: bool,
+        #[rasn(identifier = "tunnelsRestricted")]
+        pub tunnels_restricted: bool,
+        #[rasn(identifier = "limitedQuantity")]
+        pub limited_quantity: bool,
+        #[rasn(size("1..=24"), identifier = "emergencyActionCode")]
+        pub emergency_action_code: Option<Ia5String>,
+        #[rasn(identifier = "phoneNumber")]
+        pub phone_number: Option<PhoneNumber>,
+        #[rasn(identifier = "companyName")]
+        pub company_name: Option<Utf8String>,
+    }
+    impl DangerousGoodsExtended {
+        pub fn new(
+            dangerous_goods_type: DangerousGoodsBasic,
+            un_number: u16,
+            elevated_temperature: bool,
+            tunnels_restricted: bool,
+            limited_quantity: bool,
+            emergency_action_code: Option<Ia5String>,
+            phone_number: Option<PhoneNumber>,
+            company_name: Option<Utf8String>,
+        ) -> Self {
+            Self {
+                dangerous_goods_type,
+                un_number,
+                elevated_temperature,
+                tunnels_restricted,
+                limited_quantity,
+                emergency_action_code,
+                phone_number,
+                company_name,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `dangerousSituation` "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                      - in case information on the type of dangerous situation is unavailable,"]
+    #[doc = " * - 1 - `emergencyElectronicBrakeEngaged`  - in case emergency electronic brake is engaged,"]
+    #[doc = " * - 2 - `preCrashSystemEngaged`            - in case pre-crash system is engaged,"]
+    #[doc = " * - 3 - `espEngaged`                       - in case Electronic Stability Program (ESP) system is engaged,"]
+    #[doc = " * - 4 - `absEngaged`                       - in case Anti-lock Braking System (ABS) is engaged,"]
+    #[doc = " * - 5 - `aebEngaged`                       - in case Autonomous Emergency Braking (AEB) system is engaged,"]
+    #[doc = " * - 6 - `brakeWarningEngaged`              - in case brake warning is engaged,"]
+    #[doc = " * - 7 - `collisionRiskWarningEngaged`      - in case collision risk warning is engaged,"]
+    #[doc = " * - 8 - `riskMitigationFunctionEngaged`    - in case the Risk Mitigation Function according to UNECE Regulation 79 is engaged,"]
+    #[doc = " * - 9-255                                  - reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 8 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct DangerousSituationSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents an offset altitude with regards to a defined altitude value."]
+    #[doc = " * It may be used to describe a geographical point with regards to a specific reference geographical position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-12 700` for values equal to or lower than -127 metres,"]
+    #[doc = " * - `n` (`n > -12 700` and `n <= 0`) for altitude offset n x 0,01 metre below the reference position,"]
+    #[doc = " * - `0` for no altitudinal offset,"]
+    #[doc = " * - `n` (`n > 0` and `n < 12799`) for altitude offset n x 0,01 metre above the reference position,"]
+    #[doc = " * - `12 799` for values equal to or greater than 127,99 metres,"]
+    #[doc = " * - `12 800` when the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,01 metre"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-12700..=12800"))]
+    pub struct DeltaAltitude(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DE represents an offset latitude with regards to a defined latitude value."]
+    #[doc = " * It may be used to describe a geographical point with regards to a specific reference geographical position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= -131 071` and `n < 0`) for offset n x 10^-7 degree towards the south from the reference position,"]
+    #[doc = " * - `0` for no latitudinal offset,"]
+    #[doc = " * - `n` (`n > 0` and `n < 131 072`) for offset n x 10^-7 degree towards the north from the reference position,"]
+    #[doc = " * - `131 072` when the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 10^-7 degree"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-131071..=131072"))]
+    pub struct DeltaLatitude(pub i32);
+    #[doc = "*"]
+    #[doc = " * This DE represents an offset longitude with regards to a defined longitude value."]
+    #[doc = " * It may be used to describe a geographical point with regards to a specific reference geographical position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= -131 071` and `n < 0`) for offset n x 10^-7 degree towards the west from the reference position,"]
+    #[doc = " * - `0` for no longitudinal offset,"]
+    #[doc = " * - `n` (`n > 0` and `n < 131 072`) for offset n x 10^-7 degree towards the east from the reference position, "]
+    #[doc = " * - `131 072` when the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 10^-7 degree"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-131071..=131072"))]
+    pub struct DeltaLongitude(pub i32);
+    #[doc = "*"]
+    #[doc = "* This DF defines a geographical point position as a 2 dimensional offset position to a geographical reference point."]
+    #[doc = "*"]
+    #[doc = "* It shall include the following components: "]
+    #[doc = "*"]
+    #[doc = "* @field deltaLatitude: A delta latitude offset with regards to the latitude value of the reference position."]
+    #[doc = "*"]
+    #[doc = "* @field deltaLongitude: A delta longitude offset with regards to the longitude value of the reference position."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DeltaPosition {
+        #[rasn(identifier = "deltaLatitude")]
+        pub delta_latitude: DeltaLatitude,
+        #[rasn(identifier = "deltaLongitude")]
+        pub delta_longitude: DeltaLongitude,
+    }
+    impl DeltaPosition {
+        pub fn new(delta_latitude: DeltaLatitude, delta_longitude: DeltaLongitude) -> Self {
+            Self {
+                delta_latitude,
+                delta_longitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF shall contain a list of @ref DeltaPosition."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaPosition)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32", extensible))]
+    pub struct DeltaPositions(pub SequenceOf<DeltaPosition>);
+    #[doc = "*"]
+    #[doc = " * This DF defines a geographical point position as a 3 dimensional offset position to a geographical reference point."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field deltaLatitude: A delta latitude offset with regards to the latitude value of the reference position."]
+    #[doc = " *"]
+    #[doc = " * @field deltaLongitude: A delta longitude offset with regards to the longitude value of the reference position."]
+    #[doc = " *"]
+    #[doc = " * @field deltaAltitude: A delta altitude offset with regards to the altitude value of the reference position."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision:  V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DeltaReferencePosition {
+        #[rasn(identifier = "deltaLatitude")]
+        pub delta_latitude: DeltaLatitude,
+        #[rasn(identifier = "deltaLongitude")]
+        pub delta_longitude: DeltaLongitude,
+        #[rasn(identifier = "deltaAltitude")]
+        pub delta_altitude: DeltaAltitude,
+    }
+    impl DeltaReferencePosition {
+        pub fn new(
+            delta_latitude: DeltaLatitude,
+            delta_longitude: DeltaLongitude,
+            delta_altitude: DeltaAltitude,
+        ) -> Self {
+            Self {
+                delta_latitude,
+                delta_longitude,
+                delta_altitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF shall contain a list of @ref DeltaReferencePosition."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaReferencePositions)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32", extensible))]
+    pub struct DeltaReferencePositions(pub SequenceOf<DeltaReferencePosition>);
+    #[doc = "*"]
+    #[doc = " * This DE represents a difference in time with respect to a reference time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 10001`) to indicate a time value equal to or less than n x 0,001 s, and greater than (n-1) x 0,001 s,"]
+    #[doc = " *"]
+    #[doc = " * Example: a time interval between two consecutive message transmissions."]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,001 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1 from the DE TransmissionInterval in [2]"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=10000"))]
+    pub struct DeltaTimeMilliSecondPositive(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DE represents a signed difference in time with respect to a reference time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-2048` for time values equal to or less than -2,048 s,"]
+    #[doc = " * - `n` (`n > -2048` and `n < 2047`) to indicate a time value equal to or less than n x 0,001 s, and greater than (n-1) x 0,001 s,"]
+    #[doc = " * - `2047` for time values greater than 2,046 s"]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,001 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-2048..=2047"))]
+    pub struct DeltaTimeMilliSecondSigned(pub i16);
+    #[doc = "* "]
+    #[doc = " * This DE represents a difference in time with respect to a reference time."]
+    #[doc = " * It can be interpreted as the first 8 bits of a GenerationDeltaTime. To convert it to a @ref GenerationDeltaTime, "]
+    #[doc = " * multiply by 256 (i.e. append a `00` byte)"]
+    #[doc = " *"]
+    #[doc = " * @unit: 256 * 0,001 s "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=255"))]
+    pub struct DeltaTimeQuarterSecond(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents a  difference in time with respect to a reference time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-0` for a difference in time of 0 seconds. "]
+    #[doc = " * - `n` (`n > 0` and `n <= 86400`) to indicate a time value equal to or less than n x 1 s, and greater than (n-1) x 1 s,"]
+    #[doc = " *"]
+    #[doc = " * @unit: 1 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1 from ValidityDuration"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=86400"))]
+    pub struct DeltaTimeSecond(pub u32);
+    #[doc = "*"]
+    #[doc = " * This DE represents a difference in time with respect to a reference time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-0` for a difference in time of 0 seconds. "]
+    #[doc = " * - `n` (`n > 0` and `n < 128`) to indicate a time value equal to or less than n x 10 s, and greater than (n-1) x 10 s,"]
+    #[doc = " *"]
+    #[doc = " * @unit: 10 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=127"))]
+    pub struct DeltaTimeTenSeconds(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents a difference in time with respect to a reference time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` for a difference in time of 0 seconds. "]
+    #[doc = " * - `n` (`n > 0` and `n < 128`) to indicate a time value equal to or less than n x 0,1 s, and greater than (n-1) x 0,1 s,"]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=127"))]
+    pub struct DeltaTimeTenthOfSecond(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a portion of digital map. It shall contain a list of waypoints @ref ReferencePosition."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision:  V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=256"))]
+    pub struct DigitalMap(pub SequenceOf<ReferencePosition>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates a direction with respect to a defined reference direction."]
+    #[doc = " * Example: a reference direction may be implicitly defined by the definition of a geographical zone."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `sameDirection`     - to indicate the same direction as the reference direction,"]
+    #[doc = " * - 1 - `oppositeDirection` - to indicate opposite direction as the reference direction,"]
+    #[doc = " * - 2 - `bothDirections`    - to indicate both directions, i.e. the same and the opposite direction,"]
+    #[doc = " * - 3 - `unavailable`       - to indicate that the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=3"))]
+    pub struct Direction(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates in which direction something is moving."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `forward`     - to indicate it is moving forward,"]
+    #[doc = " * - 1 - `backwards`   - to indicate it is moving backwards,"]
+    #[doc = " * - 2 - `unavailable` - to indicate that the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum DriveDirection {
+        forward = 0,
+        backward = 1,
+        unavailable = 2,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates whether a driving lane is open to traffic."]
+    #[doc = " * "]
+    #[doc = " * A lane is counted from inside border of the road excluding the hard shoulder. The size of the bit string shall"]
+    #[doc = " * correspond to the total number of the driving lanes in the carriageway."]
+    #[doc = " * "]
+    #[doc = " * The numbering is matched to @ref LanePosition."]
+    #[doc = " * The bit `0` is used to indicate the innermost lane, bit `1` is used to indicate the second lane from inside border."]
+    #[doc = " * "]
+    #[doc = " * If a lane is closed to traffic, the corresponding bit shall be set to `1`. Otherwise, it shall be set to `0`."]
+    #[doc = " * "]
+    #[doc = " * @note: hard shoulder status is not provided by this DE but in @ref HardShoulderStatus."]
+    #[doc = " * "]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=13"))]
+    pub struct DrivingLaneStatus(pub BitString);
+    #[doc = "* "]
+    #[doc = " * "]
+    #[doc = " * This DF represents the shape of an elliptical area or right elliptical cylinder that is centred "]
+    #[doc = " * on the shape's reference point defined outside of the context of this DF and oriented w.r.t. a  "]
+    #[doc = " * cartesian coordinate system defined outside of the context of this DF. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field shapeReferencePoint: optional reference point which represents the centre of the ellipse, "]
+    #[doc = " * relative to an externally specified reference position. If this component is absent, the "]
+    #[doc = " * externally specified reference position represents the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field semiMajorAxisLength: half length of the major axis of the ellipse located in the X-Y Plane."]
+    #[doc = " * "]
+    #[doc = " * @field semiMinorAxisLength: half length of the minor axis of the ellipse located in the X-Y Plane."]
+    #[doc = " *"]
+    #[doc = " * @field orientation: the optional orientation of the major axis of the ellipse, measured with "]
+    #[doc = " * positive values turning around the z-axis using the right-hand rule, starting from the X-axis."]
+    #[doc = " * If absent, the orientation is equal to the value zero. "]
+    #[doc = " * "]
+    #[doc = " * @field height: the optional height, present if the shape is a right elliptical cylinder extending "]
+    #[doc = " * in the positive Z-axis."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1, the type of the field orientation changed and the description revised in V2.2.1, added note on orientation in V2.4.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct EllipticalShape {
+        #[rasn(identifier = "shapeReferencePoint")]
+        pub shape_reference_point: Option<CartesianPosition3d>,
+        #[rasn(identifier = "semiMajorAxisLength")]
+        pub semi_major_axis_length: StandardLength12b,
+        #[rasn(identifier = "semiMinorAxisLength")]
+        pub semi_minor_axis_length: StandardLength12b,
+        pub orientation: Option<CartesianAngleValue>,
+        pub height: Option<StandardLength12b>,
+    }
+    impl EllipticalShape {
+        pub fn new(
+            shape_reference_point: Option<CartesianPosition3d>,
+            semi_major_axis_length: StandardLength12b,
+            semi_minor_axis_length: StandardLength12b,
+            orientation: Option<CartesianAngleValue>,
+            height: Option<StandardLength12b>,
+        ) -> Self {
+            Self {
+                shape_reference_point,
+                semi_major_axis_length,
+                semi_minor_axis_length,
+                orientation,
+                height,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates whether a vehicle (e.g. public transport vehicle, truck) is under the embarkation process."]
+    #[doc = " * If that is the case, the value is *TRUE*, otherwise *FALSE*."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(delegate)]
+    pub struct EmbarkationStatus(pub bool);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EmergencyPriority(pub FixedBitString<2usize>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode \"emergencyVehicleApproaching\". "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                   - in case further detailed information on the emergency vehicle approaching event "]
+    #[doc = " *                                         is unavailable,"]
+    #[doc = " * - 1 - `emergencyVehicleApproaching`   - in case an operating emergency vehicle is approaching,"]
+    #[doc = " * - 2 - `prioritizedVehicleApproaching` - in case a prioritized vehicle is approaching,"]
+    #[doc = " * - 3-255                               - reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct EmergencyVehicleApproachingSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicated the type of energy being used and stored in vehicle."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 - `hydrogenStorage`       - when hydrogen is being used and stored in vehicle,"]
+    #[doc = " * - 1 - `electricEnergyStorage` - when electric energy is being used and stored in vehicle,"]
+    #[doc = " * - 2 - `liquidPropaneGas`      - when liquid Propane Gas (LPG) is being used and stored in vehicle,   "]
+    #[doc = " * - 3 - `compressedNaturalGas ` - when compressedNaturalGas (CNG) is being used and stored in vehicle,"]
+    #[doc = " * - 4 - `diesel`                - when diesel is being used and stored in vehicle,"]
+    #[doc = " * - 5 - `gasoline`              - when gasoline is being used and stored in vehicle,"]
+    #[doc = " * - 6 - `ammonia`               - when ammonia is being used and stored in vehicle."]
+    #[doc = " *"]
+    #[doc = " * - Otherwise, the corresponding bit shall be set to `0`."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: editorial revision in V2.1.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EnergyStorageType(pub FixedBitString<7usize>);
+    #[doc = "* "]
+    #[doc = " * "]
+    #[doc = " * This DF represents a vehicle category according to the UNECE/TRANS/WP.29/78/Rev.4 [16]."]
+    #[doc = " * The following options are available:"]
+    #[doc = " * "]
+    #[doc = " * @field euVehicleCategoryL: indicates a vehicle in the L category."]
+    #[doc = " *"]
+    #[doc = " * @field euVehicleCategoryM: indicates a vehicle in the M category."]
+    #[doc = " *"]
+    #[doc = " * @field euVehicleCategoryN: indicates a vehicle in the N category."]
+    #[doc = " *"]
+    #[doc = " * @field euVehicleCategoryO: indicates a vehicle in the O category."]
+    #[doc = " *"]
+    #[doc = " * @field euVehicleCategoryT: indicates a vehicle in the T category."]
+    #[doc = " *"]
+    #[doc = " * @field euVehicleCategoryG: indicates a vehicle in the G category."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum EuVehicleCategoryCode {
+        euVehicleCategoryL(EuVehicleCategoryL),
+        euVehicleCategoryM(EuVehicleCategoryM),
+        euVehicleCategoryN(EuVehicleCategoryN),
+        euVehicleCategoryO(EuVehicleCategoryO),
+        euVehicleCategoryT(()),
+        euVehicleCategoryG(()),
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents one of the specific categories in the L category: L1, L2, L3, L4, L5, L6, or L7 according to UNECE/TRANS/WP.29/78/Rev.4 [16]."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum EuVehicleCategoryL {
+        l1 = 0,
+        l2 = 1,
+        l3 = 2,
+        l4 = 3,
+        l5 = 4,
+        l6 = 5,
+        l7 = 6,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents one of the specific categories in the M category: M1, M2, or M3 according to UNECE/TRANS/WP.29/78/Rev.4 [16]."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum EuVehicleCategoryM {
+        m1 = 0,
+        m2 = 1,
+        m3 = 2,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents one of the specific categories in the N category: N1, N2, or N3 according to UNECE/TRANS/WP.29/78/Rev.4 [16]."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum EuVehicleCategoryN {
+        n1 = 0,
+        n2 = 1,
+        n3 = 2,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents one of the specific categories in the O category: O1, O2, O3 or O4 according to UNECE/TRANS/WP.29/78/Rev.4 [16]."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum EuVehicleCategoryO {
+        o1 = 0,
+        o2 = 1,
+        o3 = 2,
+        o4 = 3,
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents the Euler angles which describe the orientation of an object bounding box in a Cartesian coordinate system with an associated confidence level for each angle."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field zAngle: z-angle of object bounding box at the time of measurement, with the associated confidence."]
+    #[doc = " * The angle is measured with positive values considering the object orientation turning around the z-axis using the right-hand rule, starting from the x-axis. "]
+    #[doc = " * This extrinsic rotation shall be applied around the centre point of the object bounding box before all other rotations."]
+    #[doc = " *"]
+    #[doc = " * @field yAngle: optional y-angle of object bounding box at the time of measurement, with the associated confidence."]
+    #[doc = " * The angle is measured with positive values considering the object orientation turning around the y-axis using the right-hand rule, starting from the z-axis. "]
+    #[doc = " * This extrinsic rotation shall be applied around the centre point of the object bounding box after the rotation by zAngle and before the rotation by xAngle."]
+    #[doc = " *"]
+    #[doc = " * @field xAngle: optional x-angle of object bounding box at the time of measurement, with the associated confidence."]
+    #[doc = " * The angle is measured with positive values considering the object orientation turning around the x-axis using the right-hand rule, starting from the z-axis. "]
+    #[doc = " * This extrinsic rotation shall be applied around the centre point of the object bounding box after all other rotations."]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct EulerAnglesWithConfidence {
+        #[rasn(identifier = "zAngle")]
+        pub z_angle: CartesianAngle,
+        #[rasn(identifier = "yAngle")]
+        pub y_angle: Option<CartesianAngle>,
+        #[rasn(identifier = "xAngle")]
+        pub x_angle: Option<CartesianAngle>,
+    }
+    impl EulerAnglesWithConfidence {
+        pub fn new(
+            z_angle: CartesianAngle,
+            y_angle: Option<CartesianAngle>,
+            x_angle: Option<CartesianAngle>,
+        ) -> Self {
+            Self {
+                z_angle,
+                y_angle,
+                x_angle,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * The DF shall contain a list of @ref EventPoint.  "]
+    #[doc = " *"]
+    #[doc = " * The eventPosition of each @ref EventPoint is defined with respect to the previous @ref EventPoint in the list. "]
+    #[doc = " * Except for the first @ref EventPoint which is defined with respect to a position outside of the context of this DF."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information, Traffic information"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref EventZone instead. "]
+    #[doc = " * @revision: Generalized the semantics in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=23"))]
+    pub struct EventHistory(pub SequenceOf<EventPoint>);
+    #[doc = "*"]
+    #[doc = " * This DF provides information related to an event at a defined position."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field eventPosition: offset position of a detected event point to a defined position. "]
+    #[doc = " * "]
+    #[doc = " * @field eventDeltaTime: optional time travelled by the detecting ITS-S since the previous detected event point."]
+    #[doc = " * "]
+    #[doc = " * @field informationQuality: Information quality of the detection for this event point."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information, Traffic information"]
+    #[doc = " * @revision: generalized the semantics in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct EventPoint {
+        #[rasn(identifier = "eventPosition")]
+        pub event_position: DeltaReferencePosition,
+        #[rasn(identifier = "eventDeltaTime")]
+        pub event_delta_time: Option<PathDeltaTime>,
+        #[rasn(identifier = "informationQuality")]
+        pub information_quality: InformationQuality,
+    }
+    impl EventPoint {
+        pub fn new(
+            event_position: DeltaReferencePosition,
+            event_delta_time: Option<PathDeltaTime>,
+            information_quality: InformationQuality,
+        ) -> Self {
+            Self {
+                event_position,
+                event_delta_time,
+                information_quality,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * The DF shall contain a list of @ref EventPoint, where all @ref EventPoint either contain the COMPONENT eventDeltaTime "]
+    #[doc = " * or do not contain the COMPONENT eventDeltaTime.  "]
+    #[doc = " *"]
+    #[doc = " * The eventPosition of each @ref EventPoint is defined with respect to the previous @ref EventPoint in the list. "]
+    #[doc = " * Except for the first @ref EventPoint which is defined with respect to a position outside of the context of this DF."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information, Traffic information"]
+    #[doc = " * @revision: created in V2.1.1 based on EventHistory"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EventZone(pub EventHistory);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum Ext1 {
+        #[rasn(value("128..=16511"), tag(context, 0))]
+        content(u16),
+        #[rasn(tag(context, 1))]
+        extension(Ext2),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum Ext2 {
+        #[rasn(value("16512..=2113663"), tag(context, 0))]
+        content(u32),
+        #[rasn(tag(context, 1))]
+        extension(Ext3),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("2113664..=270549119", extensible))]
+    pub struct Ext3(pub Integer);
+    #[doc = "*"]
+    #[doc = " * This DE describes the status of the exterior light switches of a vehicle incl. VRU vehicles."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 - `lowBeamHeadlightsOn`    - when the low beam head light switch is on,"]
+    #[doc = " * - 1 - `highBeamHeadlightsOn`   - when the high beam head light switch is on,"]
+    #[doc = " * - 2 - `leftTurnSignalOn`       - when the left turnSignal switch is on,"]
+    #[doc = " * - 3 - `rightTurnSignalOn`      - when the right turn signal switch is on,"]
+    #[doc = " * - 4 - `daytimeRunningLightsOn` - when the daytime running light switch is on,"]
+    #[doc = " * - 5 - `reverseLightOn`         - when the reverse light switch is on,"]
+    #[doc = " * - 6 - `fogLightOn`             - when the tail fog light switch is on,"]
+    #[doc = " * - 7 - `parkingLightsOn`        - when the parking light switch is on."]
+    #[doc = " * "]
+    #[doc = " * @note: The value of each bit indicates the state of the switch, which commands the corresponding light."]
+    #[doc = " * The bit corresponding to a specific light is set to `1`, when the corresponding switch is turned on,"]
+    #[doc = " * either manually by the driver or automatically by a vehicle system. The bit value does not indicate"]
+    #[doc = " * if the corresponding lamps are alight or not."]
+    #[doc = " * "]
+    #[doc = " * If a vehicle is not equipped with a certain light or if the light switch status information is not available,"]
+    #[doc = " * the corresponding bit shall be set to `0`."]
+    #[doc = " * "]
+    #[doc = " * As the bit value indicates only the state of the switch, the turn signal and hazard signal bit values shall not"]
+    #[doc = " * alternate with the blinking interval."]
+    #[doc = " * "]
+    #[doc = " * For hazard indicator, the `leftTurnSignalOn (2)` and `rightTurnSignalOn (3)` shall be both set to `1`."]
+    #[doc = " * "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ExteriorLights(pub FixedBitString<8usize>);
+    #[doc = "*"]
+    #[doc = " * This DF represents the top-level DF to represent a lane position. A lane position is a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway."]
+    #[doc = " *"]
+    #[doc = " * @note: This DF is the most general way to represent a lane position: it provides a complete set of information regarding a transversal (dimensionless) position on the carriageway at a specific "]
+    #[doc = " * reference position, i.e. it provides different options and synonyms to represent the lane at which the reference position (the point) is located. A confidence is used to describe the probability "]
+    #[doc = " * that the object is located in the provided lane. The dimension of the object or extension of an area are not considered: See @ref OccupiedLanesWithConfidence for describing the occupation of lanes, "]
+    #[doc = " * where the dimensions of an object or the extension of an area is considered."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field lanePositionBased: lane position information for a defined reference position."]
+    #[doc = " * "]
+    #[doc = " * @field mapBased: optional lane position information described in the context of a MAPEM as specified in ETSI TS 103 301 [15]. "]
+    #[doc = " * If present, it shall describe the same reference position using the lane identification in the MAPEM. This component can be used only if a MAPEM is available for the reference position "]
+    #[doc = " * (e.g. on an intersection): In this case it is used as a synonym to the mandatory component lanePositionBased. "]
+    #[doc = " * "]
+    #[doc = " * @field confidence: confidence information for expressing the probability that the object is located at the indicated lane.  "]
+    #[doc = " * If the value of the component lanePositionBased is generated directly from the absolute reference position and reference topology information, "]
+    #[doc = " * no sensor shall be indicated in the component usedDetectionInformation of the @ref MetaInformation."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: newly created in V2.2.1. The previous DF GeneralizedLanePosition is now renamed to @ref LanePositionOptions. "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct GeneralizedLanePosition {
+        #[rasn(identifier = "lanePositionBased")]
+        pub lane_position_based: LanePositionOptions,
+        #[rasn(identifier = "mapBased")]
+        pub map_based: Option<MapPosition>,
+        pub confidence: MetaInformation,
+    }
+    impl GeneralizedLanePosition {
+        pub fn new(
+            lane_position_based: LanePositionOptions,
+            map_based: Option<MapPosition>,
+            confidence: MetaInformation,
+        ) -> Self {
+            Self {
+                lane_position_based,
+                map_based,
+                confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents transversal position information with respect to the road, at an externally defined reference position. It shall contain a set of up to `4` @ref GeneralizedLanePosition."]
+    #[doc = " * Multiple entries can be used to describe several lane positions with the associated confidence, in cases where the reference position cannot be mapped to a single lane."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct GeneralizedLanePositions(pub SequenceOf<GeneralizedLanePosition>);
+    #[doc = "*"]
+    #[doc = " * This DE represents a timestamp based on TimestampIts modulo 65 536."]
+    #[doc = " * This means that generationDeltaTime = TimestampIts mod 65 536."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1 based on ETSI TS 103 900 [1]"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct GenerationDeltaTime(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DF indicates a geographical position."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field latitude: the latitude of the geographical position."]
+    #[doc = " *"]
+    #[doc = " * @field longitude: the longitude of the geographical position."]
+    #[doc = " *"]
+    #[doc = " * @field altitude: the altitude of the geographical position with default value unavailable."]
+    #[doc = " *"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct GeoPosition {
+        pub latitude: Latitude,
+        pub longitude: Longitude,
+        #[rasn(default = "geo_position_altitude_default")]
+        pub altitude: AltitudeValue,
+    }
+    impl GeoPosition {
+        pub fn new(latitude: Latitude, longitude: Longitude, altitude: AltitudeValue) -> Self {
+            Self {
+                latitude,
+                longitude,
+                altitude,
+            }
+        }
+    }
+    fn geo_position_altitude_default() -> AltitudeValue {
+        AltitudeValue(800001)
+    }
+    #[doc = "*"]
+    #[doc = "* This DE indicates a geographical position with altitude."]
+    #[doc = "*"]
+    #[doc = "* It shall include the following components: "]
+    #[doc = "*"]
+    #[doc = "* @field latitude: the latitude of the geographical position."]
+    #[doc = "*"]
+    #[doc = "* @field longitude: the longitude of the geographical position."]
+    #[doc = "*"]
+    #[doc = "* @field altitude: the altitude of the geographical position."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionWAltitude)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct GeoPositionWAltitude {
+        pub latitude: Latitude,
+        pub longitude: Longitude,
+        pub altitude: Altitude,
+    }
+    impl GeoPositionWAltitude {
+        pub fn new(latitude: Latitude, longitude: Longitude, altitude: Altitude) -> Self {
+            Self {
+                latitude,
+                longitude,
+                altitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF indicates a geographical position without altitude."]
+    #[doc = "*"]
+    #[doc = "* It shall include the following components: "]
+    #[doc = "*"]
+    #[doc = "* @field latitude: the latitude of the geographical position."]
+    #[doc = "*"]
+    #[doc = "* @field longitude: the longitude of the geographical position."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePosition)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct GeoPositionWoAltitude {
+        pub latitude: Latitude,
+        pub longitude: Longitude,
+    }
+    impl GeoPositionWoAltitude {
+        pub fn new(latitude: Latitude, longitude: Longitude) -> Self {
+            Self {
+                latitude,
+                longitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF shall contain a list of @ref AbsolutePositionWAltitude."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionsWAltitude)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct GeoPositionsWAltitude(pub SequenceOf<GeoPositionWAltitude>);
+    #[doc = "*"]
+    #[doc = "* This DF shall contain a list of @ref GeoPositionWoAltitude."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (AbsolutePositions)"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct GeoPositionsWoAltitude(pub SequenceOf<GeoPositionWoAltitude>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the current status of a hard shoulder: whether it is available for special usage"]
+    #[doc = " * (e.g. for stopping or for driving) or closed for all vehicles."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `availableForStopping` - if the hard shoulder is available for stopping in e.g. emergency situations,"]
+    #[doc = " * - 1 - `closed`               - if the hard shoulder is closed and cannot be occupied in any case,"]
+    #[doc = " * - 2 - `availableForDriving`  - if the hard shoulder is available for regular driving."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum HardShoulderStatus {
+        availableForStopping = 0,
+        closed = 1,
+        availableForDriving = 2,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-AnimalOnTheRoad`."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`          - in case further detailed information on the animal(s) on the road is unavailable,"]
+    #[doc = " * - 1 - `wildAnimals`          - in case wild animals of unknown size are present on the road,"]
+    #[doc = " * - 2 - `herdOfAnimals`        - in case a herd of animals is present on the road,"]
+    #[doc = " * - 3 - `smallAnimals`         - in case small size animals of unknown type are present on the road,"]
+    #[doc = " * - 4 - `largeAnimals`         - in case large size animals of unknown type are present on the road,"]
+    #[doc = " * - 5 - `wildAnimalsSmall`     - in case small size wild animal(s) are present on the road,"]
+    #[doc = " * - 6 - `wildAnimalsLarge`     - in case large size wild animal(s) are present on the road,"]
+    #[doc = " * - 7 - `domesticAnimals`      - in case domestic animal(s) of unknown size are detected on the road,"]
+    #[doc = " * - 8 - `domesticAnimalsSmall` - in case small size domestic animal(s) are present on the road,"]
+    #[doc = " * - 9 - `domesticAnimalsLarge` - in case large size domestic animal(s) are present on the road."]
+    #[doc = " * - 10-255                     - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, named values 5 to 9 added in V2.2.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "HazardousLocation-AnimalOnTheRoadSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct HazardousLocationAnimalOnTheRoadSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the sub cause code of the @ref CauseCode  `hazardousLocation-DangerousCurve`."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                                        - in case further detailed information on the dangerous curve is unavailable,"]
+    #[doc = " * - 1 - `dangerousLeftTurnCurve`                             - in case the dangerous curve is a left turn curve,"]
+    #[doc = " * - 2 - `dangerousRightTurnCurve`                            - in case the dangerous curve is a right turn curve,"]
+    #[doc = " * - 3 - `multipleCurvesStartingWithUnknownTurningDirection`  - in case of multiple curves for which the starting curve turning direction is not known,"]
+    #[doc = " * - 4 - `multipleCurvesStartingWithLeftTurn`                 - in case of multiple curves starting with a left turn curve,"]
+    #[doc = " * - 5 - `multipleCurvesStartingWithRightTurn`                - in case of multiple curves starting with a right turn curve."]
+    #[doc = " * - 6-255                                                    - are reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * The definition of whether a curve is dangerous may vary according to region and according to vehicle types/mass"]
+    #[doc = " * and vehicle speed driving on the curve. This definition is out of scope of the present document."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "HazardousLocation-DangerousCurveSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct HazardousLocationDangerousCurveSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-ObstacleOnTheRoad`. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                - in case further detailed information on the detected obstacle is unavailable,"]
+    #[doc = " * - 1 - `shedLoad`                   - in case detected obstacle is large amount of obstacles (shedload),"]
+    #[doc = " * - 2 - `partsOfVehicles`            - in case detected obstacles are parts of vehicles,"]
+    #[doc = " * - 3 - `partsOfTyres`               - in case the detected obstacles are parts of tyres,"]
+    #[doc = " * - 4 - `bigObjects`                 - in case the detected obstacles are big objects,"]
+    #[doc = " * - 5 - `fallenTrees`                - in case the detected obstacles are fallen trees,"]
+    #[doc = " * - 6 - `hubCaps`                    - in case the detected obstacles are hub caps,"]
+    #[doc = " * - 7 - `waitingVehicles-deprecated` - deprecated since not representing an obstacle and already covered by StationaryVehicleSubCauseCode."]
+    #[doc = " * - 8-255                - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 7 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "HazardousLocation-ObstacleOnTheRoadSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct HazardousLocationObstacleOnTheRoadSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `hazardousLocation-SurfaceCondition`. "]
+    #[doc = " * "]
+    #[doc = "The value shall be set to:"]
+    #[doc = " * - 0  - `unavailable`                  - in case further detailed information on the road surface condition is unavailable,"]
+    #[doc = " * - 1  - `rockfalls`                    - in case rock falls have fallen on the road surface,"]
+    #[doc = " * - 2  - `earthquakeDamage-deprecated`  - deprecated since it is covered by 1 rockfalls and 4 subsidence,"]
+    #[doc = " * - 3  - `sinkhole`                     - in case of a partial collapse of the road surface that creates a depression (hole) in the pavement,"]
+    #[doc = " * - 4  - `subsidence`                   - in case road surface is damaged by subsidence,"]
+    #[doc = " * - 5  - `snowDrifts-deprecated`        - deprecated since not representing a road damage,"]
+    #[doc = " * - 6  - `stormDamage-deprecated`       - deprecated since not representing a road damage,"]
+    #[doc = " * - 7  - `burstPipe-deprecated`         - deprecated since not representing a road damage,"]
+    #[doc = " * - 8  - `lava           `              - in case road surface is damaged due to  lava on the road,"]
+    #[doc = " * - 9  - `fallingIce-deprecated`        - deprecated since not representing a road damage,"]
+    #[doc = " * - 10 - `fire`                         - in case there is fire on or near to the road surface,"]
+    #[doc = " * - 11 - `flooding-deprecated`          - deprecated since not representing a road damage."]
+    #[doc = " * - 12 - `wearAndTear`                  - in case the road surface is damaged by wear and tear."]
+    #[doc = " * - 13-255                              - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 10 added in V2.1.1, value 11 added in V2.3.1, "]
+    #[doc = "              name and definition of value 3 and 8 changed in V2.4.1, values 2, 5, 6, 7, 9 and 11 deprecated in V2.4.1, vaue 12 added in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(
+        delegate,
+        identifier = "HazardousLocation-SurfaceConditionSubCauseCode",
+        value("0..=255")
+    )]
+    pub struct HazardousLocationSurfaceConditionSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents the Heading in a WGS84 co-ordinates system."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field headingValue: the heading value."]
+    #[doc = " * "]
+    #[doc = " * @field headingConfidence: the confidence value of the heading value with a predefined confidence level."]
+    #[doc = " * "]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84Angle instead. "]
+    #[doc = " * @category: Kinematic Information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Heading {
+        #[rasn(identifier = "headingValue")]
+        pub heading_value: HeadingValue,
+        #[rasn(identifier = "headingConfidence")]
+        pub heading_confidence: HeadingConfidence,
+    }
+    impl Heading {
+        pub fn new(heading_value: HeadingValue, heading_confidence: HeadingConfidence) -> Self {
+            Self {
+                heading_value,
+                heading_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF  provides  information  associated to heading  change indicators  such as  a  change  of  direction."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field direction: the direction of heading change value."]
+    #[doc = " * "]
+    #[doc = " * @field actionDeltaTime: the period over which a direction change action is performed. "]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic Information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct HeadingChangeIndication {
+        pub direction: TurningDirection,
+        #[rasn(identifier = "actionDeltaTime")]
+        pub action_delta_time: DeltaTimeTenthOfSecond,
+    }
+    impl HeadingChangeIndication {
+        pub fn new(direction: TurningDirection, action_delta_time: DeltaTimeTenthOfSecond) -> Self {
+            Self {
+                direction,
+                action_delta_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the heading confidence value which represents the estimated absolute accuracy of a heading value with a confidence level of 95 %."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n x 0,1 degree and more than (n-1) x 0,1 degree,"]
+    #[doc = " * - `126` if the confidence value is out of range, i.e. greater than 12,5 degrees,"]
+    #[doc = " * - `127` if the confidence value information is not available."]
+    #[doc = " * "]
+    #[doc = " * @note:\tThe fact that a value is received with confidence value set to `unavailable(127)` can be caused by several reasons,"]
+    #[doc = " * such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the heading value may be valid and used by the application."]
+    #[doc = " *"]
+    #[doc = " * @note: If a heading value is received and its confidence value is set to `outOfRange(126)`, it means that the "]
+    #[doc = " * heading value is not valid and therefore cannot be trusted. Such value is not useful for the application."]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84AngleConfidence instead. "]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,1 degree"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct HeadingConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the orientation of the horizontal velocity vector with regards to the WGS84 north."]
+    #[doc = " * When the information is not available, the DE shall be set to 3 601. The value 3600 shall not be used."]
+    #[doc = " *"]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref Wgs84AngleValue instead. "]
+    #[doc = " *"]
+    #[doc = " * Unit: 0,1 degree"]
+    #[doc = " * Categories: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (usage of value 3600 specified) "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=3601"))]
+    pub struct HeadingValue(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the height of the left or right longitude carrier of vehicle from base to top (left or right carrier seen from vehicle"]
+    #[doc = " * rear to front). "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 1` and `n < 99`) if the height information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,"]
+    #[doc = " * - `99` if the height is out of range, i.e. equal to or greater than 0,98 m,"]
+    #[doc = " * - `100` if the height information is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 metre"]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (the definition of 99 has changed slightly) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=100"))]
+    pub struct HeightLonCarr(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause code of the @ref CauseCode `humanPresenceOnTheRoad`."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`                    - in case further detailed information abou the human presence on the road is unavailable,"]
+    #[doc = " * - 1 - `childrenOnRoadway`              - in case children are present on the road,"]
+    #[doc = " * - 2 - `cyclistOnRoadway`               - in case cyclist(s) are present on the road,"]
+    #[doc = " * - 3 - `motorcyclistOnRoadway`          - in case motorcyclist(s) are present on the road,"]
+    #[doc = " * - 4 - `pedestrian`                     - in case pedestrian(s) of any type are present on the road,"]
+    #[doc = " * - 5 - `ordinary-pedestrian`            - in case pedestrian(s) to which no more-specific profile applies are present on the road,"]
+    #[doc = " * - 6 - `road-worker`                    - in case pedestrian(s) with the role of a road worker applies are present on the road,"]
+    #[doc = " * - 7 - `first-responder`                - in case pedestrian(s) with the role of a first responder applies are present on the road,  "]
+    #[doc = " * - 8 - `lightVruVehicle                 - in case light vru vehicle(s) of any type are present on the road,"]
+    #[doc = " * - 9 - `bicyclist `                     - in case cycle(s) and their bicyclist(s) are present on the road,"]
+    #[doc = " * - 10 - `wheelchair-user`               - in case wheelchair(s) and their user(s) are present on the road,"]
+    #[doc = " * - 11 - `horse-and-rider`               - in case horse(s) and rider(s) are present on the road,"]
+    #[doc = " * - 12 - `rollerskater`                  - in case rolleskater(s) and skater(s) are present on the road,"]
+    #[doc = " * - 13 - `e-scooter`                     - in case e-scooter(s) and rider(s) are present on the road,"]
+    #[doc = " * - 14 - `personal-transporter`          - in case personal-transporter(s) and rider(s) are present on the road,"]
+    #[doc = " * - 15 - `pedelec`                       - in case pedelec(s) and rider(s) are present on the road,"]
+    #[doc = " * - 16 - `speed-pedelec`                 - in case speed-pedelec(s) and rider(s) are present on the road,"]
+    #[doc = " * - 17 - `ptw`                           - in case powered-two-wheeler(s) of any type are present on the road,"]
+    #[doc = " * - 18 - `moped`                         - in case moped(s) and rider(s) are present on the road,"]
+    #[doc = " * - 19 - `motorcycle`                    - in case motorcycle(s) and rider(s) are present on the road,"]
+    #[doc = " * - 20 - `motorcycle-and-sidecar-right`  - in case motorcycle(s) with sidecar(s) on the right and rider are present on the road,"]
+    #[doc = " * - 21 - `motorcycle-and-sidecar-left`   - in case motorcycle(s) with sidecar(s) on the left and rider are present on the road."]
+    #[doc = " * - 22-255                               - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: editorial revision in V2.1.1, named values 4-21 added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct HumanPresenceOnTheRoadSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode \"humanProblem\"."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `unavailable`        - in case further detailed information on human health problem is unavailable,"]
+    #[doc = " * - 1 - `glycemiaProblem`    - in case human problem is due to glycaemia problem,"]
+    #[doc = " * - 2 - `heartProblem`       - in case human problem is due to heart problem,"]
+    #[doc = " * - 3 - `unresponsiveDriver` - in case an unresponsive driver is detected."]
+    #[doc = " * - 3-255                    - reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 3 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct HumanProblemSubCauseCode(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE is a general identifier."]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct Identifier1B(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE is a general identifier."]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct Identifier2B(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `impassability`"]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`              - in case further detailed information about the unmanaged road blockage is unavailable,"]
+    #[doc = " * - 1 `flooding          `       - in case the road is affected by flooding,"]
+    #[doc = " * - 2 `dangerOfAvalanches`       - in case the road is at risk of being affected or blocked by avalanches,"]
+    #[doc = " * - 3 `blastingOfAvalanches`     - in case there is an active blasting of avalanches on or near the road,"]
+    #[doc = " * - 4 `landslips`                - in case the road is affected by landslips,"]
+    #[doc = " * - 5 `chemicalSpillage`         - in case the road is affected by chemical spillage,"]
+    #[doc = " * - 6 `winterClosure`            - in case the road is impassable due to a winter closure."]
+    #[doc = " * - 7 `sinkhole`                 - in case the road is impassable due to large holes in the road surface."]
+    #[doc = " * - 8 `earthquakeDamage`         - in case the road is obstructed or partially obstructed because of damage caused by an earthquake."]
+    #[doc = " * - 9 `fallenTrees`              - in case the road is obstructed or partially obstructed by one or more fallen trees. "]
+    #[doc = " * - 10 `rockfalls`               - in case the road is obstructed or partially obstructed due to fallen rocks."]
+    #[doc = " * - 11 `sewerOverflow`           - in case the road is obstructed or partially obstructed by overflows from one or more sewers. "]
+    #[doc = " * - 12 `stormDamage`             - in case the road is obstructed or partially obstructed by debris caused by strong winds."]
+    #[doc = " * - 13 `subsidence`              - in case the road surface has sunken or collapsed in places."]
+    #[doc = " * - 14 `burstPipe`               - in case the road surface has sunken or collapsed in places due to burst pipes."]
+    #[doc = " * - 15 `burstWaterMain`          - in case the road is obstructed due to local flooding and/or subsidence. "]
+    #[doc = " * - 16 `fallenPowerCables`       - in case the road is obstructed or partly obstructed by one or more fallen power cables."]
+    #[doc = " * - 17 `snowDrifts`              - in case the road is obstructed or partially obstructed by snow drifting in progress or patches of deep snow due to earlier drifting."]
+    #[doc = " * - 15-255                       - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct ImpassabilitySubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the quality level of provided information."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` if the information is unavailable,"]
+    #[doc = " * - `1` if the quality level is lowest,"]
+    #[doc = " * - `n` (`n > 1` and `n < 7`) if the quality level is n, "]
+    #[doc = " * - `7` if the quality level is highest."]
+    #[doc = " *"]
+    #[doc = " * @note: Definition of quality level is out of scope of the present document."]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=7"))]
+    pub struct InformationQuality(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a frequency channel "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field centreFrequency: the centre frequency of the channel in 10^(exp+2) Hz (where exp is exponent)"]
+    #[doc = " * "]
+    #[doc = " * @field channelWidth: width of the channel in 10^exp Hz (where exp is exponent)"]
+    #[doc = " *"]
+    #[doc = " * @field exponent: exponent of the power of 10 used in the calculation of the components above."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct InterferenceManagementChannel {
+        #[rasn(value("1..=99999"), identifier = "centreFrequency")]
+        pub centre_frequency: u32,
+        #[rasn(value("0..=9999"), identifier = "channelWidth")]
+        pub channel_width: u16,
+        #[rasn(value("0..=15"))]
+        pub exponent: u8,
+    }
+    impl InterferenceManagementChannel {
+        pub fn new(centre_frequency: u32, channel_width: u16, exponent: u8) -> Self {
+            Self {
+                centre_frequency,
+                channel_width,
+                exponent,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of up to 16 definitions containing interference management information, per affected frequency channels."]
+    #[doc = " *  "]
+    #[doc = " * @category: Communication information."]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct InterferenceManagementInfo(pub SequenceOf<InterferenceManagementInfoPerChannel>);
+    #[doc = "*"]
+    #[doc = " * This DF contains interference management information for one affected frequency channel."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementChannel: frequency channel for which the zone should be applied interference management "]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementZoneType: type of the interference management zone. "]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementMitigationType: optional type of the mitigation to be used in the interference management zone. "]
+    #[doc = " * In the case where no mitigation should be applied by the ITS-S, this is indicated by the field interferenceManagementMitigationType being absent."]
+    #[doc = " *"]
+    #[doc = " * @field expiryTime: optional time at which the validity of the interference management communication zone will expire. "]
+    #[doc = " * This component is present when the interference management is temporarily valid"]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct InterferenceManagementInfoPerChannel {
+        #[rasn(identifier = "interferenceManagementChannel")]
+        pub interference_management_channel: InterferenceManagementChannel,
+        #[rasn(identifier = "interferenceManagementZoneType")]
+        pub interference_management_zone_type: InterferenceManagementZoneType,
+        #[rasn(identifier = "interferenceManagementMitigationType")]
+        pub interference_management_mitigation_type: Option<MitigationForTechnologies>,
+        #[rasn(identifier = "expiryTime")]
+        pub expiry_time: Option<TimestampIts>,
+    }
+    impl InterferenceManagementInfoPerChannel {
+        pub fn new(
+            interference_management_channel: InterferenceManagementChannel,
+            interference_management_zone_type: InterferenceManagementZoneType,
+            interference_management_mitigation_type: Option<MitigationForTechnologies>,
+            expiry_time: Option<TimestampIts>,
+        ) -> Self {
+            Self {
+                interference_management_channel,
+                interference_management_zone_type,
+                interference_management_mitigation_type,
+                expiry_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * "]
+    #[doc = " * This DF represents a zone  inside which the ITS communication should be restricted in order to manage interference."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field zoneDefinition: contains the geographical definition of the zone."]
+    #[doc = " *"]
+    #[doc = " * @field managementInfo: contains interference management information applicable in the zone defined in the component zoneDefinition."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct InterferenceManagementZone {
+        #[rasn(identifier = "zoneDefinition")]
+        pub zone_definition: InterferenceManagementZoneDefinition,
+        #[rasn(identifier = "managementInfo")]
+        pub management_info: InterferenceManagementInfo,
+    }
+    impl InterferenceManagementZone {
+        pub fn new(
+            zone_definition: InterferenceManagementZoneDefinition,
+            management_info: InterferenceManagementInfo,
+        ) -> Self {
+            Self {
+                zone_definition,
+                management_info,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents the geographical definition of the zone where band sharing occurs. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementZoneLatitude: Latitude of the centre point of the interference management zone."]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementZoneLongitude: Longitude of the centre point of the interference management zone."]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementZoneId: optional identification of the interference management zone. "]
+    #[doc = " *"]
+    #[doc = " * @field interferenceManagementZoneShape: shape of the interference management zone placed at the centre point. "]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct InterferenceManagementZoneDefinition {
+        #[rasn(identifier = "interferenceManagementZoneLatitude")]
+        pub interference_management_zone_latitude: Latitude,
+        #[rasn(identifier = "interferenceManagementZoneLongitude")]
+        pub interference_management_zone_longitude: Longitude,
+        #[rasn(identifier = "interferenceManagementZoneId")]
+        pub interference_management_zone_id: Option<ProtectedZoneId>,
+        #[rasn(value("0.."), identifier = "interferenceManagementZoneShape")]
+        pub interference_management_zone_shape: Option<Shape>,
+    }
+    impl InterferenceManagementZoneDefinition {
+        pub fn new(
+            interference_management_zone_latitude: Latitude,
+            interference_management_zone_longitude: Longitude,
+            interference_management_zone_id: Option<ProtectedZoneId>,
+            interference_management_zone_shape: Option<Shape>,
+        ) -> Self {
+            Self {
+                interference_management_zone_latitude,
+                interference_management_zone_longitude,
+                interference_management_zone_id,
+                interference_management_zone_shape,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE defines the type of an interference management zone, so that an ITS-S can "]
+    #[doc = " * assert the actions to do while passing by such zone (e.g. reduce the transmit power in case of a DSRC tolling station)."]
+    #[doc = " * It is an extension of the type @ref ProtectedZoneType."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 - `permanentCenDsrcTolling` - as specified in ETSI TS 102 792 [14],"]
+    #[doc = " * - 1 - `temporaryCenDsrcTolling` - as specified in ETSI TS 102 792 [14],"]
+    #[doc = " * - 2 - `unavailable`             - default value. Set to 2 for backwards compatibility with DSRC tolling,"]
+    #[doc = " * - 3 - `urbanRail`               - as specified in ETSI TS 103 724 [13], clause 7,"]
+    #[doc = " * - 4 - `satelliteStation`        - as specified in ETSI TS 103 724 [13], clause 7,"]
+    #[doc = " * - 5 - `fixedLinks`              - as specified in ETSI TS 103 724 [13], clause 7."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum InterferenceManagementZoneType {
+        permanentCenDsrcTolling = 0,
+        temporaryCenDsrcTolling = 1,
+        unavailable = 2,
+        urbanRail = 3,
+        satelliteStation = 4,
+        fixedLinks = 5,
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of up to 16 interference  management zones.  "]
+    #[doc = " *"]
+    #[doc = " * **EXAMPLE**: An interference management communication zone may be defined around a CEN DSRC road side equipment or an urban rail operational area."]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct InterferenceManagementZones(pub SequenceOf<InterferenceManagementZone>);
+    #[doc = "*"]
+    #[doc = " * This DF represents a unique id for an intersection, in accordance with ETSI TS 103 301 [15]."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field region: the optional identifier of the entity that is responsible for the region in which the intersection is placed."]
+    #[doc = " * It is the duty of that entity to guarantee that the @ref Id is unique within the region."]
+    #[doc = " *"]
+    #[doc = " * @field id: the identifier of the intersection"]
+    #[doc = " *"]
+    #[doc = " * @note: when the component region is present, the IntersectionReferenceId is guaranteed to be globally unique."]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct IntersectionReferenceId {
+        pub region: Option<Identifier2B>,
+        pub id: Identifier2B,
+    }
+    impl IntersectionReferenceId {
+        pub fn new(region: Option<Identifier2B>, id: Identifier2B) -> Self {
+            Self { region, id }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the vehicle type according to ISO 3833 [22]."]
+    #[doc = " * A \"term No\" refers to the number of the corresponding term and its definition in ISO 3833."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0\t- `passengerCar`              - term No 3.1.1"]
+    #[doc = " * - 1\t- `saloon`                    - term No 3.1.1.1 (sedan)"]
+    #[doc = " * - 2\t- `convertibleSaloon`         - term No 3.1.1.2"]
+    #[doc = " * - 3\t- `pullmanSaloon`             - term No 3.1.1.3"]
+    #[doc = " * - 4\t- `stationWagon`              - term No 3.1.1.4"]
+    #[doc = " * - 5\t- `truckStationWagon`         - term No 3.1.1.4.1"]
+    #[doc = " * - 6\t- `coupe`                     - term No 3.1.1.5 (coupe)"]
+    #[doc = " * - 7\t- `convertible`               - term No 3.1.1.6 (open tourer, roadstar, spider)"]
+    #[doc = " * - 8\t- `multipurposePassengerCar`  - term No 3.1.1.7"]
+    #[doc = " * - 9\t- `forwardControlPassengerCar`- term No 3.1.1.8"]
+    #[doc = " * - 10\t- `specialPassengerCar`       - term No 3.1.1.9"]
+    #[doc = " * - 11\t- `bus`                       - term No 3.1.2"]
+    #[doc = " * - 12\t- `minibus`                   - term No 3.1.2.1"]
+    #[doc = " * - 13\t- `urbanBus`                  - term No 3.1.2.2"]
+    #[doc = " * - 14\t- `interurbanCoach`           - term No 3.1.2.3"]
+    #[doc = " * - 15\t- `longDistanceCoach`         - term No 3.1.2.4"]
+    #[doc = " * - 16\t- `articulatedBus`            - term No 3.1.2.5"]
+    #[doc = " * - 17\t- `trolleyBus\t`             - term No 3.1.2.6"]
+    #[doc = " * - 18\t- `specialBus`                - term No 3.1.2.7"]
+    #[doc = " * - 19\t- `commercialVehicle`         - term No 3.1.3"]
+    #[doc = " * - 20\t- `specialCommercialVehicle`  - term No 3.1.3.1"]
+    #[doc = " * - 21\t- `specialVehicle`            - term No 3.1.4"]
+    #[doc = " * - 22\t- `trailingTowingVehicle`     - term No 3.1.5 (draw-bar tractor)"]
+    #[doc = " * - 23\t- `semiTrailerTowingVehicle`  - term No 3.1.6 (fifth wheel tractor)"]
+    #[doc = " * - 24\t- `trailer`                   - term No 3.2.1"]
+    #[doc = " * - 25\t- `busTrailer`                - term No 3.2.1.1"]
+    #[doc = " * - 26\t- `generalPurposeTrailer`     - term No 3.2.1.2"]
+    #[doc = " * - 27\t- `caravan`                   - term No 3.2.1.3"]
+    #[doc = " * - 28\t- `specialTrailer`            - term No 3.2.1.4"]
+    #[doc = " * - 29\t- `semiTrailer`               - term No 3.2.2"]
+    #[doc = " * - 30\t- `busSemiTrailer`            - term No 3.2.2.1"]
+    #[doc = " * - 31\t- `generalPurposeSemiTrailer` - term No 3.2.2.2"]
+    #[doc = " * - 32\t- `specialSemiTrailer`        - term No 3.2.2.3"]
+    #[doc = " * - 33\t- `roadTrain`                 - term No 3.3.1"]
+    #[doc = " * - 34\t- `passengerRoadTrain`        - term No 3.3.2"]
+    #[doc = " * - 35\t- `articulatedRoadTrain`      - term No 3.3.3"]
+    #[doc = " * - 36\t- `doubleRoadTrain`           - term No 3.3.4"]
+    #[doc = " * - 37\t- `compositeRoadTrain`        - term No 3.3.5"]
+    #[doc = " * - 38\t- `specialRoadTrain`          - term No 3.3.6"]
+    #[doc = " * - 39\t- `moped`                     - term No 3.4"]
+    #[doc = " * - 40\t- `motorCycle`                - term No 3.5"]
+    #[doc = " * - 41-255                           - reserved for future use"]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct Iso3833VehicleType(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represent the identifier of an organization according to the applicable registry."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1 based on ISO 14816 [23]"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=16383"))]
+    pub struct IssuerIdentifier(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF shall contain  a list of waypoints @ref ReferencePosition."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=40"))]
+    pub struct ItineraryPath(pub SequenceOf<ReferencePosition>);
+    #[doc = "*"]
+    #[doc = " * This DF represents a common message header for application and facilities layer messages."]
+    #[doc = " * It is included at the beginning of an ITS message as the message header."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field protocolVersion: version of the ITS message."]
+    #[doc = " *"]
+    #[doc = " * @field messageId: type of the ITS message."]
+    #[doc = " *"]
+    #[doc = " * @field stationId: the identifier of the ITS-S that generated the ITS message."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision:  update in V2.1.1: messageID and stationID changed to messageId and stationId; messageId is of type MessageId."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ItsPduHeader {
+        #[rasn(identifier = "protocolVersion")]
+        pub protocol_version: OrdinalNumber1B,
+        #[rasn(identifier = "messageId")]
+        pub message_id: MessageId,
+        #[rasn(identifier = "stationId")]
+        pub station_id: StationId,
+    }
+    impl ItsPduHeader {
+        pub fn new(
+            protocol_version: OrdinalNumber1B,
+            message_id: MessageId,
+            station_id: StationId,
+        ) -> Self {
+            Self {
+                protocol_version,
+                message_id,
+                station_id,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents the identifier of the IVIM."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1 based on ETSI TS 103 301 [15]"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=32767", extensible))]
+    pub struct IviIdentificationNumber(pub Integer);
+    #[doc = "*"]
+    #[doc = " * This DF provides the reference to the information contained in a IVIM according to ETSI TS 103 301 [15]. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field serviceProviderId: identifier of the organization that provided the IVIM."]
+    #[doc = " *"]
+    #[doc = " * @field iviIdentificationNumber: identifier of the IVIM, as assigned by the organization identified in serviceProviderId."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct IvimReference {
+        #[rasn(identifier = "serviceProviderId")]
+        pub service_provider_id: Provider,
+        #[rasn(identifier = "iviIdentificationNumber")]
+        pub ivi_identification_number: IviIdentificationNumber,
+    }
+    impl IvimReference {
+        pub fn new(
+            service_provider_id: Provider,
+            ivi_identification_number: IviIdentificationNumber,
+        ) -> Self {
+            Self {
+                service_provider_id,
+                ivi_identification_number,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref IvimReference."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct IvimReferences(pub SequenceOf<IvimReference>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway. "]
+    #[doc = " *"]
+    #[doc = " * For right-hand traffic roads, the value shall be set to:"]
+    #[doc = " * - `-1` if the position is off, i.e. besides the road,"]
+    #[doc = " * - `0` if the position is on the inner hard shoulder, i.e. the hard should adjacent to the leftmost lane,"]
+    #[doc = " * - `n` (`n > 0` and `n < 14`), if the position is on the n-th driving lane counted from the leftmost lane to the rightmost lane of a specific traffic direction,"]
+    #[doc = " * - `14` if the position is on the outer hard shoulder, i.e. the hard should adjacent to rightmost lane (if present)."]
+    #[doc = " *"]
+    #[doc = " * For left-hand traffic roads, the value shall be set to:"]
+    #[doc = " * - `-1` if the position is off, i.e. besides the road,"]
+    #[doc = " * - `0` if the position is on the inner hard shoulder, i.e. the hard should adjacent to the rightmost lane,"]
+    #[doc = " * - `n` (`n > 0` and `n < 14`), if the position is on the n-th driving lane counted from the rightmost lane to the leftmost lane of a specific traffic direction,"]
+    #[doc = " * - `14` if the position is on the outer hard shoulder, i.e. the hard should adjacent to leftmost lane (if present)."]
+    #[doc = " *"]
+    #[doc = " *  @note: in practice this means that the position is counted from \"inside\" to \"outside\" no matter which traffic practice is used."]
+    #[doc = " *"]
+    #[doc = " * If the carriageway allows only traffic in one direction (e.g. in case of dual or multiple carriageway roads), the position is counted from the physical border of the carriageway. "]
+    #[doc = " * If the carriageway allows traffic in both directions and there is no physical delimitation between traffic directions (e.g. on a single carrriageway road), "]
+    #[doc = " * the position is counted from the legal (i.e. optical) separation between traffic directions (horizontal marking). "]
+    #[doc = " *"]
+    #[doc = " * If not indicated otherwise (by lane markings or traffic signs), the legal separation on carriageways allowing traffic on both directions is identified as follows:"]
+    #[doc = " * - If the total number of lanes N is even, the lanes are divided evenly between the traffic directions starting from the outside of the carriageway on both sides and the "]
+    #[doc = " *   imaginary separation between traffic directions is on the border between the even number of lanes N/2."]
+    #[doc = " * - If the total number of lanes N is odd, the lanes are divided evenly between traffic direction starting from the outside of the carriageway on both sides. "]
+    #[doc = " *   The remaining middle lane is assigned to both traffic directions as innermost lane."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Description of the legal separation of carriageways added in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-1..=14"))]
+    pub struct LanePosition(pub i8);
+    #[doc = "*"]
+    #[doc = " * This DF indicates a transversal position in resolution of lanes and other associated details."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field transversalPosition: the transversal position."]
+    #[doc = " * "]
+    #[doc = " * @field laneType: the type of the lane identified in the component transversalPosition. By default set to `traffic`."]
+    #[doc = " *"]
+    #[doc = " * @field direction: the traffic direction for the lane position relative to a defined reference direction. By default set to `sameDirection`, i.e. following the reference direction."]
+    #[doc = " *"]
+    #[doc = " * @category Road topology information"]
+    #[doc = " * @revision: direction added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct LanePositionAndType {
+        #[rasn(identifier = "transversalPosition")]
+        pub transversal_position: LanePosition,
+        #[rasn(
+            default = "lane_position_and_type_lane_type_default",
+            identifier = "laneType"
+        )]
+        pub lane_type: LaneType,
+        #[rasn(default = "lane_position_and_type_direction_default")]
+        pub direction: Direction,
+    }
+    impl LanePositionAndType {
+        pub fn new(
+            transversal_position: LanePosition,
+            lane_type: LaneType,
+            direction: Direction,
+        ) -> Self {
+            Self {
+                transversal_position,
+                lane_type,
+                direction,
+            }
+        }
+    }
+    fn lane_position_and_type_lane_type_default() -> LaneType {
+        LaneType(0)
+    }
+    fn lane_position_and_type_direction_default() -> Direction {
+        Direction(0)
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a set of options to describe a lane position and is the second level DF to represent a lane position. The top-level DFs are @ref GeneralizedLanePosition or @ref OccupiedLanesWithConfidence. "]
+    #[doc = " * A lane position is a transversal position on the carriageway at a specific longitudinal position, in resolution of lanes of the carriageway."]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " *"]
+    #[doc = " * @field simplelanePosition: a single lane position without any additional context information."]
+    #[doc = " *"]
+    #[doc = " * @field simpleLaneType: a lane type, to be used when the lane position is unknown but the type of lane is known. This can be used in scenarios where a certain confidence about the used lane type is given "]
+    #[doc = " * but no or limited knowledge about the absolute lane number is available. For example, a cyclist on a cycle-lane or vehicles on a specific lane that is unique for the part of the road (e.g. a bus lane)."]
+    #[doc = " * "]
+    #[doc = " * @field detailedlanePosition: a single lane position with additional lane details."]
+    #[doc = " * "]
+    #[doc = " * @field lanePositionWithLateralDetails: a single lane position with additional details and the lateral position within the lane."]
+    #[doc = " *"]
+    #[doc = " * @field trafficIslandPosition: a position on a traffic island, i.e. between two lanes. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.2.1 from the DF GeneralizedLanePosition of V2.1.1. "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum LanePositionOptions {
+        simplelanePosition(LanePosition),
+        simpleLaneType(LaneType),
+        detailedlanePosition(LanePositionAndType),
+        lanePositionWithLateralDetails(LanePositionWithLateralDetails),
+        trafficIslandPosition(TrafficIslandPosition),
+    }
+    #[doc = "*"]
+    #[doc = " * This DF is a third-level DF that represents a lane position and is an extended version of @ref LanePositionAndType that adds the distances to the left and right lane border."]
+    #[doc = " *"]
+    #[doc = " * It shall additionally include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field distanceToLeftBorder: the distance of the transversal position to the left lane border. The real value shall be rounded to the next lower encoding-value."]
+    #[doc = " *"]
+    #[doc = " * @field distanceToRightBorder: the distance of the transversal position to the right lane border. The real value shall be rounded to the next lower encoding-value."]
+    #[doc = " * "]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct LanePositionWithLateralDetails {
+        #[rasn(identifier = "distanceToLeftBorder")]
+        pub distance_to_left_border: StandardLength9b,
+        #[rasn(identifier = "distanceToRightBorder")]
+        pub distance_to_right_border: StandardLength9b,
+        #[rasn(identifier = "transversalPosition")]
+        pub transversal_position: LanePosition,
+        #[rasn(
+            default = "lane_position_with_lateral_details_lane_type_default",
+            identifier = "laneType"
+        )]
+        pub lane_type: LaneType,
+        #[rasn(default = "lane_position_with_lateral_details_direction_default")]
+        pub direction: Direction,
+    }
+    impl LanePositionWithLateralDetails {
+        pub fn new(
+            distance_to_left_border: StandardLength9b,
+            distance_to_right_border: StandardLength9b,
+            transversal_position: LanePosition,
+            lane_type: LaneType,
+            direction: Direction,
+        ) -> Self {
+            Self {
+                distance_to_left_border,
+                distance_to_right_border,
+                transversal_position,
+                lane_type,
+                direction,
+            }
+        }
+    }
+    fn lane_position_with_lateral_details_lane_type_default() -> LaneType {
+        LaneType(0)
+    }
+    fn lane_position_with_lateral_details_direction_default() -> Direction {
+        Direction(0)
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the type of a lane. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0\t- `traffic`            - Lane dedicated to the movement of vehicles,"]
+    #[doc = " * - 1\t- `through`            - Lane dedicated to the movement of vehicles travelling ahead and not turning,"]
+    #[doc = " * - 2\t- `reversible`         - Lane where the direction of traffic can be changed to match the peak flow,"]
+    #[doc = " * - 3\t- `acceleration`\t   - Lane that allows vehicles entering a road to accelerate to the speed of through traffic before merging with it,"]
+    #[doc = " * - 4\t- `deceleration`       - Lane that allows vehicles exiting a road to decelerate before leaving it,"]
+    #[doc = " * - 5\t- `leftHandTurning`    - Lane reserved for slowing down and making a left turn, so as not to disrupt traffic,"]
+    #[doc = " * - 6\t- `rightHandTurning`   - Lane reserved for slowing down and making a right turn so as not to disrupt traffic,"]
+    #[doc = " * - 7\t- `dedicatedVehicle`   - Lane dedicated to movement of motor vehicles with specific characteristics, such as heavy goods vehicles, etc., "]
+    #[doc = " * - 8\t- `bus`                - Lane dedicated to movement of buses providing public transport,"]
+    #[doc = " * - 9\t- `taxi`               - Lane dedicated to movement of taxis,"]
+    #[doc = " * - 10\t- `hov`                - Carpooling lane or high occupancy vehicle lane,"]
+    #[doc = " * - 11\t- `hot`                - High occupancy vehicle lanes that is allowed to be used without meeting the occupancy criteria by paying a toll,"]
+    #[doc = " * - 12\t- `pedestrian`         - Lanes dedicated to pedestrians such as pedestrian sidewalk paths,"]
+    #[doc = " * - 13\t- `cycleLane`\t       - Lane dedicated to exclusive or preferred use by bicycles,"]
+    #[doc = " * - 14\t- `median`             - Lane not dedicated to movement of vehicles but representing a median / central reservation  such as the central median, "]
+    #[doc = "                                 separating the two directional carriageways of the highway,"]
+    #[doc = " * - 15\t- `striping`\t       - Lane not dedicated to movement of vehicles but covered with roadway markings,"]
+    #[doc = " * - 16\t- `trackedVehicle`     - Lane dedicated to movement of trains, trams and trolleys,"]
+    #[doc = " * - 17\t- `parking`            - Lanes dedicated to vehicles parking, stopping and loading lanes,"]
+    #[doc = " * - 18\t- `emergency`          - Lane dedicated to vehicles in breakdown or to emergency vehicles also called hard shoulder,"]
+    #[doc = " * - 19\t- `verge`              - Lane representing the verge, i.e. a narrow strip of grass or plants and sometimes also trees located between "]
+    #[doc = "                                 the road surface edge and the boundary of a road,"]
+    #[doc = " * - 20\t`minimumRiskManoeuvre` - Lane dedicated to automated vehicles making a minimum risk manoeuvre,"]
+    #[doc = " * - 21\t`separatedCycleLane`   - Lane dedicated to exclusive or preferred use by bicycles that is phyisically separated from the vehicle-traffic lanes, e.g. by a verge."]
+    #[doc = " * - values 22 to 30             reserved for future use. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.1.1, named value 21 added in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=31"))]
+    pub struct LaneType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the width of a lane measured at a defined position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 1022`) if the lane width information is equal to or less than n x 0,01 metre and more than (n-1) x 0,01 metre,"]
+    #[doc = " * - `1022` if the lane width is out of range, i.e. greater than 10,21 m,"]
+    #[doc = " * - `1023` if the lane width information is not available."]
+    #[doc = " *"]
+    #[doc = " * The value 0 shall not be used."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,01 metre"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=1023"))]
+    pub struct LaneWidth(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF indicates the vehicle acceleration at lateral direction and the confidence value of the lateral acceleration."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field lateralAccelerationValue: lateral acceleration value at a point in time."]
+    #[doc = " * "]
+    #[doc = " * @field lateralAccelerationConfidence: confidence value of the lateral acceleration value."]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead."]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LateralAcceleration {
+        #[rasn(identifier = "lateralAccelerationValue")]
+        pub lateral_acceleration_value: LateralAccelerationValue,
+        #[rasn(identifier = "lateralAccelerationConfidence")]
+        pub lateral_acceleration_confidence: AccelerationConfidence,
+    }
+    impl LateralAcceleration {
+        pub fn new(
+            lateral_acceleration_value: LateralAccelerationValue,
+            lateral_acceleration_confidence: AccelerationConfidence,
+        ) -> Self {
+            Self {
+                lateral_acceleration_value,
+                lateral_acceleration_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the vehicle acceleration at lateral direction in the centre of the mass of the empty vehicle."]
+    #[doc = " * It corresponds to the vehicle coordinate system as specified in ISO 8855 [21]."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-160` for acceleration values equal to or less than -16 m/s^2,"]
+    #[doc = " * - `n` (`n > -160` and `n <= 0`) to indicate that the vehicle is accelerating towards the right side with regards to the vehicle orientation "]
+    #[doc = " *                            with acceleration equal to or less than n x 0,1 m/s^2 and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `n` (`n > 0` and `n < 160`) to indicate that the vehicle is accelerating towards the left hand side with regards to the vehicle orientation "]
+    #[doc = "\t\t\t\t\t\t     with acceleration equal to or less than n x 0,1 m/s^2 and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `160` for acceleration values greater than 15,9 m/s^2,"]
+    #[doc = " * - `161` when the data is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @note: the empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationValue instead."]
+    #[doc = " *  "]
+    #[doc = " * @unit: 0,1 m/s^2"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description updated in V2.1.1 (the meaning of 160 has changed slightly). "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-160..=161"))]
+    pub struct LateralAccelerationValue(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the absolute geographical latitude in a WGS84 coordinate system, providing a range of 90 degrees in north or"]
+    #[doc = " * in south hemisphere."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= -900 000 000` and `n < 0`) x 10^-7 degree, i.e. negative values for latitudes south of the Equator,"]
+    #[doc = " * - `0` is used for the latitude of the equator,"]
+    #[doc = " * - `n` (`n > 0` and `n < 900 000 001`) x 10^-7 degree, i.e. positive values for latitudes north of the Equator,"]
+    #[doc = " * - `900 000 001` when the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 10^-7 degree"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-900000000..=900000001"))]
+    pub struct Latitude(pub i32);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the status of light bar and any sort of audible alarm system besides the horn."]
+    #[doc = " * This includes various common sirens as well as backup up beepers and other slow speed manoeuvring alerts."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 - `lightBarActivated`      - when the light bar is activated,"]
+    #[doc = " * - 1 - `sirenActivated`         - when the siren is activated."]
+    #[doc = " *"]
+    #[doc = " * Otherwise, it shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct LightBarSirenInUse(pub FixedBitString<2usize>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the absolute geographical longitude in a WGS84 coordinate system, providing a range of 180 degrees"]
+    #[doc = " * to the east or to the west of the prime meridian."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > -1 800 000 000` and `n < 0`) x 10^-7 degree, i.e. negative values for longitudes to the west,"]
+    #[doc = " * - `0` to indicate the prime meridian,"]
+    #[doc = " * - `n` (`n > 0` and `n < 1 800 000 001`) x 10^-7 degree, i.e. positive values for longitudes to the east,"]
+    #[doc = " * - `1 800 000 001` when the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * The value -1 800 000 000 shall not be used. "]
+    #[doc = " * "]
+    #[doc = " * @unit: 10^-7 degree"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-1800000000..=1800000001"))]
+    pub struct Longitude(pub i32);
+    #[doc = "*"]
+    #[doc = " * This DF indicates the vehicle acceleration at longitudinal direction and the confidence value of the longitudinal acceleration."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field longitudinalAccelerationValue: longitudinal acceleration value at a point in time."]
+    #[doc = ""]
+    #[doc = " * @field longitudinalAccelerationConfidence: confidence value of the longitudinal acceleration value."]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead. "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LongitudinalAcceleration {
+        #[rasn(identifier = "longitudinalAccelerationValue")]
+        pub longitudinal_acceleration_value: LongitudinalAccelerationValue,
+        #[rasn(identifier = "longitudinalAccelerationConfidence")]
+        pub longitudinal_acceleration_confidence: AccelerationConfidence,
+    }
+    impl LongitudinalAcceleration {
+        pub fn new(
+            longitudinal_acceleration_value: LongitudinalAccelerationValue,
+            longitudinal_acceleration_confidence: AccelerationConfidence,
+        ) -> Self {
+            Self {
+                longitudinal_acceleration_value,
+                longitudinal_acceleration_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the vehicle acceleration at longitudinal direction in the centre of the mass of the empty vehicle."]
+    #[doc = " * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-160` for acceleration values equal to or less than -16 m/s^2,"]
+    #[doc = " * - `n` (`n > -160` and `n <= 0`) to indicate that the vehicle is braking with acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2"]
+    #[doc = " * - `n` (`n > 0` and `n < 160`) to indicate that the vehicle is accelerating with acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `160` for acceleration values greater than 15,9 m/s^2,"]
+    #[doc = " * - `161` when the data is unavailable. "]
+    #[doc = " * "]
+    #[doc = " * This acceleration is along the tangent plane of the road surface and does not include gravity components."]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationValue instead."]
+    #[doc = " * "]
+    #[doc = " * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " * @unit: 0,1 m/s^2"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: description revised in V2.1.1 (the meaning of 160 has changed slightly). T"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-160..=161"))]
+    pub struct LongitudinalAccelerationValue(pub i16);
+    #[doc = "* "]
+    #[doc = " * This DF represents the estimated position along the longitudinal extension of a carriageway or lane. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field  longitudinalLanePositionValue: the mean value of the longitudinal position along the carriageway or lane w.r.t. an externally defined start position."]
+    #[doc = " *"]
+    #[doc = " * @field  longitudinalLanePositionConfidence: The confidence value associated to the value."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: created in V2.1.1, description revised in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LongitudinalLanePosition {
+        #[rasn(identifier = "longitudinalLanePositionValue")]
+        pub longitudinal_lane_position_value: LongitudinalLanePositionValue,
+        #[rasn(identifier = "longitudinalLanePositionConfidence")]
+        pub longitudinal_lane_position_confidence: LongitudinalLanePositionConfidence,
+    }
+    impl LongitudinalLanePosition {
+        pub fn new(
+            longitudinal_lane_position_value: LongitudinalLanePositionValue,
+            longitudinal_lane_position_confidence: LongitudinalLanePositionConfidence,
+        ) -> Self {
+            Self {
+                longitudinal_lane_position_value,
+                longitudinal_lane_position_confidence,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates the longitudinal lane position confidence value which represents the estimated accuracy of longitudinal lane position measurement with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 1 022`) if the  confidence value is equal to or less than n x 0,1 m, and more than (n-1) x 0,1 m,"]
+    #[doc = " * - `1 022` if the confidence value is out of range i.e. greater than 102,1 m,"]
+    #[doc = " * - `1 023` if the confidence value is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 metre"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=1023"))]
+    pub struct LongitudinalLanePositionConfidence(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DE represents the longitudinal offset of a map-matched position along a matched lane, beginning from the lane's starting point."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 0` and `n < 32766`) if the longitudinal offset information is equal to or less than n x 0,1 metre and more than (n-1) x 0,1 metre,"]
+    #[doc = " * - `32 766` if the longitudinal offset is out of range, i.e. greater than 3276,5 m,"]
+    #[doc = " * - `32 767` if the longitudinal offset information is not available. "]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 metre"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct LongitudinalLanePositionValue(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DF shall contain a list of a lower triangular positive semi-definite matrices."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct LowerTriangularPositiveSemidefiniteMatrices(
+        pub SequenceOf<LowerTriangularPositiveSemidefiniteMatrix>,
+    );
+    #[doc = "* "]
+    #[doc = " * This DF represents a lower triangular positive semi-definite matrix. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field componentsIncludedIntheMatrix: the indication of which components of a @ref PerceivedObject are included in the matrix. "]
+    #[doc = " * This component also implicitly indicates the number n of included components which defines the size (n x n) of the full correlation matrix \"A\"."]
+    #[doc = " *"]
+    #[doc = " * @field matrix: the list of cells of the lower triangular positive semi-definite matrix ordered by columns and by rows. "]
+    #[doc = " *"]
+    #[doc = " * The number of columns to be included \"k\" is equal to the number of included components \"n\" indicated by componentsIncludedIntheMatrix minus 1: k = n-1."]
+    #[doc = " * These components shall be included in the order or their appearance in componentsIncludedIntheMatrix."]
+    #[doc = " * Each column \"i\" of the lowerTriangularCorrelationMatrixColumns contains k-(i-1) values."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LowerTriangularPositiveSemidefiniteMatrix {
+        #[rasn(identifier = "componentsIncludedIntheMatrix")]
+        pub components_included_inthe_matrix: MatrixIncludedComponents,
+        pub matrix: LowerTriangularPositiveSemidefiniteMatrixColumns,
+    }
+    impl LowerTriangularPositiveSemidefiniteMatrix {
+        pub fn new(
+            components_included_inthe_matrix: MatrixIncludedComponents,
+            matrix: LowerTriangularPositiveSemidefiniteMatrixColumns,
+        ) -> Self {
+            Self {
+                components_included_inthe_matrix,
+                matrix,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents the columns of a lower triangular positive semi-definite matrix, each column not including the main diagonal cell of the matrix."]
+    #[doc = " * Given a matrix \"A\" of size n x n, the number of @ref CorrelationColumn to be included in the lower triangular matrix is k=n-1."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1, extension indicator added in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=13", extensible))]
+    pub struct LowerTriangularPositiveSemidefiniteMatrixColumns(pub SequenceOf<CorrelationColumn>);
+    #[doc = "*"]
+    #[doc = " * This DF indicates a position on a topology description transmitted in a MAPEM according to ETSI TS 103 301 [15]."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field mapReference: optionally identifies the MAPEM containing the topology information."]
+    #[doc = " * It is absent if the MAPEM topology is known from the context."]
+    #[doc = " * "]
+    #[doc = " * @field laneId: optionally identifies the lane in the road segment or intersection topology on which the position is located."]
+    #[doc = " *"]
+    #[doc = " * @field connectionId: optionally identifies the connection inside the conflict area of an intersection, i.e. it identifies a trajectory for travelling through the"]
+    #[doc = " * conflict area of an intersection which connects e.g an ingress with an egress lane."]
+    #[doc = " *"]
+    #[doc = " * @field longitudinalLanePosition: optionally indicates the longitudinal offset of the map-matched position of the object along the lane or connection measured from the start of the lane/connection, along the lane."]
+    #[doc = " * "]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.1.1, definition of longitudinalLanePosition amended in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MapPosition {
+        #[rasn(identifier = "mapReference")]
+        pub map_reference: Option<MapReference>,
+        #[rasn(identifier = "laneId")]
+        pub lane_id: Option<Identifier1B>,
+        #[rasn(identifier = "connectionId")]
+        pub connection_id: Option<Identifier1B>,
+        #[rasn(identifier = "longitudinalLanePosition")]
+        pub longitudinal_lane_position: Option<LongitudinalLanePosition>,
+    }
+    impl MapPosition {
+        pub fn new(
+            map_reference: Option<MapReference>,
+            lane_id: Option<Identifier1B>,
+            connection_id: Option<Identifier1B>,
+            longitudinal_lane_position: Option<LongitudinalLanePosition>,
+        ) -> Self {
+            Self {
+                map_reference,
+                lane_id,
+                connection_id,
+                longitudinal_lane_position,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF provides the reference to the information contained in a MAPEM according to ETSI TS 103 301 [15]. "]
+    #[doc = " *"]
+    #[doc = " * The following options are provided:"]
+    #[doc = " * "]
+    #[doc = " * @field roadsegment: option that identifies the description of a road segment contained in a MAPEM."]
+    #[doc = " * "]
+    #[doc = " * @field intersection: option that identifies the description of an intersection contained in a MAPEM."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum MapReference {
+        roadsegment(RoadSegmentReferenceId),
+        intersection(IntersectionReferenceId),
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref MapReference."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct MapReferences(pub SequenceOf<MapReference>);
+    #[doc = "* "]
+    #[doc = " * This DF provides information about the configuration of a road section in terms of MAPEM lanes or connections using a list of @ref MapemExtractedElementReference. "]
+    #[doc = ""]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct MapemConfiguration(pub SequenceOf<MapemElementReference>);
+    #[doc = "* "]
+    #[doc = " * This DF provides references to MAPEM connections using a list of @ref Identifier1B."]
+    #[doc = " * Note: connections are  allowed Ã¯Â¿Â½maneuversÃ¯Â¿Â½ (e.g. an ingress / egress relation) on an intersection."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct MapemConnectionList(pub SequenceOf<Identifier1B>);
+    #[doc = "* "]
+    #[doc = " * This DF provides references to an element described in a MAPEM according to ETSI TS 103 301 [i.15], such as a lane or connection at a specific intersection or road segment. "]
+    #[doc = " * "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field mapReference: the optional reference to a MAPEM that describes the intersection or road segment. It is absent if the MAPEM topology is known from the context."]
+    #[doc = " * "]
+    #[doc = " * @field laneIds: the optional list of the identifiers of the lanes to be referenced. "]
+    #[doc = " * "]
+    #[doc = " * @field connectionIds: the optional list of the identifiers of the connections to be referenced. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MapemElementReference {
+        #[rasn(identifier = "mapReference")]
+        pub map_reference: Option<MapReference>,
+        #[rasn(identifier = "laneIds")]
+        pub lane_ids: Option<MapemLaneList>,
+        #[rasn(identifier = "connectionIds")]
+        pub connection_ids: Option<MapemConnectionList>,
+    }
+    impl MapemElementReference {
+        pub fn new(
+            map_reference: Option<MapReference>,
+            lane_ids: Option<MapemLaneList>,
+            connection_ids: Option<MapemConnectionList>,
+        ) -> Self {
+            Self {
+                map_reference,
+                lane_ids,
+                connection_ids,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF provides references to MAPEM lanes using a list of @ref Identifier1B."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in 2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct MapemLaneList(pub SequenceOf<Identifier1B>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the components of an @ref PerceivedObject that are included in the @ref LowerTriangularPositiveSemidefiniteMatrix."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 if the component is included:"]
+    #[doc = " * - 0 - `xCoordinate`                   - when the component xCoordinate of the component @ref CartesianPosition3dWithConfidence is included,"]
+    #[doc = " * - 1 - `yCoordinate`                   - when the component yCoordinate of the component @ref CartesianPosition3dWithConfidence is included,   "]
+    #[doc = " * - 2 - `zCoordinate`                   - when the component zCoordinate of the component @ref CartesianPosition3dWithConfidence is included, "]
+    #[doc = " * - 3 - `xVelocityOrVelocityMagnitude`  - when the component xVelocity of the component @ref VelocityCartesian or the component VelocityMagnitude of the component @ref VelocityPolarWithZ is included,   "]
+    #[doc = " * - 4 - `yVelocityOrVelocityDirection`  - when the component yVelocity of the component @ref VelocityCartesian or the component VelocityDirection of the component @ref VelocityPolarWithZ is included,   "]
+    #[doc = " * - 5 - `zVelocity`                     - when the component zVelocity of the component @ref VelocityCartesian or of the component @ref VelocityPolarWithZ is included,"]
+    #[doc = " * - 6 - `xAccelOrAccelMagnitude`        - when the component xAcceleration of the component @ref AccelerationCartesian or the component AccelerationMagnitude of the component @ref AccelerationPolarWithZ is included,  "]
+    #[doc = " * - 7 - `yAccelOrAccelDirection`        - when the component yAcceleration of the component @ref AccelerationCartesian or the component AccelerationDirection of the component @ref AccelerationPolarWithZ is included,   "]
+    #[doc = " * - 8 - `zAcceleration`                 - when the component zAcceleration of the component @ref AccelerationCartesian or of the component @ref AccelerationPolarWithZ is included,"]
+    #[doc = " * - 9 - `zAngle`                        - when the component zAngle is included,"]
+    #[doc = " * - 10 - `yAngle`                       - when the component yAngle is included,   "]
+    #[doc = " * - 11 - `xAngle`                       - when the component xAngle is included,   "]
+    #[doc = " * - 12 - `zAngularVelocity`             - when the component zAngularVelocity is included.   "]
+    #[doc = " *"]
+    #[doc = " * Otherwise, it shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("13", extensible))]
+    pub struct MatrixIncludedComponents(pub BitString);
+    #[doc = "* "]
+    #[doc = " * This DE represents the type of facility layer message."]
+    #[doc = " *"]
+    #[doc = " *  The value shall be set to:"]
+    #[doc = " *\t- 1  - `denm`              - for Decentralized Environmental Notification Message (DENM) as specified in ETSI EN 302 637-3 [2],"]
+    #[doc = " *  - 2  - `cam`               - for Cooperative Awareness Message (CAM) as specified in ETSI EN 302 637-2 [1],"]
+    #[doc = " *  - 3  - `poim`              - for Point of Interest Message as specified in ETSI TS 103 916 [9],"]
+    #[doc = " *  - 4  - `spatem`            - for Signal Phase And Timing Extended Message (SPATEM) as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 5  - `mapem`             - for MAP Extended Message (MAPEM) as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 6  - `ivim`              - for in Vehicle Information Message (IVIM) as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 7  - `rfu1`              - reserved for future usage,"]
+    #[doc = " *  - 8  - `rfu2`              - reserved for future usage,"]
+    #[doc = " *  - 9  - `srem`              - for Signal Request Extended Message as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 10 - `ssem`              - for Signal request Status Extended Message as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 11 - `evcsn`             - for Electrical Vehicle Charging Spot Notification message as specified in ETSI TS 101 556-1 [9],"]
+    #[doc = " *  - 12 - `saem`              - for Services Announcement Extended Message as specified in ETSI EN 302 890-1 [17],"]
+    #[doc = " *  - 13 - `rtcmem`            - for Radio Technical Commission for Maritime Services Extended Message (RTCMEM) as specified in ETSI TS 103 301 [15],"]
+    #[doc = " *  - 14 - `cpm`               - for Collective Perception Message (CPM) as specified in ETSI TS 103 324 [10], "]
+    #[doc = " *  - 15 - `imzm`              - for Interference Management Zone Message (IMZM) as specified in ETSI TS 103 724 [13],"]
+    #[doc = " *  - 16 - `vam`               - for Vulnerable Road User Awareness Message as specified in ETSI TS 130 300-3 [12], "]
+    #[doc = " *  - 17 - `dsm`               - reserved for Diagnosis, logging and Status Message,"]
+    #[doc = " *  - 18 - `mim`               - for Marshalling Infrastructure Message as specified in ETSI TS TS 103 882 [11],"]
+    #[doc = " *  - 19 - `mvm`               - for Marshalling Vehicle Message as specified in ETSI TS TS 103 882 [11],"]
+    #[doc = " *  - 20 - `mcm`               - reserved for Manoeuvre Coordination Message,"]
+    #[doc = " *  - 21 - `pim`               - reserved for Parking Information Message, "]
+    #[doc = " *  - 22-255                   - reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1 from @ref ItsPduHeader. Value 3 re-assigned to poim and value 7 and 8 reserved in V2.2.1, values 18 and 19 assigned in V2.3.1, "]
+    #[doc = "              value 21 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct MessageId(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF indicates a message rate."]
+    #[doc = " *"]
+    #[doc = " * @field mantissa: indicates the mantissa."]
+    #[doc = " *"]
+    #[doc = " * @field exponent: indicates the exponent."]
+    #[doc = " *"]
+    #[doc = " * The specified message rate is: mantissa*(10^exponent) "]
+    #[doc = " *"]
+    #[doc = " * @unit: Hz"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MessageRateHz {
+        #[rasn(value("1..=100"))]
+        pub mantissa: u8,
+        #[rasn(value("-5..=2"))]
+        pub exponent: i8,
+    }
+    impl MessageRateHz {
+        pub fn new(mantissa: u8, exponent: i8) -> Self {
+            Self { mantissa, exponent }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF provides information about a message with respect to the segmentation process on facility layer at the sender."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field totalMsgNo: indicates the total number of messages that have been assembled on the transmitter side to encode the information "]
+    #[doc = " * during the same messsage generation process."]
+    #[doc = " *"]
+    #[doc = " * @field thisMsgNo: indicates the position of the message within of the total set of messages generated during the same message generation process."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1, description revised in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MessageSegmentationInfo {
+        #[rasn(identifier = "totalMsgNo")]
+        pub total_msg_no: CardinalNumber3b,
+        #[rasn(identifier = "thisMsgNo")]
+        pub this_msg_no: OrdinalNumber3b,
+    }
+    impl MessageSegmentationInfo {
+        pub fn new(total_msg_no: CardinalNumber3b, this_msg_no: OrdinalNumber3b) -> Self {
+            Self {
+                total_msg_no,
+                this_msg_no,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF provides information about the source of and confidence in information."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field usedDetectionInformation: the type of sensor(s) that is used to provide the detection information."]
+    #[doc = " * "]
+    #[doc = " * @field usedStoredInformation: the type of source of the stored information. "]
+    #[doc = " *"]
+    #[doc = " * @field confidenceValue: an optional confidence value associated to the information. "]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MetaInformation {
+        #[rasn(identifier = "usedDetectionInformation")]
+        pub used_detection_information: SensorTypes,
+        #[rasn(identifier = "usedStoredInformation")]
+        pub used_stored_information: StoredInformationType,
+        #[rasn(identifier = "confidenceValue")]
+        pub confidence_value: Option<ConfidenceLevel>,
+    }
+    impl MetaInformation {
+        pub fn new(
+            used_detection_information: SensorTypes,
+            used_stored_information: StoredInformationType,
+            confidence_value: Option<ConfidenceLevel>,
+        ) -> Self {
+            Self {
+                used_detection_information,
+                used_stored_information,
+                confidence_value,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref MitigationPerTechnologyClass."]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8"))]
+    pub struct MitigationForTechnologies(pub SequenceOf<MitigationPerTechnologyClass>);
+    #[doc = "*"]
+    #[doc = " * This DF represents a set of mitigation parameters for a specific technology, as specified in ETSI TS 103 724 [24], clause 7."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field accessTechnologyClass:  channel access technology to which this mitigation is intended to be applied."]
+    #[doc = " *"]
+    #[doc = " * @field lowDutyCycle: duty cycle limit."]
+    #[doc = " * @unit: 0,01 % steps"]
+    #[doc = " *"]
+    #[doc = " * @field powerReduction: the delta value of power to be reduced."]
+    #[doc = " * @unit: dB"]
+    #[doc = " *"]
+    #[doc = " * @field dmcToffLimit: idle time limit as defined in ETSI TS 103 175 [19]."]
+    #[doc = " * @unit: ms"]
+    #[doc = " *"]
+    #[doc = " * @field dmcTonLimit: Transmission duration limit, as defined in ETSI EN 302 571 [20]."]
+    #[doc = " * @unit: ms"]
+    #[doc = " *"]
+    #[doc = " * @note: All parameters are optional, as they may not apply to some of the technologies or"]
+    #[doc = " * interference management zone types. Specification details are in ETSI TS 103 724 [24], clause 7. "]
+    #[doc = " *"]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MitigationPerTechnologyClass {
+        #[rasn(identifier = "accessTechnologyClass")]
+        pub access_technology_class: AccessTechnologyClass,
+        #[rasn(value("0..=10000"), identifier = "lowDutyCycle")]
+        pub low_duty_cycle: Option<u16>,
+        #[rasn(value("0..=30"), identifier = "powerReduction")]
+        pub power_reduction: Option<u8>,
+        #[rasn(value("0..=1200"), identifier = "dmcToffLimit")]
+        pub dmc_toff_limit: Option<u16>,
+        #[rasn(value("0..=20"), identifier = "dmcTonLimit")]
+        pub dmc_ton_limit: Option<u8>,
+    }
+    impl MitigationPerTechnologyClass {
+        pub fn new(
+            access_technology_class: AccessTechnologyClass,
+            low_duty_cycle: Option<u16>,
+            power_reduction: Option<u8>,
+            dmc_toff_limit: Option<u16>,
+            dmc_ton_limit: Option<u8>,
+        ) -> Self {
+            Self {
+                access_technology_class,
+                low_duty_cycle,
+                power_reduction,
+                dmc_toff_limit,
+                dmc_ton_limit,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE provides a factor to be multiplied with a DE that represents a measure of something, to extend the range/change the unit. "]
+    #[doc = " * The DE that is multiplied is to be specified outside of the context of this DE, e.g. in a facility layer service specification."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `tenth`      - to indicate a factor of 0,1,        "]
+    #[doc = " * - `half`       - to indicate a factor of 0,5,        "]
+    #[doc = " * - `two`        - to indicate a factor of 2,        "]
+    #[doc = " * - `three`      - to indicate a factor of 3,        "]
+    #[doc = " * - `five`       - to indicate a factor of 5,        "]
+    #[doc = " * - `tenth`      - to indicate a factor of 10,        "]
+    #[doc = " * - `fifthy`     - to indicate a factor of 50,        "]
+    #[doc = " * - `hundred`    - to indicate a factor of 100,        "]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum MultiplicativeFactor {
+        tenth = 0,
+        half = 1,
+        two = 2,
+        three = 3,
+        five = 4,
+        ten = 5,
+        fifty = 6,
+        hundred = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the number of occupants in a vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 0` and `n < 126`) for the number n of occupants,"]
+    #[doc = " * - `126` for values equal to or higher than 125,"]
+    #[doc = " * - `127` if information is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit: 1 person"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=127"))]
+    pub struct NumberOfOccupants(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DF indicates both the class and associated subclass that best describes an object."]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " *"]
+    #[doc = " * @field vehicleSubClass: the object is a road vehicle and the specific subclass is specified."]
+    #[doc = " *"]
+    #[doc = " * @field vruSubClass: the object is a VRU and the specific subclass is specified."]
+    #[doc = " *"]
+    #[doc = " * @field groupSubClass: the object is a VRU group or cluster and the cluster information is specified."]
+    #[doc = " *"]
+    #[doc = " * @field otherSubClass: the object is of a different type than the above and the specific subclass is specified."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ObjectClass {
+        #[rasn(value("0..=14"))]
+        vehicleSubClass(TrafficParticipantType),
+        vruSubClass(VruProfileAndSubprofile),
+        #[rasn(value("0.."))]
+        groupSubClass(VruClusterInformation),
+        otherSubClass(OtherSubClass),
+    }
+    #[doc = "* "]
+    #[doc = " * This DF shall contain a list of object classes."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8"))]
+    pub struct ObjectClassDescription(pub SequenceOf<ObjectClassWithConfidence>);
+    #[doc = "* "]
+    #[doc = " * This DF represents the classification of a detected object together with a confidence level."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field objectClass: the class of the object."]
+    #[doc = " *"]
+    #[doc = " * @field Confidence: the associated confidence level."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ObjectClassWithConfidence {
+        #[rasn(identifier = "objectClass")]
+        pub object_class: ObjectClass,
+        pub confidence: ConfidenceLevel,
+    }
+    impl ObjectClassWithConfidence {
+        pub fn new(object_class: ObjectClass, confidence: ConfidenceLevel) -> Self {
+            Self {
+                object_class,
+                confidence,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents a dimension of an object together with a confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field value: the object dimension value which can be estimated as the mean of the current distribution."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ObjectDimension {
+        pub value: ObjectDimensionValue,
+        pub confidence: ObjectDimensionConfidence,
+    }
+    impl ObjectDimension {
+        pub fn new(value: ObjectDimensionValue, confidence: ObjectDimensionConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates the object dimension confidence value which represents the estimated absolute accuracy of an object dimension value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 31`) if the confidence value is equal to or less than n x 0,1 metre, and more than (n-1) x 0,1 metre,"]
+    #[doc = " * - `31` if the confidence value is out of range i.e. greater than 3,0 m,"]
+    #[doc = " * - `32` if the confidence value is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 m"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=32"))]
+    pub struct ObjectDimensionConfidence(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents a single dimension of an object."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 255`) if the dimension is equal to or less than n x 0,1 m, and more than (n-1) x 0,1 m,"]
+    #[doc = " * - `255` if the dimension is out of range i.e. greater than 25,4 m,"]
+    #[doc = " * - `256` if the dimension is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 m"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1, corrected the wording in V2.4.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=256"))]
+    pub struct ObjectDimensionValue(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the face or part of a face of a solid object."]
+    #[doc = " *"]
+    #[doc = " * The object is modelled  as a rectangular prism that has a length that is greater than its width, with the faces of the object being defined as:"]
+    #[doc = " * - front: the face defined by the prism's width and height, and which is the first face in direction of longitudinal movement of the object,"]
+    #[doc = " * - back: the face defined by the prism's width and height, and which is the last face in direction of longitudinal movement of the object,"]
+    #[doc = " * - side: the faces defined by the prism's length and height with \"left\" and \"right\" defined by looking at the front face and \"front\" and \"back\" defined w.r.t to the front and back faces. "]
+    #[doc = " *"]
+    #[doc = " * Note: It is permissible to derive the required object dimensions and orientation from models to provide a best guess."]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum ObjectFace {
+        front = 0,
+        sideLeftFront = 1,
+        sideLeftBack = 2,
+        sideRightFront = 3,
+        sideRightBack = 4,
+        back = 5,
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents a single-value indication about the overall information quality of a perceived object."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:  "]
+    #[doc = " * - `0`                        : if there is no confidence in detected object, e.g. for \"ghost\"-objects or if confidence could not be computed,"]
+    #[doc = " * - `n` (`n > 0` and `n < 15`) : for the applicable confidence value,"]
+    #[doc = " * - `15`                       : if there is full confidence in the detected Object."]
+    #[doc = " * "]
+    #[doc = " * @unit n/a"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct ObjectPerceptionQuality(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a set of lanes which are partially or fully occupied by an object or event at an externally defined reference position. "]
+    #[doc = " *"]
+    #[doc = " * @note: In contrast to @ref GeneralizedLanePosition, the dimension of the object or event area (width and length) is taken into account to determine the occupancy, "]
+    #[doc = " * i.e. this DF describes the lanes which are blocked by an object or event and not the position of the object / event itself. A confidence is used to describe the "]
+    #[doc = " * probability that exactly all the provided lanes are occupied. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field lanePositionBased: a set of up to `4` lanes that are partially or fully occupied by an object or event, ordered by increasing value of @ref LanePosition. "]
+    #[doc = " * Lanes that are partially occupied can be described using the component lanePositionWithLateralDetails of @ref  Options, with the following constraints: "]
+    #[doc = " * The distance to lane borders which are covered by the object / event shall be set to 0. Only the distances to the leftmost and/or rightmost border which are not covered by "]
+    #[doc = " * the object / event shall be provided with values > 0. Those values shall be added to the respective instances of @ref LanePositionOptions, i.e. the first entry shall contain the component distanceToLeftBorder > 0 , "]
+    #[doc = " * and/or the last entry shall contain the component distanceToRightBorder > 0; the respective other components of these entries shall be set to 0."]
+    #[doc = " * "]
+    #[doc = " * @field mapBased: optional lane information described in the context of a MAPEM as specified in ETSI TS 103 301 [15]. "]
+    #[doc = " * If present, it shall describe the same lane(s) as listed in the component lanePositionBased, but using the lane identification of the MAPEM. This component can be used only if a "]
+    #[doc = " * MAPEM is available for the reference position (e.g. on an intersection): In this case it is used as a synonym to the mandatory component lanePositionBased. "]
+    #[doc = " *"]
+    #[doc = " * @field confidence: mandatory confidence information for expressing the probability that all the provided lanes are occupied. It also provides information on how the lane "]
+    #[doc = " * information were generated. If none of the sensors were used, the lane information is assumed to be derived directly from the absolute reference position and the related dimension."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct OccupiedLanesWithConfidence {
+        #[rasn(size("1..=4"), identifier = "lanePositionBased")]
+        pub lane_position_based: SequenceOf<LanePositionOptions>,
+        #[rasn(size("1..=4"), identifier = "mapBased")]
+        pub map_based: Option<SequenceOf<MapPosition>>,
+        pub confidence: MetaInformation,
+    }
+    impl OccupiedLanesWithConfidence {
+        pub fn new(
+            lane_position_based: SequenceOf<LanePositionOptions>,
+            map_based: Option<SequenceOf<MapPosition>>,
+            confidence: MetaInformation,
+        ) -> Self {
+            Self {
+                lane_position_based,
+                map_based,
+                confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents a time period to describe the opening days and hours of a Point of Interest."]
+    #[doc = " * (for example local commerce)."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct OpeningDaysHours(pub Utf8String);
+    #[doc = "*"]
+    #[doc = " * The DE represents an ordinal number that indicates the position of an element in a set. "]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct OrdinalNumber1B(pub u8);
+    #[doc = "*"]
+    #[doc = " * The DE represents an ordinal number that indicates the position of an element in a set. "]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=8"))]
+    pub struct OrdinalNumber3b(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the subclass of a detected object for @ref ObjectClass \"otherSubclass\"."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` - unknown          - if the subclass is unknown."]
+    #[doc = " * - `1` - singleObject     - if the object is a single object."]
+    #[doc = " * - `2` - multipleObjects  - if the object is a group of multiple objects."]
+    #[doc = " * - `3` - bulkMaterial     - if the object is a bulk material."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct OtherSubClass(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the arrangement of parking space in a parking area."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` to indicate that the parking spaces are arranged in a line and parallel to a road or curb,"]
+    #[doc = " * - `1` to indicate that the parking spaces are arranged side-by-side and diagonally to a curb,"]
+    #[doc = " * - `2` to indicate that the parking spaces are arranged side-by-side and perpendicularly to a curb,"]
+    #[doc = " * - `3` to indicate that the parking spaces are arranged so that vehicles form a queue,"]
+    #[doc = " * - `4` to indicate that the parking spaces are arranged in a mixed fashion, "]
+    #[doc = " * - 5-7 - reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=7"))]
+    pub struct ParkingAreaArrangementType(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DF indicates the allowed type of occupancy of a parking space/area in terms of time and/or usage."]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " * "]
+    #[doc = " * @field unknown: indicates that the allowed type of occupancy is unknown."]
+    #[doc = " *"]
+    #[doc = " * @field unlimitedOccupancy: indicates that it can be occupied without limits."]
+    #[doc = " *"]
+    #[doc = " * @field onlyWhileCharging: indicates that it can be occupied only while charging an electric vehicle."]
+    #[doc = " *"]
+    #[doc = " * @field limitedDuration: indicates that it can be occupied for a limited and indicated duration in minutes."]
+    #[doc = " *"]
+    #[doc = " * @field onlyWhileChargingLimitedDuration: indicates that it can be occupied only while charging an electric vehicle and only for a limited and indicated duration in minutes."]
+    #[doc = " *"]
+    #[doc = " * @field parkingAllowedUntil: indicates that it can be occupied only until an indicated moment in time."]
+    #[doc = " *"]
+    #[doc = " * @field forcedParkingUntil: indicates that it can be occupied and departure is possible only after an indicated moment in time."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.3.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ParkingOccupancyInfo {
+        unknown(()),
+        unlimitedOccupancy(()),
+        onlyWhileCharging(()),
+        limitedDuration(Integer),
+        onlyWhileChargingLimitedDuration(Integer),
+        parkingAllowedUntil(TimestampIts),
+        forcedParkingUntil(TimestampIts),
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates the type of a reservation of a parking space/area."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` to indicate that it is reserved to disabled persons,"]
+    #[doc = " * - `1` to indicate that it is reserved to pregnant women,"]
+    #[doc = " * - `2` to indicate that it is reserved to women,"]
+    #[doc = " * - `3` to indicate that it is reserved to parents with small children,"]
+    #[doc = " * - `4` to indicate that it is reserved for loading and unloading of goods,"]
+    #[doc = " * - `5` to indicate that it is reserved for manual charging of electric vehicles,"]
+    #[doc = " * - `6` to indicate that it is reserved for automated charging of electric vehicles,"]
+    #[doc = " * - `7` to indicate that it is reserved for vehicles carrying out refrigerated transport of goods,"]
+    #[doc = " * - `8` to indicate that it is reserved for VIPs,"]
+    #[doc = " * - `9` to indicate that it is reserved for pre-booked reservations only,"]
+    #[doc = " * - `10` to indicate that it is not reserved and can still be reserved,"]
+    #[doc = " * - `11` to indicate that a reservation type is not applicable, i.e. that it cannot be reserved,"]
+    #[doc = " * - `12` to indicate that it reserved for drop-off and pick-up of vehicles for automated valet parking,"]
+    #[doc = " * - `13` to indicate that it is reserved for vehicles with a permit,"]
+    #[doc = " * - `14` to indicate that it is an (often unmarked / undesignated, but still not prohibited) space/area which is reserved for use only on occasions "]
+    #[doc = "          when all official marked parking spaces to which it blocks the access (if any), are already occupied at the moment of arrival."]
+    #[doc = " * - 15-31  - reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.3.1, value 14 assigned in V2.4.1."]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=31"))]
+    pub struct ParkingReservationType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF provides basic information about the parking capabilities and availabilities of a single parking space. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field id: the unqiue identifier of the parking space within the parking area."]
+    #[doc = " *"]
+    #[doc = " * @field location: the optional location of the geometrical center of the parking space w.r.t. the location of the parking area."]
+    #[doc = " *"]
+    #[doc = " * @field status: the actual status of the parking space."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.3.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ParkingSpaceBasic {
+        pub id: Identifier2B,
+        pub location: Option<DeltaReferencePosition>,
+        pub status: ParkingSpaceStatus,
+    }
+    impl ParkingSpaceBasic {
+        pub fn new(
+            id: Identifier2B,
+            location: Option<DeltaReferencePosition>,
+            status: ParkingSpaceStatus,
+        ) -> Self {
+            Self {
+                id,
+                location,
+                status,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF provides detailed information about the parking capabilities and availabilities of a single parking space. "]
+    #[doc = " * "]
+    #[doc = " * It is an extension of @ref ParkingSpaceBasic and it shall additionally include the following additional components: "]
+    #[doc = " *"]
+    #[doc = " * @field arrangementType: the optional arrangement of the parking space w.r.t. other spaces."]
+    #[doc = " * This is component, if present, overrides the common arrangementType defined in the @ref ParkingArea."]
+    #[doc = " *"]
+    #[doc = " * @field boundary: the optional physical boundary of the parking space as a polygon w.r.t. the location of the parking space."]
+    #[doc = " *"]
+    #[doc = " * @field orientation: the optional orientation of the parking space."]
+    #[doc = " * This is component, if present, overrides the common orientation defined in the @ref ParkingArea."]
+    #[doc = " *"]
+    #[doc = " * @field occupancyRule: the occupancy rule applicable to the parking space."]
+    #[doc = " *"]
+    #[doc = " * @field chargingStationId: the optional identitfier of a charging station that serves the parking space."]
+    #[doc = " *"]
+    #[doc = " * @field accessViaLane: the optional identifier of a lane that provides access to the parking space."]
+    #[doc = " *"]
+    #[doc = " * @field accessViaParkingSpaces: the optional identifier(s) of a parking spaces that provide access to the parking space."]
+    #[doc = " * "]
+    #[doc = " * @field reservationType: the optional parking reservation type(s) associated to the parking space."]
+    #[doc = " * This is component, if present, overrides the common reservationType defined in the @ref ParkingArea."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.3.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ParkingSpaceDetailed {
+        #[rasn(identifier = "arrangementType")]
+        pub arrangement_type: Option<ParkingAreaArrangementType>,
+        pub boundary: Option<DeltaPositions>,
+        pub orientation: Option<Wgs84Angle>,
+        #[rasn(identifier = "occupancyRule")]
+        pub occupancy_rule: ParkingOccupancyInfo,
+        #[rasn(identifier = "chargingStationId")]
+        pub charging_station_id: Option<Identifier2B>,
+        #[rasn(identifier = "accessViaLane")]
+        pub access_via_lane: Option<Identifier2B>,
+        #[rasn(size("0..=7"), identifier = "accessViaParkingSpaces")]
+        pub access_via_parking_spaces: Option<SequenceOf<Identifier2B>>,
+        #[rasn(size("1..=4", extensible), identifier = "reservationType")]
+        pub reservation_type: Option<SequenceOf<ParkingReservationType>>,
+        pub id: Identifier2B,
+        pub location: Option<DeltaReferencePosition>,
+        pub status: ParkingSpaceStatus,
+    }
+    impl ParkingSpaceDetailed {
+        pub fn new(
+            arrangement_type: Option<ParkingAreaArrangementType>,
+            boundary: Option<DeltaPositions>,
+            orientation: Option<Wgs84Angle>,
+            occupancy_rule: ParkingOccupancyInfo,
+            charging_station_id: Option<Identifier2B>,
+            access_via_lane: Option<Identifier2B>,
+            access_via_parking_spaces: Option<SequenceOf<Identifier2B>>,
+            reservation_type: Option<SequenceOf<ParkingReservationType>>,
+            id: Identifier2B,
+            location: Option<DeltaReferencePosition>,
+            status: ParkingSpaceStatus,
+        ) -> Self {
+            Self {
+                arrangement_type,
+                boundary,
+                orientation,
+                occupancy_rule,
+                charging_station_id,
+                access_via_lane,
+                access_via_parking_spaces,
+                reservation_type,
+                id,
+                location,
+                status,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF indicates the status of parking space."]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " * "]
+    #[doc = " * @field unknown: indicates that the status is unknown."]
+    #[doc = " *"]
+    #[doc = " * @field free: indicates that the parking space is free and hence available to be used."]
+    #[doc = " *"]
+    #[doc = " * @field freeUntil: indicates that the parking space is free to be used until an indicated moment in time."]
+    #[doc = " *"]
+    #[doc = " * @field fullyOccupied: indicates that the parking space is interely occupied."]
+    #[doc = " *"]
+    #[doc = " * @field partiallyOccupied: indicates that the parking space that allows parking of multiple vehicles is occupied by an indicated percentage."]
+    #[doc = " *"]
+    #[doc = " * @field occupiedUntil: indicates that the parking space is entirely occupied until an indicated moment in time."]
+    #[doc = " *"]
+    #[doc = " * @field reservedUntil: indicates that the parking space is reserved (but not necessarily occupied) until an indicated moment in time."]
+    #[doc = " *"]
+    #[doc = " * @field accessBlocked: indicates that the parking space cannot accessed, e.g. due to obstructing vehicles."]
+    #[doc = " *"]
+    #[doc = " * @field retrictedUsage: indicates that the parking space is available but that it is not an official parking space and that there are some phyiscal restrictions applicable, "]
+    #[doc = " * such as parking behind or in front of other vehicles that, depending on the situation, may then have problems entering or leaving their respective parking spaces."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.3.1 "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ParkingSpaceStatus {
+        unknown(()),
+        free(()),
+        freeUntil(TimestampIts),
+        fullyOccupied(()),
+        #[rasn(value("0..=100"))]
+        partiallyOccupied(u8),
+        occupiedUntil(TimestampIts),
+        reservedUntil(TimestampIts),
+        accessBlocked(()),
+        retrictedUsage(()),
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a path with a set of path points."]
+    #[doc = " * It shall contain up to `40` @ref PathPoint. "]
+    #[doc = " * "]
+    #[doc = " * The first PathPoint presents an offset delta position with regards to an external reference position."]
+    #[doc = " * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. "]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information, Vehicle information"]
+    #[doc = " * @revision: created in V2.1.1 based on PathHistory"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("0..=40"))]
+    pub struct Path(pub SequenceOf<PathPoint>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the recorded or estimated travel time between a position and a predefined reference position. "]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 second"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=65535", extensible))]
+    pub struct PathDeltaTime(pub Integer);
+    #[doc = "*"]
+    #[doc = " * This DF represents estimated/predicted travel time between a position and a predefined reference position. "]
+    #[doc = " *"]
+    #[doc = " * the following options are available:"]
+    #[doc = " * "]
+    #[doc = " * @field deltaTimeHighPrecision: delta time with precision of 0,1 s."]
+    #[doc = " *"]
+    #[doc = " * @field deltaTimeBigRange: delta time with precision of 10 s."]
+    #[doc = " *"]
+    #[doc = " * @field deltaTimeMidRange: delta time with precision of 1 s."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1, added deltaTimeMidRange extension in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PathDeltaTimeChoice {
+        deltaTimeHighPrecision(DeltaTimeTenthOfSecond),
+        deltaTimeBigRange(DeltaTimeTenSeconds),
+        #[rasn(extension_addition)]
+        deltaTimeMidRange(DeltaTimeSecond),
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents a path towards a specific point specified in the @ref EventZone."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field pointOfEventZone: the ordinal number of the point within the DF EventZone, i.e. within the list of EventPoints."]
+    #[doc = " *"]
+    #[doc = " * @field path: the associated path towards the point specified in pointOfEventZone."]
+    #[doc = " * The first PathPoint presents an offset delta position with regards to the position of that pointOfEventZone."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PathExtended {
+        #[rasn(value("1..=23"), identifier = "pointOfEventZone")]
+        pub point_of_event_zone: u8,
+        pub path: Path,
+    }
+    impl PathExtended {
+        pub fn new(point_of_event_zone: u8, path: Path) -> Self {
+            Self {
+                point_of_event_zone,
+                path,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a path history with a set of path points."]
+    #[doc = " * It shall contain up to `40` @ref PathPoint. "]
+    #[doc = " * "]
+    #[doc = " * The first PathPoint presents an offset delta position with regards to an external reference position."]
+    #[doc = " * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. "]
+    #[doc = " *"]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref Path instead."]
+    #[doc = " * @category: GeoReference information, Vehicle information"]
+    #[doc = " * @revision: semantics updated in V2.1.1, size corrected to 0..40 in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("0..=40"))]
+    pub struct PathHistory(pub SequenceOf<PathPoint>);
+    #[doc = "* "]
+    #[doc = " * This DE indicates an ordinal number that represents the position of a component in the list of @ref Traces or @ref TracesExtended. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` - noPath  - if no path is identified"]
+    #[doc = " * - `1..7`        - for instances 1..7 of @ref Traces "]
+    #[doc = " * - `8..14`       - for instances 1..7 of @ref TracesExtended. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=14"))]
+    pub struct PathId(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF defines an offset waypoint position within a path."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field pathPosition: The waypoint position defined as an offset position with regards to a pre-defined reference position. "]
+    #[doc = " *"]
+    #[doc = " * @field pathDeltaTime: The optional travel time separated from a waypoint to the predefined reference position."]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: semantics updated in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PathPoint {
+        #[rasn(identifier = "pathPosition")]
+        pub path_position: DeltaReferencePosition,
+        #[rasn(identifier = "pathDeltaTime")]
+        pub path_delta_time: Option<PathDeltaTime>,
+    }
+    impl PathPoint {
+        pub fn new(
+            path_position: DeltaReferencePosition,
+            path_delta_time: Option<PathDeltaTime>,
+        ) -> Self {
+            Self {
+                path_position,
+                path_delta_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF defines a predicted offset position that can be used within a predicted path or trajectory, together with optional data to describe a path zone shape."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field deltaLatitude: the offset latitude with regards to a pre-defined reference position. "]
+    #[doc = " *"]
+    #[doc = " * @field deltaLongitude: the offset longitude with regards to a pre-defined reference position. "]
+    #[doc = " * "]
+    #[doc = " * @field horizontalPositionConfidence: the optional confidence value associated to the horizontal geographical position."]
+    #[doc = " *"]
+    #[doc = " * @field deltaAltitude: the optional offset altitude with regards to a pre-defined reference position, with default value unavailable. "]
+    #[doc = " *"]
+    #[doc = " * @field altitudeConfidence: the optional confidence value associated to the altitude value of the geographical position, with default value unavailable."]
+    #[doc = " * "]
+    #[doc = " * @field pathDeltaTime: the optional travel time to the waypoint from the predefined reference position."]
+    #[doc = ""]
+    #[doc = " * @field symmetricAreaOffset: the optional symmetric offset to generate a shape, see Annex D for details."]
+    #[doc = " *  "]
+    #[doc = " * @field asymmetricAreaOffset: the optional asymmetric offset to generate a shape, see Annex D for details. "]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1, type of pathDeltaTime changed and optionality added, fields symmetricAreaOffset and asymmetricAreaOffset added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PathPointPredicted {
+        #[rasn(identifier = "deltaLatitude")]
+        pub delta_latitude: DeltaLatitude,
+        #[rasn(identifier = "deltaLongitude")]
+        pub delta_longitude: DeltaLongitude,
+        #[rasn(identifier = "horizontalPositionConfidence")]
+        pub horizontal_position_confidence: Option<PosConfidenceEllipse>,
+        #[rasn(
+            default = "path_point_predicted_delta_altitude_default",
+            identifier = "deltaAltitude"
+        )]
+        pub delta_altitude: DeltaAltitude,
+        #[rasn(
+            default = "path_point_predicted_altitude_confidence_default",
+            identifier = "altitudeConfidence"
+        )]
+        pub altitude_confidence: AltitudeConfidence,
+        #[rasn(identifier = "pathDeltaTime")]
+        pub path_delta_time: Option<PathDeltaTimeChoice>,
+        #[rasn(identifier = "symmetricAreaOffset")]
+        pub symmetric_area_offset: Option<StandardLength9b>,
+        #[rasn(identifier = "asymmetricAreaOffset")]
+        pub asymmetric_area_offset: Option<StandardLength9b>,
+    }
+    impl PathPointPredicted {
+        pub fn new(
+            delta_latitude: DeltaLatitude,
+            delta_longitude: DeltaLongitude,
+            horizontal_position_confidence: Option<PosConfidenceEllipse>,
+            delta_altitude: DeltaAltitude,
+            altitude_confidence: AltitudeConfidence,
+            path_delta_time: Option<PathDeltaTimeChoice>,
+            symmetric_area_offset: Option<StandardLength9b>,
+            asymmetric_area_offset: Option<StandardLength9b>,
+        ) -> Self {
+            Self {
+                delta_latitude,
+                delta_longitude,
+                horizontal_position_confidence,
+                delta_altitude,
+                altitude_confidence,
+                path_delta_time,
+                symmetric_area_offset,
+                asymmetric_area_offset,
+            }
+        }
+    }
+    fn path_point_predicted_delta_altitude_default() -> DeltaAltitude {
+        DeltaAltitude(12800)
+    }
+    fn path_point_predicted_altitude_confidence_default() -> AltitudeConfidence {
+        AltitudeConfidence::unavailable
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a predicted path or trajectory with a set of predicted points and optional information to generate a shape which is estimated to contain the real path. "]
+    #[doc = " * It shall contain up to `16` @ref PathPointPredicted. "]
+    #[doc = " * "]
+    #[doc = " * The first PathPoint presents an offset delta position with regards to an external reference position."]
+    #[doc = " * Each other PathPoint presents an offset delta position and optionally an offset travel time with regards to the previous PathPoint. "]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1 , size constraint changed to SIZE(1..16, ...) in V2.2.1, size extended in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct PathPredicted(pub SequenceOf<PathPointPredicted>);
+    #[doc = "* "]
+    #[doc = " * This DF represents a predicted path, predicted trajectory or predicted path zone together with usage information and a prediction confidence."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field pathPredicted: the predicted path (pathDeltaTime ABSENT) or trajectory (pathDeltaTime PRESENT) and/or the path zone (symmetricAreaOffset PRESENT)."]
+    #[doc = " *"]
+    #[doc = " * @field usageIndication: an indication of how the predicted path will be used. "]
+    #[doc = " *"]
+    #[doc = " * @field confidenceLevel: the confidence that the path/trajectory in pathPredicted will occur as predicted."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: created in V2.2.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PathPredicted2 {
+        #[rasn(value("0.."), identifier = "pathPredicted")]
+        pub path_predicted: PathPredicted,
+        #[rasn(identifier = "usageIndication")]
+        pub usage_indication: UsageIndication,
+        #[rasn(identifier = "confidenceLevel")]
+        pub confidence_level: ConfidenceLevel,
+    }
+    impl PathPredicted2 {
+        pub fn new(
+            path_predicted: PathPredicted,
+            usage_indication: UsageIndication,
+            confidence_level: ConfidenceLevel,
+        ) -> Self {
+            Self {
+                path_predicted,
+                usage_indication,
+                confidence_level,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents one or more predicted paths, or trajectories or path zones (zones that include all possible paths/trajectories within its boundaries) using @ref PathPredicted2."]
+    #[doc = " * It shall contain up to `16` @ref PathPredicted2. "]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct PathPredictedList(pub SequenceOf<PathPredicted2>);
+    #[doc = "* "]
+    #[doc = " * This DF represents a list of references to the components of a @ref Traces or @ref TracesExtended DF using the @ref PathId. "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=14"))]
+    pub struct PathReferences(pub SequenceOf<PathId>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the position of a vehicle pedal (e.g. brake or accelerator pedal)."]
+    #[doc = " *"]
+    #[doc = " * @unit: 10%"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=11"))]
+    pub struct PedalPositionValue(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE contains information about the status of a vehicle pedal."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field pedalPositionValue: information about the pedal position. "]
+    #[doc = " *"]
+    #[doc = " * @category: vehicle information"]
+    #[doc = " * @revision: created in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PedalStatus {
+        #[rasn(identifier = "pedalPositionValue")]
+        pub pedal_position_value: PedalPositionValue,
+    }
+    impl PedalStatus {
+        pub fn new(pedal_position_value: PedalPositionValue) -> Self {
+            Self {
+                pedal_position_value,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DF contains information about a perceived object including its kinematic state and attitude vector in a pre-defined coordinate system and with respect to a reference time."]
+    #[doc = " * "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field objectId: optional identifier assigned to a detected object."]
+    #[doc = " *"]
+    #[doc = " * @field measurementDeltaTime: the time difference from a reference time to the time of the  measurement of the object. "]
+    #[doc = " * Negative values indicate that the provided object state refers to a point in time before the reference time."]
+    #[doc = " *"]
+    #[doc = " * @field position: the position of the geometric centre of the object's bounding box within the pre-defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * @field velocity: the velocity vector of the object within the pre-defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * @field acceleration: the acceleration vector of the object within the pre-defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * @field angles: optional Euler angles of the object bounding box at the time of measurement. "]
+    #[doc = " * "]
+    #[doc = " * @field zAngularVelocity: optional angular velocity of the object around the z-axis at the time of measurement."]
+    #[doc = " * The angular velocity is measured with positive values considering the object orientation turning around the z-axis using the right-hand rule."]
+    #[doc = " *"]
+    #[doc = " * @field lowerTriangularCorrelationMatrices: optional set of lower triangular correlation matrices for selected components of the provided kinematic state and attitude vector."]
+    #[doc = " *"]
+    #[doc = " * @field objectDimensionZ: optional z-dimension of object bounding box. "]
+    #[doc = " * This dimension shall be measured along the direction of the z-axis after all the rotations have been applied. "]
+    #[doc = " *"]
+    #[doc = " * @field objectDimensionY: optional y-dimension of the object bounding box. "]
+    #[doc = " * This dimension shall be measured along the direction of the y-axis after all the rotations have been applied. "]
+    #[doc = " *"]
+    #[doc = " * @field objectDimensionX: optional x-dimension of object bounding box."]
+    #[doc = " * This dimension shall be measured along the direction of the x-axis after all the rotations have been applied."]
+    #[doc = " * "]
+    #[doc = " * @field objectAge: optional age of the detected and described object, i.e. the difference in time between the moment "]
+    #[doc = " * it has been first detected and the reference time of the message. Value `1500` indicates that the object has been observed for more than 1.5s."]
+    #[doc = " *"]
+    #[doc = " * @field objectPerceptionQuality: optional confidence associated to the object. "]
+    #[doc = " *"]
+    #[doc = " * @field sensorIdList: optional list of sensor-IDs which provided the measurement data. "]
+    #[doc = " *"]
+    #[doc = " * @field classification: optional classification of the described object"]
+    #[doc = " *"]
+    #[doc = " * @field matchedPosition: optional map-matched position of an object."]
+    #[doc = " *"]
+    #[doc = " * @category Sensing information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PerceivedObject {
+        #[rasn(identifier = "objectId")]
+        pub object_id: Option<Identifier2B>,
+        #[rasn(identifier = "measurementDeltaTime")]
+        pub measurement_delta_time: DeltaTimeMilliSecondSigned,
+        pub position: CartesianPosition3dWithConfidence,
+        pub velocity: Option<Velocity3dWithConfidence>,
+        pub acceleration: Option<Acceleration3dWithConfidence>,
+        pub angles: Option<EulerAnglesWithConfidence>,
+        #[rasn(identifier = "zAngularVelocity")]
+        pub z_angular_velocity: Option<CartesianAngularVelocityComponent>,
+        #[rasn(identifier = "lowerTriangularCorrelationMatrices")]
+        pub lower_triangular_correlation_matrices:
+            Option<LowerTriangularPositiveSemidefiniteMatrices>,
+        #[rasn(identifier = "objectDimensionZ")]
+        pub object_dimension_z: Option<ObjectDimension>,
+        #[rasn(identifier = "objectDimensionY")]
+        pub object_dimension_y: Option<ObjectDimension>,
+        #[rasn(identifier = "objectDimensionX")]
+        pub object_dimension_x: Option<ObjectDimension>,
+        #[rasn(value("0..=2047"), identifier = "objectAge")]
+        pub object_age: Option<DeltaTimeMilliSecondSigned>,
+        #[rasn(identifier = "objectPerceptionQuality")]
+        pub object_perception_quality: Option<ObjectPerceptionQuality>,
+        #[rasn(identifier = "sensorIdList")]
+        pub sensor_id_list: Option<SequenceOfIdentifier1B>,
+        pub classification: Option<ObjectClassDescription>,
+        #[rasn(identifier = "mapPosition")]
+        pub map_position: Option<MapPosition>,
+    }
+    impl PerceivedObject {
+        pub fn new(
+            object_id: Option<Identifier2B>,
+            measurement_delta_time: DeltaTimeMilliSecondSigned,
+            position: CartesianPosition3dWithConfidence,
+            velocity: Option<Velocity3dWithConfidence>,
+            acceleration: Option<Acceleration3dWithConfidence>,
+            angles: Option<EulerAnglesWithConfidence>,
+            z_angular_velocity: Option<CartesianAngularVelocityComponent>,
+            lower_triangular_correlation_matrices: Option<
+                LowerTriangularPositiveSemidefiniteMatrices,
+            >,
+            object_dimension_z: Option<ObjectDimension>,
+            object_dimension_y: Option<ObjectDimension>,
+            object_dimension_x: Option<ObjectDimension>,
+            object_age: Option<DeltaTimeMilliSecondSigned>,
+            object_perception_quality: Option<ObjectPerceptionQuality>,
+            sensor_id_list: Option<SequenceOfIdentifier1B>,
+            classification: Option<ObjectClassDescription>,
+            map_position: Option<MapPosition>,
+        ) -> Self {
+            Self {
+                object_id,
+                measurement_delta_time,
+                position,
+                velocity,
+                acceleration,
+                angles,
+                z_angular_velocity,
+                lower_triangular_correlation_matrices,
+                object_dimension_z,
+                object_dimension_y,
+                object_dimension_x,
+                object_age,
+                object_perception_quality,
+                sensor_id_list,
+                classification,
+                map_position,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE denotes the ability of an ITS-S to provide information fullfilling additional requirements."]
+    #[doc = " * A performance class value is used to describe characteristics of data. The semantic defintion of the values are out of scope of the present document "]
+    #[doc = " * and should be subject to profiling."]
+    #[doc = " * "]
+    #[doc = " *  The value shall be set to:"]
+    #[doc = " * - `0` if  the performance class is unknown,"]
+    #[doc = " * - `1` for performance class A,"]
+    #[doc = " * - `2` for performance class B,"]
+    #[doc = " * -  3-7 reserved for future use."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Editorial update in V2.1.1, description changed in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=7"))]
+    pub struct PerformanceClass(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents a telephone number"]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct PhoneNumber(pub NumericString);
+    #[doc = "*"]
+    #[doc = "* The data frame PolygonalLine shall contain the definition of a polygonal line (also known as polygonal chain) w.r.t. an externally defined reference position."]
+    #[doc = "*"]
+    #[doc = "* The following options are available:"]
+    #[doc = "* "]
+    #[doc = "* @field deltaPositions: an ordered sequence of delta geographical positions with respect to the previous position, with latitude and longitude,"]
+    #[doc = "* with the first instance referring to the reference position and with the order implicitly defining a direction associated with the polygonal line."]
+    #[doc = "*"]
+    #[doc = "* @field deltaPositionsWithAltitude:  an ordered sequence of delta geographical positions with respect to the previous position, with latitude, longitude and altitude,"]
+    #[doc = "* with the first instance referring to the reference position and with the order implicitly defining a direction associated with the polygonal line."]
+    #[doc = "*"]
+    #[doc = "* @field absolutePositions: a sequence of absolute geographical positions, with latitude and longitude."]
+    #[doc = "*"]
+    #[doc = "* @field absolutePositionsWithAltitude: a sequence of absolute geographical positions, with latitude, longitude and altitude."]
+    #[doc = "*"]
+    #[doc = "* @category: GeoReference information"]
+    #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PolygonalLine {
+        deltaPositions(DeltaPositions),
+        deltaPositionsWithAltitude(DeltaReferencePositions),
+        absolutePositions(GeoPositionsWoAltitude),
+        absolutePositionsWithAltitude(GeoPositionsWAltitude),
+    }
+    #[doc = "* "]
+    #[doc = " * This DF represents the shape of a polygonal area or of a right prism."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field shapeReferencePoint: the optional reference point used for the definition of the shape, relative to an externally specified reference position. "]
+    #[doc = " * If this component is absent, the externally specified reference position represents the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field polygon: the polygonal area represented by a list of minimum `3` to maximum `16` @ref CartesianPosition3d."]
+    #[doc = " * All nodes of the polygon shall be considered relative to the shape's reference point."]
+    #[doc = " *"]
+    #[doc = " * @field height: the optional height, present if the shape is a right prism extending in the positive z-axis."]
+    #[doc = " * "]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " *"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PolygonalShape {
+        #[rasn(identifier = "shapeReferencePoint")]
+        pub shape_reference_point: Option<CartesianPosition3d>,
+        #[rasn(size("3..=16", extensible))]
+        pub polygon: SequenceOfCartesianPosition3d,
+        pub height: Option<StandardLength12b>,
+    }
+    impl PolygonalShape {
+        pub fn new(
+            shape_reference_point: Option<CartesianPosition3d>,
+            polygon: SequenceOfCartesianPosition3d,
+            height: Option<StandardLength12b>,
+        ) -> Self {
+            Self {
+                shape_reference_point,
+                polygon,
+                height,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the perpendicular distance from the centre of mass of an empty load vehicle to the front line of"]
+    #[doc = " * the vehicle bounding box of the empty load vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 62`) for any aplicable value n between 0,1 metre and 6,2 metres, "]
+    #[doc = " * - `62` for values equal to or higher than 6.1 metres,"]
+    #[doc = " * - `63`  if the information is unavailable."]
+    #[doc = " * "]
+    #[doc = " * @note:\tThe empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 metre "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: description revised in V2.1.1 (the meaning of 62 has changed slightly) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=63"))]
+    pub struct PosCentMass(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF indicates the horizontal position confidence ellipse which represents the estimated accuracy with a "]
+    #[doc = " * confidence level of 95  %. The centre of the ellipse shape corresponds to the reference"]
+    #[doc = " * position point for which the position accuracy is evaluated."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field semiMajorConfidence: half of length of the major axis, i.e. distance between the centre point"]
+    #[doc = " * and major axis point of the position accuracy ellipse. "]
+    #[doc = " *"]
+    #[doc = " * @field semiMinorConfidence: half of length of the minor axis, i.e. distance between the centre point"]
+    #[doc = " * and minor axis point of the position accuracy ellipse. "]
+    #[doc = " *"]
+    #[doc = " * @field semiMajorOrientation: orientation direction of the ellipse major axis of the position accuracy"]
+    #[doc = " * ellipse with regards to the WGS84 north. "]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PosConfidenceEllipse {
+        #[rasn(identifier = "semiMajorConfidence")]
+        pub semi_major_confidence: SemiAxisLength,
+        #[rasn(identifier = "semiMinorConfidence")]
+        pub semi_minor_confidence: SemiAxisLength,
+        #[rasn(identifier = "semiMajorOrientation")]
+        pub semi_major_orientation: HeadingValue,
+    }
+    impl PosConfidenceEllipse {
+        pub fn new(
+            semi_major_confidence: SemiAxisLength,
+            semi_minor_confidence: SemiAxisLength,
+            semi_major_orientation: HeadingValue,
+        ) -> Self {
+            Self {
+                semi_major_confidence,
+                semi_minor_confidence,
+                semi_major_orientation,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the perpendicular distance between the vehicle front line of the bounding box and the front wheel axle in 0,1 metre."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 19`) for any aplicable value between 0,1 metre and 1,9 metres,"]
+    #[doc = " * - `19` for values equal to or higher than 1.8 metres,"]
+    #[doc = " * - `20` if the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @unit 0,1 metre"]
+    #[doc = " * @revision: description revised in V2.1.1 (the meaning of 19 has changed slightly) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=20"))]
+    pub struct PosFrontAx(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the distance from the centre of vehicle front bumper to the right or left longitudinal carrier of vehicle."]
+    #[doc = " * The left/right carrier refers to the left/right as seen from a passenger sitting in the vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 126`) for any aplicable value between 0,01 metre and 1,26 metres, "]
+    #[doc = " * - `126` for values equal to or higher than 1.25 metres,"]
+    #[doc = " * - `127` if the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,01 metre "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: description revised in V2.1.1 (the meaning of 126 has changed slightly) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct PosLonCarr(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the perpendicular inter-distance of neighbouring pillar axis of vehicle starting from the"]
+    #[doc = " * middle point of the front line of the vehicle bounding box."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 29`) for any aplicable value between 0,1 metre and 2,9 metres, "]
+    #[doc = " * - `29` for values equal to or greater than 2.8 metres,"]
+    #[doc = " * - `30` if the information is unavailable."]
+    #[doc = " * "]
+    #[doc = " * @unit 0,1 metre "]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: description revised in V2.1.1 (the meaning of 29 has changed slightly) "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=30"))]
+    pub struct PosPillar(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents a position along a single dimension such as the middle of a road or lane, measured as an offset from an externally defined starting point, "]
+    #[doc = " * in direction of an externally defined reference direction."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= -8190` and `n < 0`) if the position is equal to or less than n x 1 metre and more than (n-1) x 1 metre, in opposite direction of the reference direction,"]
+    #[doc = " * - `0` if the position is at the starting point,"]
+    #[doc = " * - `n` (`n > 0` and `n < 8190`) if the position is equal to or less than n x 1 metre and more than (n-1) x 1 metre, in the same direction as the reference direction,"]
+    #[doc = " * - `8 190` if the position is out of range, i.e. equal to or greater than 8 189 m,"]
+    #[doc = " * - `8 191` if the position information is not available. "]
+    #[doc = " *"]
+    #[doc = " * @unit 1 metre"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-8190..=8191"))]
+    pub struct Position1d(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DF indicates the horizontal position confidence ellipse which represents the estimated accuracy with a "]
+    #[doc = " * confidence level of 95 %. The centre of the ellipse shape corresponds to the reference"]
+    #[doc = " * position point for which the position accuracy is evaluated."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field semiMajorAxisLength: half of length of the major axis, i.e. distance between the centre point"]
+    #[doc = " * and major axis point of the position accuracy ellipse. "]
+    #[doc = " *"]
+    #[doc = " * @field semiMinorAxisLength: half of length of the minor axis, i.e. distance between the centre point"]
+    #[doc = " * and minor axis point of the position accuracy ellipse. "]
+    #[doc = " *"]
+    #[doc = " * @field semiMajorAxisOrientation: orientation direction of the ellipse major axis of the position accuracy"]
+    #[doc = " * ellipse with regards to the WGS84 north. "]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1 based on @ref PosConfidenceEllipse"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PositionConfidenceEllipse {
+        #[rasn(identifier = "semiMajorAxisLength")]
+        pub semi_major_axis_length: SemiAxisLength,
+        #[rasn(identifier = "semiMinorAxisLength")]
+        pub semi_minor_axis_length: SemiAxisLength,
+        #[rasn(identifier = "semiMajorAxisOrientation")]
+        pub semi_major_axis_orientation: Wgs84AngleValue,
+    }
+    impl PositionConfidenceEllipse {
+        pub fn new(
+            semi_major_axis_length: SemiAxisLength,
+            semi_minor_axis_length: SemiAxisLength,
+            semi_major_axis_orientation: Wgs84AngleValue,
+        ) -> Self {
+            Self {
+                semi_major_axis_length,
+                semi_minor_axis_length,
+                semi_major_axis_orientation,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates whether a passenger seat is occupied or whether the occupation status is detectable or not."]
+    #[doc = " * "]
+    #[doc = " * The number of row in vehicle seats layout is counted in rows from the driver row backwards from front to the rear"]
+    #[doc = " * of the vehicle."]
+    #[doc = " * The left side seat of a row refers to the left hand side seen from vehicle rear to front."]
+    #[doc = " * Additionally, a bit is reserved for each seat row, to indicate if the seat occupation of a row is detectable or not,"]
+    #[doc = " * i.e. `row1NotDetectable (3)`, `row2NotDetectable(8)`, `row3NotDetectable(13)` and `row4NotDetectable(18)`."]
+    #[doc = " * Finally, a bit is reserved for each row seat to indicate if the seat row is present or not in the vehicle,"]
+    #[doc = " * i.e. `row1NotPresent (4)`, `row2NotPresent (9)`, `row3NotPresent(14)`, `row4NotPresent(19)`."]
+    #[doc = " * "]
+    #[doc = " * When a seat is detected to be occupied, the corresponding seat occupation bit shall be set to `1`."]
+    #[doc = " * For example, when the row 1 left seat is occupied, `row1LeftOccupied(0)` bit shall be set to `1`."]
+    #[doc = " * When a seat is detected to be not occupied, the corresponding seat occupation bit shall be set to `0`."]
+    #[doc = " * Otherwise, the value of seat occupation bit shall be set according to the following conditions:"]
+    #[doc = " * - If the seat occupation of a seat row is not detectable, the corresponding bit shall be set to `1`."]
+    #[doc = " *   When any seat row not detectable bit is set to `1`, all corresponding seat occupation bits of the same row"]
+    #[doc = " *   shall be set to `1`."]
+    #[doc = " * - If the seat row is not present, the corresponding not present bit of the same row shall be set to `1`."]
+    #[doc = " *   When any of the seat row not present bit is set to `1`, the corresponding not detectable bit for that row"]
+    #[doc = " *   shall be set to `1`, and all the corresponding seat occupation bits in that row shall be set to `0`."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PositionOfOccupants(pub FixedBitString<20usize>);
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of distances @ref PosPillar that refer to the perpendicular distance between centre of vehicle front bumper"]
+    #[doc = " * and vehicle pillar A, between neighbour pillars until the last pillar of the vehicle."]
+    #[doc = " *"]
+    #[doc = " * Vehicle pillars refer to the vertical or near vertical support of vehicle,"]
+    #[doc = " * designated respectively as the A, B, C or D and other pillars moving in side profile view from the front to rear."]
+    #[doc = " * "]
+    #[doc = " * The first value of the DF refers to the perpendicular distance from the centre of vehicle front bumper to "]
+    #[doc = " * vehicle A pillar. The second value refers to the perpendicular distance from the centre position of A pillar"]
+    #[doc = " * to the B pillar of vehicle and so on until the last pillar."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=3", extensible))]
+    pub struct PositionOfPillars(pub SequenceOf<PosPillar>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the positioning technology being used to estimate a geographical position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `noPositioningSolution`  - no positioning solution used,"]
+    #[doc = " * - 1 `sGNSS`                  - Global Navigation Satellite System used,"]
+    #[doc = " * - 2 `dGNSS`                  - Differential GNSS used,"]
+    #[doc = " * - 3 `sGNSSplusDR`            - GNSS and dead reckoning used,"]
+    #[doc = " * - 4 `dGNSSplusDR`            - Differential GNSS and dead reckoning used,"]
+    #[doc = " * - 5 `dR`                     - dead reckoning used,"]
+    #[doc = " * - 6 `manuallyByOperator`     - position set manually by a human operator."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: V1.3.1, extension with value 6 added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum PositioningSolutionType {
+        noPositioningSolution = 0,
+        sGNSS = 1,
+        dGNSS = 2,
+        sGNSSplusDR = 3,
+        dGNSSplusDR = 4,
+        dR = 5,
+        #[rasn(extension_addition)]
+        manuallyByOperator = 6,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `postCrash` ."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                                               - in case further detailed information on post crash event is unavailable,"]
+    #[doc = " * - 1 `accidentWithoutECallTriggered`                             - in case no eCall has been triggered for an accident,"]
+    #[doc = " * - 2 `accidentWithECallManuallyTriggered`                        - in case eCall has been manually triggered and transmitted to eCall back end,"]
+    #[doc = " * - 3 `accidentWithECallAutomaticallyTriggered`                   - in case eCall has been automatically triggered and transmitted to eCall back end,"]
+    #[doc = " * - 4 `accidentWithECallTriggeredWithoutAccessToCellularNetwork`  - in case eCall has been triggered but cellular network is not accessible from triggering vehicle."]
+    #[doc = " * - 5-255                                                         - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct PostCrashSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE represent the total amount of rain falling during one hour. It is measured in mm per hour at an area of 1 square metre.  "]
+    #[doc = "* "]
+    #[doc = "* The following values are specified:"]
+    #[doc = "* - `n` (`n > 0` and `n < 2000`) if the amount of rain falling is equal to or less than n x 0,1 mm/h and greater than (n-1) x 0,1 mm/h,"]
+    #[doc = "* - `2000` if the amount of rain falling is greater than 199.9 mm/h, "]
+    #[doc = "* - `2001` if the information is not available."]
+    #[doc = "*"]
+    #[doc = "* @unit: 0,1 mm/h "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=2001"))]
+    pub struct PrecipitationIntensity(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF describes a zone of protection inside which the ITS communication should be restricted."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneType: type of the protected zone. "]
+    #[doc = " * "]
+    #[doc = " * @field expiryTime: optional time at which the validity of the protected communication zone will expire."]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneLatitude: latitude of the centre point of the protected communication zone."]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneLongitude: longitude of the centre point of the protected communication zone."]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneRadius: optional radius of the protected communication zone in metres."]
+    #[doc = " * "]
+    #[doc = " * @field protectedZoneId: the optional ID of the protected communication zone."]
+    #[doc = " * "]
+    #[doc = " * @note: A protected communication zone may be defined around a CEN DSRC road side equipment."]
+    #[doc = " * "]
+    #[doc = " * @category: Infrastructure information, Communication information"]
+    #[doc = " * @revision: revised in V2.1.1 (changed protectedZoneID to protectedZoneId)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProtectedCommunicationZone {
+        #[rasn(identifier = "protectedZoneType")]
+        pub protected_zone_type: ProtectedZoneType,
+        #[rasn(identifier = "expiryTime")]
+        pub expiry_time: Option<TimestampIts>,
+        #[rasn(identifier = "protectedZoneLatitude")]
+        pub protected_zone_latitude: Latitude,
+        #[rasn(identifier = "protectedZoneLongitude")]
+        pub protected_zone_longitude: Longitude,
+        #[rasn(identifier = "protectedZoneRadius")]
+        pub protected_zone_radius: Option<ProtectedZoneRadius>,
+        #[rasn(identifier = "protectedZoneId")]
+        pub protected_zone_id: Option<ProtectedZoneId>,
+    }
+    impl ProtectedCommunicationZone {
+        pub fn new(
+            protected_zone_type: ProtectedZoneType,
+            expiry_time: Option<TimestampIts>,
+            protected_zone_latitude: Latitude,
+            protected_zone_longitude: Longitude,
+            protected_zone_radius: Option<ProtectedZoneRadius>,
+            protected_zone_id: Option<ProtectedZoneId>,
+        ) -> Self {
+            Self {
+                protected_zone_type,
+                expiry_time,
+                protected_zone_latitude,
+                protected_zone_longitude,
+                protected_zone_radius,
+                protected_zone_id,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref ProtectedCommunicationZone provided by a road side ITS-S (Road Side Unit RSU)."]
+    #[doc = " *"]
+    #[doc = " * It may provide up to 16 protected communication zones information."]
+    #[doc = " *"]
+    #[doc = " * @category: Infrastructure information, Communication information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct ProtectedCommunicationZonesRSU(pub SequenceOf<ProtectedCommunicationZone>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the indentifier of a protected communication zone."]
+    #[doc = " * "]
+    #[doc = " * "]
+    #[doc = " * @category: Infrastructure information, Communication information"]
+    #[doc = " * @revision: Revision in V2.1.1 (changed name from ProtectedZoneID to ProtectedZoneId)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=134217727"))]
+    pub struct ProtectedZoneId(pub u32);
+    #[doc = "*"]
+    #[doc = " * This DE represents the radius of a protected communication zone. "]
+    #[doc = " * "]
+    #[doc = " * "]
+    #[doc = " * @unit: metre"]
+    #[doc = " * @category: Infrastructure information, Communication information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=255", extensible))]
+    pub struct ProtectedZoneRadius(pub Integer);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the type of a protected communication zone, so that an ITS-S is aware of the actions to do"]
+    #[doc = " * while passing by such zone (e.g. reduce the transmit power in case of a DSRC tolling station)."]
+    #[doc = " * "]
+    #[doc = " * The protected zone type is defined in ETSI TS 102 792 [14]."]
+    #[doc = " * "]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum ProtectedZoneType {
+        permanentCenDsrcTolling = 0,
+        #[rasn(extension_addition)]
+        temporaryCenDsrcTolling = 1,
+    }
+    #[doc = "*"]
+    #[doc = " * This DF identifies an organization."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field countryCode: represents the country code that identifies the country of the national registration administrator for issuers according to ISO 14816."]
+    #[doc = " *"]
+    #[doc = " * @field providerIdentifier: identifies the organization according to the national ISO 14816 register for issuers."]
+    #[doc = " *"]
+    #[doc = " * @note: See https://www.itsstandards.eu/registries/register-of-nra-i-cs1/ for a list of national registration administrators and their respective registers"]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information"]
+    #[doc = " * @revision: Created in V2.2.1 based on ISO 17573-3 [24]"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Provider {
+        #[rasn(identifier = "countryCode")]
+        pub country_code: CountryCode,
+        #[rasn(identifier = "providerIdentifier")]
+        pub provider_identifier: IssuerIdentifier,
+    }
+    impl Provider {
+        pub fn new(country_code: CountryCode, provider_identifier: IssuerIdentifier) -> Self {
+            Self {
+                country_code,
+                provider_identifier,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents activation data for real-time systems designed for operations control, traffic light priorities, track switches, barriers, etc."]
+    #[doc = " * using a range of activation devices equipped in public transport vehicles."]
+    #[doc = " *"]
+    #[doc = " * The activation of the corresponding equipment is triggered by the approach or passage of a public transport"]
+    #[doc = " * vehicle at a certain point (e.g. a beacon)."]
+    #[doc = " *"]
+    #[doc = " * @field ptActivationType: type of activation. "]
+    #[doc = " *"]
+    #[doc = " * @field ptActicationData: data of activation. "]
+    #[doc = " *"]
+    #[doc = " * Today there are different payload variants defined for public transport activation-data. The R09.x is one of"]
+    #[doc = " * the industry standard used by public transport vehicles (e.g. buses, trams) in Europe (e.g. Germany Austria)"]
+    #[doc = " * for controlling traffic lights, barriers, bollards, etc. This DF shall include information like route, course,"]
+    #[doc = " * destination, priority, etc."]
+    #[doc = " * "]
+    #[doc = " * The R09.x content is defined in VDV recommendation 420 [7]. It includes following information:"]
+    #[doc = " * - Priority Request Information (pre-request, request, ready to start)"]
+    #[doc = " * - End of Prioritization procedure"]
+    #[doc = " * - Priority request direction"]
+    #[doc = " * - Public Transport line number"]
+    #[doc = " * - Priority of public transport"]
+    #[doc = " * - Route line identifier of the public transport"]
+    #[doc = " * - Route number identification"]
+    #[doc = " * - Destination of public transport vehicle"]
+    #[doc = " *"]
+    #[doc = " * Other countries may use different message sets defined by the local administration."]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PtActivation {
+        #[rasn(identifier = "ptActivationType")]
+        pub pt_activation_type: PtActivationType,
+        #[rasn(identifier = "ptActivationData")]
+        pub pt_activation_data: PtActivationData,
+    }
+    impl PtActivation {
+        pub fn new(
+            pt_activation_type: PtActivationType,
+            pt_activation_data: PtActivationData,
+        ) -> Self {
+            Self {
+                pt_activation_type,
+                pt_activation_data,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE is used for various tasks in the public transportation environment, especially for controlling traffic"]
+    #[doc = " * signal systems to prioritize and speed up public transportation in urban area (e.g. intersection \"_bottlenecks_\")."]
+    #[doc = " * The traffic lights may be controlled by an approaching bus or tram automatically. This permits \"_In Time_\" activation"]
+    #[doc = " * of the green phase, will enable the individual traffic to clear a potential traffic jam in advance. Thereby the"]
+    #[doc = " * approaching bus or tram may pass an intersection with activated green light without slowing down the speed due to"]
+    #[doc = " * traffic congestion. Other usage of the DE is the provision of information like the public transport line number"]
+    #[doc = " * or the schedule delay of a public transport vehicle."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=20"))]
+    pub struct PtActivationData(pub OctetString);
+    #[doc = "*"]
+    #[doc = " * This DE indicates a certain coding type of the PtActivationData data."]
+    #[doc = " *"]
+    #[doc = " * The folowing value are specified:"]
+    #[doc = " * - 0 `undefinedCodingType`  : undefined coding type,"]
+    #[doc = " * - 1 `r09-16CodingType`     : coding of PtActivationData conform to VDV recommendation 420 [7],"]
+    #[doc = " * - 2 `vdv-50149CodingType`  : coding of PtActivationData based on VDV recommendation 420 [7]."]
+    #[doc = " * - 3 - 255                  : reserved for alternative and future use."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information "]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct PtActivationType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF describes a radial shape. The circular or spherical sector is constructed by sweeping      "]
+    #[doc = " * the provided range about the reference position specified outside of the context of this DF or "]
+    #[doc = " * about the optional shapeReferencePoint. The range is swept between a horizontal start and a "]
+    #[doc = " * horizontal end angle in the X-Y plane of a cartesian coordinate system specified outside of the "]
+    #[doc = " * context of this DF, in a right-hand positive angular direction w.r.t. the x-axis. "]
+    #[doc = " * A vertical opening angle in the X-Z plane may optionally be provided in a right-hand positive "]
+    #[doc = " * angular direction w.r.t. the x-axis. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components:"]
+    #[doc = " * "]
+    #[doc = " * @field shapeReferencePoint: the optional reference point used for the definition of the shape, "]
+    #[doc = " * relative to an externally specified reference position. If this component is absent, the  "]
+    #[doc = " * externally specified reference position represents the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field range: the radial range of the shape from the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field horizontalOpeningAngleStart: the start of the shape's horizontal opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @field horizontalOpeningAngleEnd: the end of the shape's horizontal opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @field verticalOpeningAngleStart: optional start of the shape's vertical opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @field verticalOpeningAngleEnd: optional end of the shape's vertical opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1, names and types of the horizontal opening angles changed, constraint added and description revised in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RadialShape {
+        #[rasn(identifier = "shapeReferencePoint")]
+        pub shape_reference_point: Option<CartesianPosition3d>,
+        pub range: StandardLength12b,
+        #[rasn(identifier = "horizontalOpeningAngleStart")]
+        pub horizontal_opening_angle_start: CartesianAngleValue,
+        #[rasn(identifier = "horizontalOpeningAngleEnd")]
+        pub horizontal_opening_angle_end: CartesianAngleValue,
+        #[rasn(identifier = "verticalOpeningAngleStart")]
+        pub vertical_opening_angle_start: Option<CartesianAngleValue>,
+        #[rasn(identifier = "verticalOpeningAngleEnd")]
+        pub vertical_opening_angle_end: Option<CartesianAngleValue>,
+    }
+    impl RadialShape {
+        pub fn new(
+            shape_reference_point: Option<CartesianPosition3d>,
+            range: StandardLength12b,
+            horizontal_opening_angle_start: CartesianAngleValue,
+            horizontal_opening_angle_end: CartesianAngleValue,
+            vertical_opening_angle_start: Option<CartesianAngleValue>,
+            vertical_opening_angle_end: Option<CartesianAngleValue>,
+        ) -> Self {
+            Self {
+                shape_reference_point,
+                range,
+                horizontal_opening_angle_start,
+                horizontal_opening_angle_end,
+                vertical_opening_angle_start,
+                vertical_opening_angle_end,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF describes radial shape details. The circular sector or cone is"]
+    #[doc = " * constructed by sweeping the provided range about the position specified outside of the  "]
+    #[doc = " * context of this DF. The range is swept between a horizontal start and a horizontal end angle in "]
+    #[doc = " * the X-Y plane of a right-hand cartesian coordinate system specified outside of the context of "]
+    #[doc = " * this DF, in positive angular direction w.r.t. the x-axis. A vertical opening angle in the X-Z "]
+    #[doc = " * plane may optionally be provided in positive angular direction w.r.t. the x-axis."]
+    #[doc = " * "]
+    #[doc = " * It shall include the following components:"]
+    #[doc = " * "]
+    #[doc = " * @field range: the radial range of the sensor from the reference point or sensor point offset. "]
+    #[doc = " *"]
+    #[doc = " * @field horizontalOpeningAngleStart:  the start of the shape's horizontal opening angle."]
+    #[doc = " *"]
+    #[doc = " * @field horizontalOpeningAngleEnd: the end of the shape's horizontal opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @field verticalOpeningAngleStart: optional start of the shape's vertical opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @field verticalOpeningAngleEnd: optional end of the shape's vertical opening angle. "]
+    #[doc = " *"]
+    #[doc = " * @category: Georeference information"]
+    #[doc = " * @revision: created in V2.1.1, description revised and constraint added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RadialShapeDetails {
+        pub range: StandardLength12b,
+        #[rasn(identifier = "horizontalOpeningAngleStart")]
+        pub horizontal_opening_angle_start: CartesianAngleValue,
+        #[rasn(identifier = "horizontalOpeningAngleEnd")]
+        pub horizontal_opening_angle_end: CartesianAngleValue,
+        #[rasn(identifier = "verticalOpeningAngleStart")]
+        pub vertical_opening_angle_start: Option<CartesianAngleValue>,
+        #[rasn(identifier = "verticalOpeningAngleEnd")]
+        pub vertical_opening_angle_end: Option<CartesianAngleValue>,
+    }
+    impl RadialShapeDetails {
+        pub fn new(
+            range: StandardLength12b,
+            horizontal_opening_angle_start: CartesianAngleValue,
+            horizontal_opening_angle_end: CartesianAngleValue,
+            vertical_opening_angle_start: Option<CartesianAngleValue>,
+            vertical_opening_angle_end: Option<CartesianAngleValue>,
+        ) -> Self {
+            Self {
+                range,
+                horizontal_opening_angle_start,
+                horizontal_opening_angle_end,
+                vertical_opening_angle_start,
+                vertical_opening_angle_end,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF describes a list of radial shapes positioned w.r.t. to an offset position defined  "]
+    #[doc = " * relative to a reference position specified outside of the context of this DF and oriented w.r.t.  "]
+    #[doc = " * a cartesian coordinate system specified outside of the context of this DF. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components:"]
+    #[doc = " *"]
+    #[doc = " * @field refPointId: the identification of the reference point in case of a sensor mounted to trailer. Defaults to ITS ReferencePoint (0)."]
+    #[doc = " * "]
+    #[doc = " * @field xCoordinate: the x-coordinate of the offset position."]
+    #[doc = " *"]
+    #[doc = " * @field yCoordinate: the y-coordinate of the offset position."]
+    #[doc = " *"]
+    #[doc = " * @field zCoordinate: the optional z-coordinate of the offset position."]
+    #[doc = " *"]
+    #[doc = " * @field radialShapesList: the list of radial shape details."]
+    #[doc = " *"]
+    #[doc = " * @category: Georeference information"]
+    #[doc = " * @revision: created in V2.1.1, description revised in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RadialShapes {
+        #[rasn(identifier = "refPointId")]
+        pub ref_point_id: Identifier1B,
+        #[rasn(identifier = "xCoordinate")]
+        pub x_coordinate: CartesianCoordinateSmall,
+        #[rasn(identifier = "yCoordinate")]
+        pub y_coordinate: CartesianCoordinateSmall,
+        #[rasn(identifier = "zCoordinate")]
+        pub z_coordinate: Option<CartesianCoordinateSmall>,
+        #[rasn(identifier = "radialShapesList")]
+        pub radial_shapes_list: RadialShapesList,
+    }
+    impl RadialShapes {
+        pub fn new(
+            ref_point_id: Identifier1B,
+            x_coordinate: CartesianCoordinateSmall,
+            y_coordinate: CartesianCoordinateSmall,
+            z_coordinate: Option<CartesianCoordinateSmall>,
+            radial_shapes_list: RadialShapesList,
+        ) -> Self {
+            Self {
+                ref_point_id,
+                x_coordinate,
+                y_coordinate,
+                z_coordinate,
+                radial_shapes_list,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * The DF contains a list of @ref RadialShapeDetails."]
+    #[doc = " *"]
+    #[doc = " * @category: Georeference information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct RadialShapesList(pub SequenceOf<RadialShapeDetails>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `railwayLevelCrossing` ."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                   - in case no further detailed information on the railway level crossing status is available,"]
+    #[doc = " * - 1 `doNotCrossAbnormalSituation`   - in case when something wrong is detected by equation or sensors of the railway level crossing, "]
+    #[doc = "                                         including level crossing is closed for too long (e.g. more than 10 minutes long ; default value),"]
+    #[doc = " * - 2 `closed`                        - in case the crossing is closed or closing (barriers down),"]
+    #[doc = " * - 3 `unguarded`                     - in case the level crossing is unguarded (i.e a Saint Andrew cross level crossing without detection of train),"]
+    #[doc = " * - 4 `nominal`                       - in case the barriers are up and/or the warning systems are off,"]
+    #[doc = " * - 5 `trainApproaching`              - in case a train is approaching and the railway level crossing is without barriers."]
+    #[doc = " * - 6-255: reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, description of value 2 and 4 changed and value 5 added in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RailwayLevelCrossingSubCauseCode(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DF represents the shape of a rectangular area or a right rectangular prism that is centred "]
+    #[doc = " * on a reference position defined outside of the context of this DF and oriented w.r.t. a cartesian    "]
+    #[doc = " * coordinate system defined outside of the context of this DF. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field shapeReferencePoint: represents an optional offset point which the rectangle is centred on with "]
+    #[doc = " * respect to the reference position. If this component is absent, the externally specified  "]
+    #[doc = " * reference position represents the shape's reference point. "]
+    #[doc = " *"]
+    #[doc = " * @field semiLength: represents half the length of the rectangle located in the X-Y Plane."]
+    #[doc = " * "]
+    #[doc = " * @field semiBreadth: represents half the breadth of the rectangle located in the X-Y Plane."]
+    #[doc = " *"]
+    #[doc = " * @field orientation: represents the optional orientation of the longer side of the rectangle, "]
+    #[doc = " * measured with positive values turning around the Z-axis using the right-hand rule, starting from"]
+    #[doc = " * the X-axis. If absent, the orientation is equal to the value zero."]
+    #[doc = " *"]
+    #[doc = " * @field height: represents the optional height, present if the shape is a right rectangular prism "]
+    #[doc = " * with height extending in the positive Z-axis."]
+    #[doc = " *"]
+    #[doc = " * @category GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1, centerPoint renamed to shapeReferencePoint, the type of the field orientation changed "]
+    #[doc = " *            and description revised in V2.2.1, added sentence on absence in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RectangularShape {
+        #[rasn(identifier = "shapeReferencePoint")]
+        pub shape_reference_point: Option<CartesianPosition3d>,
+        #[rasn(identifier = "semiLength")]
+        pub semi_length: StandardLength12b,
+        #[rasn(identifier = "semiBreadth")]
+        pub semi_breadth: StandardLength12b,
+        pub orientation: Option<CartesianAngleValue>,
+        pub height: Option<StandardLength12b>,
+    }
+    impl RectangularShape {
+        pub fn new(
+            shape_reference_point: Option<CartesianPosition3d>,
+            semi_length: StandardLength12b,
+            semi_breadth: StandardLength12b,
+            orientation: Option<CartesianAngleValue>,
+            height: Option<StandardLength12b>,
+        ) -> Self {
+            Self {
+                shape_reference_point,
+                semi_length,
+                semi_breadth,
+                orientation,
+                height,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * A position within a geographic coordinate system together with a confidence ellipse. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field latitude: the latitude of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @field longitude: the longitude of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @field positionConfidenceEllipse: the confidence ellipse associated to the geographical position."]
+    #[doc = " *"]
+    #[doc = " * @field altitude: the altitude and an altitude accuracy of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref ReferencePositionWithConfidence instead. "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: description updated in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReferencePosition {
+        pub latitude: Latitude,
+        pub longitude: Longitude,
+        #[rasn(identifier = "positionConfidenceEllipse")]
+        pub position_confidence_ellipse: PosConfidenceEllipse,
+        pub altitude: Altitude,
+    }
+    impl ReferencePosition {
+        pub fn new(
+            latitude: Latitude,
+            longitude: Longitude,
+            position_confidence_ellipse: PosConfidenceEllipse,
+            altitude: Altitude,
+        ) -> Self {
+            Self {
+                latitude,
+                longitude,
+                position_confidence_ellipse,
+                altitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * A position within a geographic coordinate system together with a confidence ellipse. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field latitude: the latitude of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @field longitude: the longitude of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @field positionConfidenceEllipse: the confidence ellipse associated to the geographical position."]
+    #[doc = " *"]
+    #[doc = " * @field altitude: the altitude and an altitude accuracy of the geographical point."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1 based on @ref ReferencePosition but using @ref PositionConfidenceEllipse."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReferencePositionWithConfidence {
+        pub latitude: Latitude,
+        pub longitude: Longitude,
+        #[rasn(identifier = "positionConfidenceEllipse")]
+        pub position_confidence_ellipse: PositionConfidenceEllipse,
+        pub altitude: Altitude,
+    }
+    impl ReferencePositionWithConfidence {
+        pub fn new(
+            latitude: Latitude,
+            longitude: Longitude,
+            position_confidence_ellipse: PositionConfidenceEllipse,
+            altitude: Altitude,
+        ) -> Self {
+            Self {
+                latitude,
+                longitude,
+                position_confidence_ellipse,
+                altitude,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE describes a distance of relevance for information indicated in a message."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `lessThan50m`   - for distances below 50 m,"]
+    #[doc = " * - 1 `lessThan100m`  - for distances below 100 m, "]
+    #[doc = " * - 2 `lessThan200m`  - for distances below 200 m, "]
+    #[doc = " * - 3 `lessThan500m`  - for distances below 300 m, "]
+    #[doc = " * - 4 `lessThan1000m` - for distances below 1 000 m, "]
+    #[doc = " * - 5 `lessThan5km`   - for distances below 5 000 m, "]
+    #[doc = " * - 6 `lessThan10km`  - for distances below 10 000 m, "]
+    #[doc = " * - 7 `over10km`      - for distances over 10 000 m. "]
+    #[doc = " * "]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref StandardLength3b instead. "]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RelevanceDistance {
+        lessThan50m = 0,
+        lessThan100m = 1,
+        lessThan200m = 2,
+        lessThan500m = 3,
+        lessThan1000m = 4,
+        lessThan5km = 5,
+        lessThan10km = 6,
+        over10km = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates a traffic direction that is relevant to information indicated in a message."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `allTrafficDirections` - for all traffic directions, "]
+    #[doc = " * - 1 `upstreamTraffic`      - for upstream traffic, "]
+    #[doc = " * - 2 `downstreamTraffic`    - for downstream traffic, "]
+    #[doc = " * - 3 `oppositeTraffic`      - for traffic in the opposite direction. "]
+    #[doc = " *"]
+    #[doc = " * The terms `upstream`, `downstream` and `oppositeTraffic` are relative to the event position."]
+    #[doc = " *"]
+    #[doc = " * @note: Upstream traffic corresponds to the incoming traffic towards the event position,"]
+    #[doc = " * and downstream traffic to the departing traffic away from the event position."]
+    #[doc = " *"]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref TrafficDirection instead. "]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RelevanceTrafficDirection {
+        allTrafficDirections = 0,
+        upstreamTraffic = 1,
+        downstreamTraffic = 2,
+        oppositeTraffic = 3,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates whether an ITS message is transmitted as request from ITS-S or a response transmitted from"]
+    #[doc = " * ITS-S after receiving request from other ITS-Ss."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `request`  - for a request message, "]
+    #[doc = " * - 1 `response` - for a response message.  "]
+    #[doc = " *"]
+    #[doc = " * @category Communication information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RequestResponseIndication {
+        request = 0,
+        response = 1,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode` "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                         - in case further detailed information on rescue and recovery work is unavailable,"]
+    #[doc = " * - 1 `emergencyVehicles`                   - in case rescue and/or safeguarding work is ongoing by emergency vehicles, i.e. by vehicles that have the absolute right of way,"]
+    #[doc = " * - 2 `rescueHelicopterLanding`             - in case rescue helicopter is landing,"]
+    #[doc = " * - 3 `policeActivityOngoing`               - in case police activity is ongoing (only to be used if a more specific sub cause than (1) is needed),"]
+    #[doc = " * - 4 `medicalEmergencyOngoing`             - in case medical emergency recovery is ongoing (only to be used if a more specific sub cause than (1) is needed),"]
+    #[doc = " * - 5 `childAbductionInProgress-deprecated` - deprecated,"]
+    #[doc = " * - 6 `prioritizedVehicle`                  - in case rescue and/or safeguarding work is ongoing by prioritized vehicles, i.e. by vehicles that have priority but not the absolute right of way,"]
+    #[doc = " * - 7 `rescueAndRecoveryVehicle`            - in case technical rescue work is ongoing by rescue and recovery vehicles."]
+    #[doc = " * - 8-255: reserved for future usage."]
+    #[doc = ""]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, named values 6 and 7 added in V2.2.1, DE renamed and value 5 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RescueRecoveryAndMaintenanceWorkInProgressSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref StationType. to which a certain traffic restriction, e.g. the speed limit, applies."]
+    #[doc = " * "]
+    #[doc = " * @category: Infrastructure information, Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=3", extensible))]
+    pub struct RestrictedTypes(pub SequenceOf<StationType>);
+    #[doc = "* "]
+    #[doc = " * This DF provides configuration information about a road section."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field roadSectionDefinition: the topological definition of the road section for which the information in the other components applies throughout its entire length."]
+    #[doc = " * "]
+    #[doc = " * @field roadType: the optional type of road on which the section is located."]
+    #[doc = " * "]
+    #[doc = " * @field laneConfiguration: the optional configuration of the road section in terms of basic information per lane."]
+    #[doc = " *"]
+    #[doc = " * @field mapemConfiguration: the optional configuration of the road section in terms of MAPEM lanes or connections."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RoadConfigurationSection {
+        #[rasn(identifier = "roadSectionDefinition")]
+        pub road_section_definition: RoadSectionDefinition,
+        #[rasn(identifier = "roadType")]
+        pub road_type: Option<RoadType>,
+        #[rasn(identifier = "laneConfiguration")]
+        pub lane_configuration: Option<BasicLaneConfiguration>,
+        #[rasn(identifier = "mapemConfiguration")]
+        pub mapem_configuration: Option<MapemConfiguration>,
+    }
+    impl RoadConfigurationSection {
+        pub fn new(
+            road_section_definition: RoadSectionDefinition,
+            road_type: Option<RoadType>,
+            lane_configuration: Option<BasicLaneConfiguration>,
+            mapem_configuration: Option<MapemConfiguration>,
+        ) -> Self {
+            Self {
+                road_section_definition,
+                road_type,
+                lane_configuration,
+                mapem_configuration,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF shall contain a list of @ref RoadConfigurationSection."]
+    #[doc = " * "]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct RoadConfigurationSectionList(pub SequenceOf<RoadConfigurationSection>);
+    #[doc = "* "]
+    #[doc = " * This DF provides the basic topological definition of a road section."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field startingPointSection: the position of the starting point of the section. "]
+    #[doc = " * "]
+    #[doc = " * @field lengthOfSection: the optional length of the section along the road profile (i.e. including curves)."]
+    #[doc = " * "]
+    #[doc = " * @field endingPointSection: the optional position of the ending point of the section. "]
+    #[doc = " * If this component is absent, the ending position is implicitly defined by other means, e.g. the starting point of the next RoadConfigurationSection, or the sectionÃ¯Â¿Â½s length."]
+    #[doc = " *"]
+    #[doc = " * @field connectedPaths: the identifier(s) of the path(s) having one or an ordered subset of waypoints located upstream of the RoadConfigurationSectionÃ¯Â¿Â½ starting point. "]
+    #[doc = " * "]
+    #[doc = " * @field includedPaths: the identifier(s) of the path(s) that covers (either with all its length or with a part of it) a RoadConfigurationSection. "]
+    #[doc = " *"]
+    #[doc = " * @field isEventZoneIncluded: indicates, if set to TRUE, that the @ref EventZone incl. its reference position covers a RoadConfigurationSection (either with all its length or with a part of it). "]
+    #[doc = " * "]
+    #[doc = " * @field isEventZoneConnected: indicates, if set to TRUE, that the @ref EventZone incl. its reference position has one or an ordered subset of waypoints located upstream of the RoadConfigurationSectionÃ¯Â¿Â½ starting point."]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RoadSectionDefinition {
+        #[rasn(identifier = "startingPointSection")]
+        pub starting_point_section: GeoPosition,
+        #[rasn(identifier = "lengthOfSection")]
+        pub length_of_section: Option<StandardLength2B>,
+        #[rasn(identifier = "endingPointSection")]
+        pub ending_point_section: Option<GeoPosition>,
+        #[rasn(identifier = "connectedPaths")]
+        pub connected_paths: PathReferences,
+        #[rasn(identifier = "includedPaths")]
+        pub included_paths: PathReferences,
+        #[rasn(identifier = "isEventZoneIncluded")]
+        pub is_event_zone_included: bool,
+        #[rasn(identifier = "isEventZoneConnected")]
+        pub is_event_zone_connected: bool,
+    }
+    impl RoadSectionDefinition {
+        pub fn new(
+            starting_point_section: GeoPosition,
+            length_of_section: Option<StandardLength2B>,
+            ending_point_section: Option<GeoPosition>,
+            connected_paths: PathReferences,
+            included_paths: PathReferences,
+            is_event_zone_included: bool,
+            is_event_zone_connected: bool,
+        ) -> Self {
+            Self {
+                starting_point_section,
+                length_of_section,
+                ending_point_section,
+                connected_paths,
+                included_paths,
+                is_event_zone_included,
+                is_event_zone_connected,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates an ordinal number that represents the position of a component in the list @ref RoadConfigurationSectionList. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0`     - if no road section is identified"]
+    #[doc = " * - `1..8`  - for instances 1..8 of @ref RoadConfigurationSectionList "]
+    #[doc = " *"]
+    #[doc = " * @category: Road topology information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=8", extensible))]
+    pub struct RoadSectionId(pub Integer);
+    #[doc = "*"]
+    #[doc = " * This DF represents a unique id for a road segment"]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field region: the optional identifier of the entity that is responsible for the region in which the road segment is placed."]
+    #[doc = " * It is the duty of that entity to guarantee that the @ref Id is unique within the region."]
+    #[doc = " *"]
+    #[doc = " * @field id: the identifier of the road segment."]
+    #[doc = " *"]
+    #[doc = " * @note: when the component region is present, the RoadSegmentReferenceId is guaranteed to be globally unique."]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RoadSegmentReferenceId {
+        pub region: Option<Identifier2B>,
+        pub id: Identifier2B,
+    }
+    impl RoadSegmentReferenceId {
+        pub fn new(region: Option<Identifier2B>, id: Identifier2B) -> Self {
+            Self { region, id }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the type of a road segment."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `urban-NoStructuralSeparationToOppositeLanes`       - for an urban road with no structural separation between lanes carrying traffic in opposite directions,"]
+    #[doc = " * - 1 `urban-WithStructuralSeparationToOppositeLanes`     - for an urban road with structural separation between lanes carrying traffic in opposite directions,"]
+    #[doc = " * - 2 `nonUrban-NoStructuralSeparationToOppositeLanes`    - for an non urban road with no structural separation between lanes carrying traffic in opposite directions,"]
+    #[doc = " * - 3 `nonUrban-WithStructuralSeparationToOppositeLanes`  - for an non urban road with structural separation between lanes carrying traffic in opposite directions."]
+    #[doc = " *"]
+    #[doc = " * @category: Road Topology Information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RoadType {
+        #[rasn(identifier = "urban-NoStructuralSeparationToOppositeLanes")]
+        urban_NoStructuralSeparationToOppositeLanes = 0,
+        #[rasn(identifier = "urban-WithStructuralSeparationToOppositeLanes")]
+        urban_WithStructuralSeparationToOppositeLanes = 1,
+        #[rasn(identifier = "nonUrban-NoStructuralSeparationToOppositeLanes")]
+        nonUrban_NoStructuralSeparationToOppositeLanes = 2,
+        #[rasn(identifier = "nonUrban-WithStructuralSeparationToOppositeLanes")]
+        nonUrban_WithStructuralSeparationToOppositeLanes = 3,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `roadworks`."]
+    #[doc = " * "]
+    #[doc = "The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                 - in case further detailed information on roadworks is unavailable,"]
+    #[doc = " * - 1 `roadOrCarriagewayClosure`    - in case roadworks are ongoing which comprise the closure of the entire road or of one entire carriageway,"]
+    #[doc = " * - 2 `roadMarkingWork-deprecated`  - deprecated since covered by 3 or 4,"]
+    #[doc = " * - 3 `movingLaneClosure`           - in case moving roadworks are ongoing, which comprise the closure of a lane,"]
+    #[doc = " * - 4 `stationaryLaneClosure`       - in case stationary roadworks are ongoing, which comprise the closure of one or multiple lanes but not of the carriageway/road,"]
+    #[doc = " * - 5 `streetCleaning-deprecated`   - deprecated since not pertinent to roadworks and already covered by SlowVehicleSubCauseCode,"]
+    #[doc = " * - 6 `winterService-deprecated`    - deprecated since not pertinent to roadworks and already covered by SlowVehicleSubCauseCode,"]
+    #[doc = " * - 7 `setupPhase`                  - in case the work zone is being setup which, may comprise the closure of one or multiple lanes but the carriageway/road is not closed, "]
+    #[doc = " * - 8 `remodellingPhase`            - in case the work zone is being changed, which may comprise the closure of one or multiple lanes but the carriageway/road is not closed, "]
+    #[doc = " * - 9 `dismantlingPhase`            - in case the work zone is being dismantled after finished works, which comprised the closure of one or multiple lanes "]
+    #[doc = "                                       but the carriageway/road was not closed,"]
+    #[doc = " * - 10 `carriagewayCrossover`       - in case the work zone includes lanes that are re-directed to another carriageway. "]
+    #[doc = " * - 11-255                          - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, values 7-9 added in V2.3.1, values 1, 3, 4 renamed in V2.4.1, value 2, 5 und 6 deprecated in V2.4.1, value 10 added in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RoadworksSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the driving automation level as defined in SAE J3016 [26]."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: created in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=5"))]
+    pub struct SaeAutomationLevel(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF provides the safe distance indication of a traffic participant with other traffic participant(s)."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field subjectStation: optionally indicates one \"other\" traffic participant identified by its ITS-S."]
+    #[doc = " *  "]
+    #[doc = " * @field safeDistanceIndicator: indicates whether the distance between the ego ITS-S and the traffic participant(s) is safe."]
+    #[doc = " * If subjectStation is present then it indicates whether the distance between the ego ITS-S and the traffic participant indicated in the component subjectStation is safe. "]
+    #[doc = " *"]
+    #[doc = " * @field timeToCollision: optionally indicated the time-to-collision calculated as sqrt(LaDi^2 + LoDi^2 + VDi^2/relative speed "]
+    #[doc = " * and represented in  the  nearest 100  ms. This component may be present only if subjectStation is present. "]
+    #[doc = " *"]
+    #[doc = " * @note: the abbreviations used are Lateral Distance (LaD),  Longitudinal Distance (LoD) and Vertical Distance (VD) "]
+    #[doc = " * and their respective  thresholds, Minimum  Safe  Lateral  Distance (MSLaD), Minimum  Safe  Longitudinal Distance  (MSLoD),  and  Minimum  Safe Vertical Distance (MSVD)."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information, Kinematic information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SafeDistanceIndication {
+        #[rasn(identifier = "subjectStation")]
+        pub subject_station: Option<StationId>,
+        #[rasn(identifier = "safeDistanceIndicator")]
+        pub safe_distance_indicator: SafeDistanceIndicator,
+        #[rasn(identifier = "timeToCollision")]
+        pub time_to_collision: Option<DeltaTimeTenthOfSecond>,
+    }
+    impl SafeDistanceIndication {
+        pub fn new(
+            subject_station: Option<StationId>,
+            safe_distance_indicator: SafeDistanceIndicator,
+            time_to_collision: Option<DeltaTimeTenthOfSecond>,
+        ) -> Self {
+            Self {
+                subject_station,
+                safe_distance_indicator,
+                time_to_collision,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates if a distance is safe. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * -  `FALSE`  if  the triple  {LaD,  LoD, VD} < {MSLaD, MSLoD, MSVD} is simultaneously  satisfied with confidence level of  90 % or  more, "]
+    #[doc = " * -  `TRUE` otherwise. "]
+    #[doc = " *"]
+    #[doc = " * @note: the abbreviations used are Lateral Distance (LaD),  Longitudinal Distance (LoD) and Vertical Distance (VD) "]
+    #[doc = " * and their respective  thresholds, Minimum  Safe  Lateral  Distance (MSLaD), Minimum  Safe  Longitudinal Distance  (MSLoD),  and  Minimum  Safe Vertical Distance (MSVD)."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information, Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(delegate)]
+    pub struct SafeDistanceIndicator(pub bool);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4095"))]
+    pub struct SemiAxisLength(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the type of sensor."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0  `undefined`         - in case the sensor type is undefined, "]
+    #[doc = " * - 1  `radar`             - in case the sensor is a radar,"]
+    #[doc = " * - 2  `lidar`             - in case the sensor is a lidar,"]
+    #[doc = " * - 3  `monovideo`         - in case the sensor is mono video,"]
+    #[doc = " * - 4  `stereovision`      - in case the sensor is stereo vision,"]
+    #[doc = " * - 5  `nightvision`       - in case the sensor supports night vision, using e.g. infrared illumination or thermal imaging,"]
+    #[doc = " * - 6  `ultrasonic`        - in case the sensor is ultrasonic,"]
+    #[doc = " * - 7  `pmd`               - in case the sensor is photonic mixing device,"]
+    #[doc = " * - 8  `inductionLoop`     - in case the sensor is an induction loop,"]
+    #[doc = " * - 9  `sphericalCamera`   - in case the sensor is a spherical camera,"]
+    #[doc = " * - 10 `uwb`               - in case the sensor is ultra wide band,"]
+    #[doc = " * - 11 `acoustic`          - in case the sensor is acoustic,"]
+    #[doc = " * - 12 `localAggregation`  - in case the information is provided by a system that aggregates information from different local sensors. Aggregation may include fusion,"]
+    #[doc = " * - 13 `itsAggregation`    - in case the information is provided by a system that aggregates information from other received ITS messages,"]
+    #[doc = " * - 14 `rfid`              - in case the sensor is radio frequency identification using a passive or active (e.g. Bluetooth, W-LAN) technology. "]
+    #[doc = " * - 15-31                  - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing Information"]
+    #[doc = " * @revision: created in V2.1.1, description of value 5 changed and value 14 added in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=31"))]
+    pub struct SensorType(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the type of sensor(s)."]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * "]
+    #[doc = " * - 0  `undefined`         - in case the sensor type is undefined. "]
+    #[doc = " * - 1  `radar`             - in case the sensor is a radar,"]
+    #[doc = " * - 2  `lidar`             - in case the sensor is a lidar,"]
+    #[doc = " * - 3  `monovideo`         - in case the sensor is mono video,"]
+    #[doc = " * - 4  `stereovision`      - in case the sensor is stereo vision,"]
+    #[doc = " * - 5  `nightvision`       - in case the sensor supports night vision, using e.g. infrared illumination or thermal imaging,"]
+    #[doc = " * - 6  `ultrasonic`        - in case the sensor is ultrasonic,"]
+    #[doc = " * - 7  `pmd`               - in case the sensor is photonic mixing device,"]
+    #[doc = " * - 8  `inductionLoop`     - in case the sensor is an induction loop,"]
+    #[doc = " * - 9  `sphericalCamera`   - in case the sensor is a spherical camera,"]
+    #[doc = " * - 10 `uwb`               - in case the sensor is ultra wide band,"]
+    #[doc = " * - 11 `acoustic`          - in case the sensor is acoustic,"]
+    #[doc = " * - 12 `localAggregation`  - in case the information is provided by a system that aggregates information from different local sensors. Aggregation may include fusion,"]
+    #[doc = " * - 13 `itsAggregation`    - in case the information is provided by a system that aggregates information from other received ITS messages,"]
+    #[doc = " * - 14 `rfid`              - in case the sensor is radio frequency identification using a passive or active (e.g. Bluetooth, W-LAN) technology. "]
+    #[doc = " * - 15                     - reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * @note: If all bits are set to 0, then no sensor type is used"]
+    #[doc = " *"]
+    #[doc = " * @category: Sensing Information"]
+    #[doc = " * @revision: created in V2.2.1, description of value 5 changed and value 14 added in V2.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("16", extensible))]
+    pub struct SensorTypes(pub BitString);
+    #[doc = "*"]
+    #[doc = " * This DE represents a sequence number."]
+    #[doc = " * "]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct SequenceNumber(pub u16);
+    #[doc = "* "]
+    #[doc = " * This DF shall contain a list of DF @ref CartesianPosition3d."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16", extensible))]
+    pub struct SequenceOfCartesianPosition3d(pub SequenceOf<CartesianPosition3d>);
+    #[doc = "* "]
+    #[doc = " * The DF contains a list of DE @ref Identifier1B."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128", extensible))]
+    pub struct SequenceOfIdentifier1B(pub SequenceOf<Identifier1B>);
+    #[doc = "*"]
+    #[doc = " * The DF contains a list of DF @ref SafeDistanceIndication."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information, Kinematic information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct SequenceOfSafeDistanceIndication(pub SequenceOf<SafeDistanceIndication>);
+    #[doc = "*"]
+    #[doc = " * The DF shall contain a list of DF @ref TrajectoryInterceptionIndication."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information, Kinematic information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8", extensible))]
+    pub struct SequenceOfTrajectoryInterceptionIndication(
+        pub SequenceOf<TrajectoryInterceptionIndication>,
+    );
+    #[doc = "*"]
+    #[doc = " * This DF provides the definition of a geographical area or volume, based on different options."]
+    #[doc = " *"]
+    #[doc = " * It is a choice of the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field rectangular: definition of an rectangular area or a right rectangular prism (with a rectangular base) also called a cuboid, or informally a rectangular box."]
+    #[doc = " *"]
+    #[doc = " * @field circular: definition of an area of circular shape or a right circular cylinder."]
+    #[doc = " *"]
+    #[doc = " * @field polygonal: definition of an area of polygonal shape or a right prism."]
+    #[doc = " *"]
+    #[doc = " * @field elliptical: definition of an area of elliptical shape or a right elliptical cylinder."]
+    #[doc = " *"]
+    #[doc = " * @field radial: definition of a radial shape."]
+    #[doc = " *"]
+    #[doc = " * @field radialList: definition of list of radial shapes."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum Shape {
+        rectangular(RectangularShape),
+        circular(CircularShape),
+        polygonal(PolygonalShape),
+        elliptical(EllipticalShape),
+        radial(RadialShape),
+        radialShapes(RadialShapes),
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `signalViolation`."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`               - in case further detailed information on signal violation event is unavailable,"]
+    #[doc = " * - 1 `stopSignViolation`         - in case a stop sign violation is detected,"]
+    #[doc = " * - 2 `trafficLightViolation`     - in case a traffic light violation is detected,"]
+    #[doc = " * - 3 `turningRegulationViolation`- in case a turning regulation violation is detected."]
+    #[doc = " * - 4-255                         - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SignalViolationSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the sub cause codes of the @ref CauseCode \"slowVehicle\"."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                            - in case further detailed information on slow vehicle driving event is unavailable,"]
+    #[doc = " * - 1 `maintenanceVehicle`                     - in case of a slow driving maintenance vehicle on the road (incl. winter maintenance without detailed status),"]
+    #[doc = " * - 2 `vehiclesSlowingToLookAtAccident`        - in case vehicle is temporally slowing down to look at accident, spot, etc.,"]
+    #[doc = " * - 3 `abnormalLoad`                           - in case an abnormal loaded vehicle is driving slowly on the road,"]
+    #[doc = " * - 4 `abnormalWideLoad`                       - in case an abnormal wide load vehicle is driving slowly on the road,"]
+    #[doc = " * - 5 `convoy`                                 - in case of slow driving convoy on the road,"]
+    #[doc = " * - 6 `winterMaintenanceSnowplough             - in case of slow driving snow plough on the road,"]
+    #[doc = " * - 7 `deicing-deprecated`                     - deprecated since covered by 8 `winterMaintenanceAdhesionImprovement`,"]
+    #[doc = " * - 8 `winterMaintenanceAdhesionImprovement`   - in case of a slow driving winter maintenance vehicle applying measures to improve the driving conditions "]
+    #[doc = "                                                  and adhesion on winter roads, including improving grip (by applying sand or grit), de-icing (by applying salt or brine),"]
+    #[doc = "                                                  or anti-icing (by applying brine to prevent buildup of ice and snow). "]
+    #[doc = " * - 9-255                                      - are reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 7 deprecated and name of 6 and 8 changed and semantics of 8 refined in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SlowVehicleSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * The DE indicates if a vehicle is carrying goods in the special transport conditions."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 `heavyLoad`        - the vehicle is carrying goods with heavy load,"]
+    #[doc = " * - 1 `excessWidth`      - the vehicle is carrying goods in excess of width,"]
+    #[doc = " * - 2 `excessLength`     - the vehicle is carrying goods in excess of length,"]
+    #[doc = " * - 3 `excessHeight`     - the vehicle is carrying goods in excess of height."]
+    #[doc = " *"]
+    #[doc = " * Otherwise, the corresponding bit shall be set to 0."]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct SpecialTransportType(pub FixedBitString<4usize>);
+    #[doc = "*"]
+    #[doc = " * This DF represents the speed and associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field speedValue: the speed value."]
+    #[doc = " * "]
+    #[doc = " * @field speedConfidence: the confidence value of the speed value."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Speed {
+        #[rasn(identifier = "speedValue")]
+        pub speed_value: SpeedValue,
+        #[rasn(identifier = "speedConfidence")]
+        pub speed_confidence: SpeedConfidence,
+    }
+    impl Speed {
+        pub fn new(speed_value: SpeedValue, speed_confidence: SpeedConfidence) -> Self {
+            Self {
+                speed_value,
+                speed_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the speed confidence value which represents the estimated absolute accuracy of a speed value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n * 0,01 m/s."]
+    #[doc = " * - `126` if the confidence value is out of range, i.e. greater than 1,25 m/s,"]
+    #[doc = " * - `127` if the confidence value information is not available."]
+    #[doc = " *  "]
+    #[doc = " * @note: The fact that a speed value is received with confidence value set to `unavailable(127)` can be caused by several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the speed value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * @note: If a speed value is received and its confidence value is set to `outOfRange(126)`, it means that the speed value is not valid "]
+    #[doc = " * and therefore cannot be trusted. Such is not useful for the application."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,01 m/s"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct SpeedConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents a speed limitation applied to a geographical position, a road section or a geographical region."]
+    #[doc = " * "]
+    #[doc = " * @unit: km/h"]
+    #[doc = " * @category: Infrastructure information, Traffic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=255"))]
+    pub struct SpeedLimit(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents a speed value, i.e. the magnitude of the velocity-vector. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` in a standstill situation."]
+    #[doc = " * - `n` (`n > 0` and `n < 16 382`) if the applicable value is equal to or less than n x 0,01 m/s, and greater than (n-1) x 0,01 m/s,"]
+    #[doc = " * - `16 382` for speed values greater than 163,81 m/s,"]
+    #[doc = " * - `16 383` if the speed accuracy information is not available."]
+    #[doc = " * "]
+    #[doc = " * @note: the definition of standstill is out of scope of the present document."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,01 m/s"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (the meaning of 16382 has changed slightly) "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=16383"))]
+    pub struct SpeedValue(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF  provides the  indication of  change in stability."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field lossProbability: the probability of stability loss. "]
+    #[doc = " * "]
+    #[doc = " * @field actionDeltaTime: the period over which the the probability of stability loss is estimated. "]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct StabilityChangeIndication {
+        #[rasn(identifier = "lossProbability")]
+        pub loss_probability: StabilityLossProbability,
+        #[rasn(identifier = "actionDeltaTime")]
+        pub action_delta_time: DeltaTimeTenthOfSecond,
+    }
+    impl StabilityChangeIndication {
+        pub fn new(
+            loss_probability: StabilityLossProbability,
+            action_delta_time: DeltaTimeTenthOfSecond,
+        ) -> Self {
+            Self {
+                loss_probability,
+                action_delta_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the estimated probability of a stability level and conversely also the probability of a stability loss."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` to indicate an estimated probability of a loss of stability of 0 %, i.e. \"stable\", "]
+    #[doc = " * - `n` (`n > 0` and `n < 50`) to indicate the actual stability level,"]
+    #[doc = " * - `50` to indicate a estimated probability of a loss of stability of 100 %, i.e. \"total loss of stability\","]
+    #[doc = " * - the values between 51 and 62 are reserved for future use,"]
+    #[doc = " * - `63`: this value indicates that the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 2 %"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=63"))]
+    pub struct StabilityLossProbability(pub u8);
+    #[doc = "*"]
+    #[doc = " * The DE represents length as a measure of distance between points or as a dimension of an object or shape. "]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4095"))]
+    pub struct StandardLength12b(pub u16);
+    #[doc = "*"]
+    #[doc = " * The DE represents length as a measure of distance between points or as a dimension of an object. "]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct StandardLength1B(pub u8);
+    #[doc = "*"]
+    #[doc = " * The DE represents length as a measure of distance between points or as a dimension of an object.  "]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct StandardLength2B(pub u16);
+    #[doc = "*"]
+    #[doc = " * The DE represents length as a measure of distance between points. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `lessThan50m`   - for distances below 50 m, "]
+    #[doc = " * - 1 `lessThan100m`  - for distances below 100 m,"]
+    #[doc = " * - 2 `lessThan200m`  - for distances below 200 m, "]
+    #[doc = " * - 3 `lessThan500m`  - for distances below 300 m, "]
+    #[doc = " * - 4 `lessThan1000m` - for distances below 1 000 m,"]
+    #[doc = " * - 5 `lessThan5km`   - for distances below 5 000 m, "]
+    #[doc = " * - 6 `lessThan10km`  - for distances below 10 000 m, "]
+    #[doc = " * - 7 `over10km`      - for distances over 10 000 m."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1 from RelevanceDistance"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum StandardLength3b {
+        lessThan50m = 0,
+        lessThan100m = 1,
+        lessThan200m = 2,
+        lessThan500m = 3,
+        lessThan1000m = 4,
+        lessThan5km = 5,
+        lessThan10km = 6,
+        over10km = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * The DE represents length as a measure of distance between points or as a dimension of an object. "]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=511"))]
+    pub struct StandardLength9b(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the identifier of an ITS-S."]
+    #[doc = " * The ITS-S ID may be a pseudonym. It may change over space and/or over time."]
+    #[doc = " *"]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref StationId instead."]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct StationID(pub u32);
+    #[doc = "*"]
+    #[doc = " * This DE represents the identifier of an ITS-S."]
+    #[doc = " * The ITS-S ID may be a pseudonym. It may change over space and/or over time."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1 based on @ref StationID"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct StationId(pub u32);
+    #[doc = "*"]
+    #[doc = " * This DE represents the type of technical context the ITS-S is integrated in."]
+    #[doc = " * The station type depends on the integration environment of ITS-S into vehicle, mobile devices or at infrastructure."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to the corresponding value of the integration environment of DE TrafficParticipantType"]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information."]
+    #[doc = " * @revision: revised in V2.1.1 (named values 12 and 13 added and note to value 9 deleted). Deleted note and type set equal to TrafficParticipantType in V2.4.1."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StationType(pub TrafficParticipantType);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the duration in minutes since which something is stationary."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `lessThan1Minute`         - for being stationary since less than 1 minute, "]
+    #[doc = " * - 1 `lessThan2Minutes`        - for being stationary since less than 2 minute and for equal to or more than 1 minute,"]
+    #[doc = " * - 2 `lessThan15Minutes`       - for being stationary since less than 15 minutes and for equal to or more than 1 minute,"]
+    #[doc = " * - 3 `equalOrGreater15Minutes` - for being stationary since equal to or more than 15 minutes."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum StationarySince {
+        lessThan1Minute = 0,
+        lessThan2Minutes = 1,
+        lessThan15Minutes = 2,
+        equalOrGreater15Minutes = 3,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE provides the value of the sub cause codes of the @ref CauseCode \"stationaryVehicle\". "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`             - in case further detailed information on stationary vehicle is unavailable,"]
+    #[doc = " * - 1 `humanProblem-deprecated` - deprecated since covered by DE HumanProblemSubCauseCode,"]
+    #[doc = " * - 2 `vehicleBreakdown`        - in case stationary vehicle is due to vehicle break down,"]
+    #[doc = " * - 3 `postCrash`               - in case stationary vehicle is caused by collision,"]
+    #[doc = " * - 4 `publicTransportStop`     - in case public transport vehicle is stationary at bus stop,"]
+    #[doc = " * - 5 `carryingDangerousGoods`  - in case the stationary vehicle is carrying dangerous goods,"]
+    #[doc = " * - 6 `vehicleOnFire`           - in case of vehicle on fire."]
+    #[doc = " * - 7-255 reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 6 added in V2.1.1, value 1 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct StationaryVehicleSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents the steering wheel angle of the vehicle at certain point in time."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field steeringWheelAngleValue: steering wheel angle value."]
+    #[doc = " * "]
+    #[doc = " * @field steeringWheelAngleConfidence: confidence value of the steering wheel angle value."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SteeringWheelAngle {
+        #[rasn(identifier = "steeringWheelAngleValue")]
+        pub steering_wheel_angle_value: SteeringWheelAngleValue,
+        #[rasn(identifier = "steeringWheelAngleConfidence")]
+        pub steering_wheel_angle_confidence: SteeringWheelAngleConfidence,
+    }
+    impl SteeringWheelAngle {
+        pub fn new(
+            steering_wheel_angle_value: SteeringWheelAngleValue,
+            steering_wheel_angle_confidence: SteeringWheelAngleConfidence,
+        ) -> Self {
+            Self {
+                steering_wheel_angle_value,
+                steering_wheel_angle_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the steering wheel angle confidence value which represents the estimated absolute accuracy for a  steering wheel angle value with a confidence level of 95 %."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 126`) if the confidence value is equal to or less than n x 1,5 degrees,"]
+    #[doc = " * - `126` if the confidence value is out of range, i.e. greater than 187,5 degrees,"]
+    #[doc = " * - `127` if the confidence value is not available."]
+    #[doc = " * "]
+    #[doc = " * @note: The fact that a steering wheel angle value is received with confidence value set to `unavailable(127)`"]
+    #[doc = " * can be caused by several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the steering wheel angle value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * If a steering wheel angle value is received and its confidence value is set to `outOfRange(126)`,"]
+    #[doc = " * it means that the steering wheel angle value is not valid and therefore cannot be trusted."]
+    #[doc = " * Such value is not useful for the application."]
+    #[doc = " * "]
+    #[doc = " * @unit: 1,5 degree"]
+    #[doc = " * @category: Vehicle Information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct SteeringWheelAngleConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the steering wheel angle of the vehicle at certain point in time."]
+    #[doc = " * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-511` if the steering wheel angle is equal to or greater than 511 x 1,5 degrees = 766,5 degrees to the right,"]
+    #[doc = " * - `n` (`n > -511` and `n <= 0`) if  the steering wheel angle is equal to or less than n x 1,5 degrees, and greater than (n-1) x 1,5 degrees, "]
+    #[doc = "      turning clockwise (i.e. to the right),"]
+    #[doc = " * - `n` (`n >= 1` and `n < 511`) if the steering wheel angle is equal to or less than n x 0,1 degrees, and greater than (n-1) x 0,1 degrees, "]
+    #[doc = "      turning counter-clockwise (i.e. to the left),"]
+    #[doc = " * - `511` if the steering wheel angle is greater than 510 x 1,5 degrees = 765 degrees to the left,"]
+    #[doc = " * - `512` if information is not available."]
+    #[doc = " *"]
+    #[doc = " * @unit: 1,5 degree"]
+    #[doc = " * @revision: Description revised in V2.1.1 (meaning of value 511 has changed slightly)."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-511..=512"))]
+    pub struct SteeringWheelAngleValue(pub i16);
+    #[doc = "* "]
+    #[doc = " * This DE indicates the type of stored information."]
+    #[doc = " *"]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * "]
+    #[doc = " * - `0` undefined        - in case the stored information type is undefined. "]
+    #[doc = " * - `1` staticDb         - in case the stored information type is a static database."]
+    #[doc = " * - `2` dynamicDb        - in case the stored information type is a dynamic database"]
+    #[doc = " * - `3` realTimeDb       - in case the stored information type is a real time updated database."]
+    #[doc = " * - `4` map              - in case the stored information type is a road topology map."]
+    #[doc = " * - Bits 5 to 7          - are reserved for future use."]
+    #[doc = " *"]
+    #[doc = " * @note: If all bits are set to 0, then no stored information type is used"]
+    #[doc = " *"]
+    #[doc = " * @category: Basic Information"]
+    #[doc = " * @revision: created in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8", extensible))]
+    pub struct StoredInformationType(pub BitString);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the generic sub cause of a detected event."]
+    #[doc = " * "]
+    #[doc = " * @note: The sub cause code value assignment varies based on value of @ref CauseCode."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (this is  the generic sub cause type)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SubCauseCodeType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates a temperature value."]
+    #[doc = ""]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-60` for temperature equal to or less than -60 degrees C,"]
+    #[doc = " * - `n` (`n > -60` and `n < 67`) for the actual temperature n in degrees C,"]
+    #[doc = " * - `67` for temperature equal to or greater than 67 degrees C."]
+    #[doc = " * "]
+    #[doc = " * @unit: degrees Celsius"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-60..=67"))]
+    pub struct Temperature(pub i8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the number of elapsed (TAI) milliseconds since the ITS Epoch. "]
+    #[doc = " * The ITS epoch is `00:00:00.000 UTC, 1 January 2004`."]
+    #[doc = " * \"Elapsed\" means that the true number of milliseconds is continuously counted without interruption,"]
+    #[doc = " *  i.e. it is not altered by leap seconds, which occur in UTC."]
+    #[doc = " * "]
+    #[doc = " * @note: International Atomic Time (TAI) is the time reference coordinate on the basis of the readings of atomic clocks, "]
+    #[doc = " * operated in accordance with the definition of the second, the unit of time of the International System of Units. "]
+    #[doc = " * TAI is a continuous time scale. UTC has discontinuities, as it is occasionally adjusted by leap seconds. "]
+    #[doc = " * As of 1 January, 2022, TimestampIts is 5 seconds ahead of UTC, because since the ITS epoch on 1 January 2004 00:00:00.000 UTC, "]
+    #[doc = " * further 5 leap seconds have been inserted in UTC."]
+    #[doc = " * "]
+    #[doc = " * EXAMPLE: The value for TimestampIts for 1 January 2007 00:00:00.000 UTC is `94 694 401 000` milliseconds,"]
+    #[doc = " * which includes one leap second insertion since the ITS epoch."]
+    #[doc = " * @unit: 0,001 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Description revised in in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4398046511103"))]
+    pub struct TimestampIts(pub u64);
+    #[doc = "*"]
+    #[doc = " * This DF represents one or more paths using @ref Path."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Description revised in V2.1.1. Is is now based on Path and not on PathHistory"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=7"))]
+    pub struct Traces(pub SequenceOf<Path>);
+    #[doc = "*"]
+    #[doc = " * This DF represents one or more paths using @ref PathExtended."]
+    #[doc = " * "]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=7"))]
+    pub struct TracesExtended(pub SequenceOf<PathExtended>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `trafficCondition`. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                  - in case further detailed information on the traffic condition is unavailable,"]
+    #[doc = " * - 1 `increasedVolumeOfTraffic`     - in case the type of traffic condition is increased traffic volume,"]
+    #[doc = " * - 2 `trafficJamSlowlyIncreasing`   - in case the type of traffic condition is a traffic jam which volume is increasing slowly,"]
+    #[doc = " * - 3 `trafficJamIncreasing`         - in case the type of traffic condition is a traffic jam which volume is increasing,"]
+    #[doc = " * - 4 `trafficJamStronglyIncreasing` - in case the type of traffic condition is a traffic jam which volume is strongly increasing,"]
+    #[doc = " * - 5 `trafficJam`         `         - in case the type of traffic condition is a traffic jam and no further detailed information about its volume is available,"]
+    #[doc = " * - 6 `trafficJamSlightlyDecreasing` - in case the type of traffic condition is a traffic jam which volume is decreasing slowly,"]
+    #[doc = " * - 7 `trafficJamDecreasing`         - in case the type of traffic condition is a traffic jam which volume is decreasing,"]
+    #[doc = " * - 8 `trafficJamStronglyDecreasing` - in case the type of traffic condition is a traffic jam which volume is decreasing rapidly,"]
+    #[doc = " * - 9 `trafficJamStable`             - in case the traffic condition is a traffic jam with stable volume,"]
+    #[doc = " * - 10-255: reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, definition of value 0 and 1 changed in V2.2.1, name and definition of value 5 changed in V2.2.1, value 9 added in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct TrafficConditionSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates a direction of traffic with respect to a reference direction, and a portion of that traffic with respect to a reference position."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `allTrafficDirections`                                    - for all directions of traffic, "]
+    #[doc = " * - 1 `sameAsReferenceDirection-upstreamOfReferencePosition`    - for the direction of traffic according to the reference direction, and the portion of traffic upstream of the reference position, "]
+    #[doc = " * - 2 `sameAsReferenceDirection-downstreamOfReferencePosition`  - for the direction of traffic according to the reference direction, and the portion of traffic downstream of the reference position, "]
+    #[doc = " * - 3 `oppositeToReferenceDirection`                            - for the direction of traffic opposite to the reference direction. "]
+    #[doc = " *"]
+    #[doc = " * @note: Upstream traffic corresponds to the incoming traffic towards the event position, and downstream traffic to the departing traffic away from the event position."]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1 from RelevanceTrafficDirection, description and naming of values changed in V2.2.1"]
+    #[doc = " *"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TrafficDirection {
+        allTrafficDirections = 0,
+        #[rasn(identifier = "sameAsReferenceDirection-upstreamOfReferencePosition")]
+        sameAsReferenceDirection_upstreamOfReferencePosition = 1,
+        #[rasn(identifier = "sameAsReferenceDirection-downstreamOfReferencePosition")]
+        sameAsReferenceDirection_downstreamOfReferencePosition = 2,
+        oppositeToReferenceDirection = 3,
+    }
+    #[doc = "*"]
+    #[doc = " * Ths DF represents the a position on a traffic island between two lanes. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field oneSide: represents one lane."]
+    #[doc = " * "]
+    #[doc = " * @field otherSide: represents the other lane."]
+    #[doc = " * "]
+    #[doc = " * @category: Road Topology information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TrafficIslandPosition {
+        #[rasn(identifier = "oneSide")]
+        pub one_side: LanePositionAndType,
+        #[rasn(identifier = "otherSide")]
+        pub other_side: LanePositionAndType,
+    }
+    impl TrafficIslandPosition {
+        pub fn new(one_side: LanePositionAndType, other_side: LanePositionAndType) -> Self {
+            Self {
+                one_side,
+                other_side,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the type of a traffic participant."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unknown`          - information about traffic participant is not provided,"]
+    #[doc = " * - 1 `pedestrian`       - human being not using a mechanical device for their trip (VRU profile 1),"]
+    #[doc = " * - 2 `cyclist`          - non-motorized unicycles, bicycles , tricycles, quadracycles (VRU profile 2),"]
+    #[doc = " * - 3 `moped`            - light motor vehicles with less than four wheels as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class L1, L2 (VRU Profile 3),"]
+    #[doc = " * - 4 `motorcycles`      - motor vehicles with less than four wheels as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class L3, L4, L5, L6, L7 (VRU Profile 3),"]
+    #[doc = " * - 5 `passengerCar`     - small passenger vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class M1,"]
+    #[doc = " * - 6 `bus`              - large passenger vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class M2, M3,"]
+    #[doc = " * - 7 `lightTruck`       - light Goods Vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class N1,"]
+    #[doc = " * - 8 `heavyTruck`       - Heavy Goods Vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class N2 and N3,"]
+    #[doc = " * - 9 `trailer`          - unpowered vehicle that is intended to be towed by a powered vehicle as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class O,"]
+    #[doc = " * - 10 `specialVehicles` - vehicles which have special purposes other than the above (e.g. moving road works vehicle),"]
+    #[doc = " * - 11 `tram`            - vehicle which runs on tracks along public streets,"]
+    #[doc = " * - 12 `lightVruVehicle` - human being traveling on light vehicle, incl. possible use of roller skates or skateboards (VRU profile 2),"]
+    #[doc = " * - 13 `animal`          - animal presenting a safety risk to other road users e.g. domesticated dog in a city or horse (VRU Profile 4),"]
+    #[doc = " * - 14 `agricultural`    - agricultural and forestry vehicles as defined in UNECE/TRANS/WP.29/78/Rev.4 [16] class T,"]
+    #[doc = " * - 15 `infrastructure`  - infrastructure typically positioned outside of the drivable roadway (e.g. on a gantry, on a pole, on a stationary road works trailer, "]
+    #[doc = "                            or in a traffic control center); the infrastructure is static during the entire operation period of the ITS-S (e.g. no stop and go activity),"]
+    #[doc = " * - 16-255               - are reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * @category: Communication information."]
+    #[doc = " * @revision: Created in V2.1.1 based on StationType, Changed name and definition of value 15 in V2.4.1 "]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct TrafficParticipantType(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates traffic rules that apply to vehicles at a certain position."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` - if overtaking is prohibited for all vehicles,"]
+    #[doc = " * - `1` - if overtaking is prohibited for trucks,"]
+    #[doc = " * - `2` - if vehicles should pass to the right lane,"]
+    #[doc = " * - `3` - if vehicles should pass to the left lane."]
+    #[doc = " * - `4` - if vehicles should pass to the left or right lane."]
+    #[doc = " *"]
+    #[doc = " * @category: Infrastructure information, Traffic information"]
+    #[doc = " * @revision: Editorial update in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum TrafficRule {
+        noPassing = 0,
+        noPassingForTrucks = 1,
+        passToRight = 2,
+        passToLeft = 3,
+        #[rasn(extension_addition)]
+        passToLeftOrRight = 4,
+    }
+    #[doc = "* "]
+    #[doc = " * This DF provides detailed information about an attached trailer."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field refPointId: identifier of the reference point of the trailer."]
+    #[doc = " *"]
+    #[doc = " * @field hitchPointOffset: optional position of the hitch point in negative x-direction (according to ISO 8855) from the"]
+    #[doc = " * vehicle Reference Point."]
+    #[doc = " *"]
+    #[doc = " * @field frontOverhang: optional length of the trailer overhang in the positive x direction (according to ISO 8855) from the"]
+    #[doc = " * trailer Reference Point indicated by the refPointID. The value defaults to 0 in case the trailer"]
+    #[doc = " * is not overhanging to the front with respect to the trailer reference point."]
+    #[doc = " *"]
+    #[doc = " * @field rearOverhang: optional length of the trailer overhang in the negative x direction (according to ISO 8855) from the"]
+    #[doc = " * trailer Reference Point indicated by the refPointID."]
+    #[doc = " *"]
+    #[doc = " * @field trailerWidth: optional width of the trailer."]
+    #[doc = " *"]
+    #[doc = " * @field hitchAngle: optional Value and confidence value of the angle between the trailer orientation (corresponding to the x"]
+    #[doc = " * direction of the ISO 8855 [21] coordinate system centered on the trailer) and the direction of"]
+    #[doc = " * the segment having as end points the reference point of the trailer and the reference point of"]
+    #[doc = " * the pulling vehicle, which can be another trailer or a vehicle looking on the horizontal plane"]
+    #[doc = " * xy, described in the local Cartesian coordinate system of the trailer. The"]
+    #[doc = " * angle is measured with negative values considering the trailer orientation turning clockwise"]
+    #[doc = " * starting from the segment direction. The angle value accuracy is provided with the"]
+    #[doc = " * confidence level of 95 %."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TrailerData {
+        #[rasn(identifier = "refPointId")]
+        pub ref_point_id: Identifier1B,
+        #[rasn(identifier = "hitchPointOffset")]
+        pub hitch_point_offset: StandardLength1B,
+        #[rasn(identifier = "frontOverhang")]
+        pub front_overhang: Option<StandardLength1B>,
+        #[rasn(identifier = "rearOverhang")]
+        pub rear_overhang: Option<StandardLength1B>,
+        #[rasn(identifier = "trailerWidth")]
+        pub trailer_width: Option<VehicleWidth>,
+        #[rasn(identifier = "hitchAngle")]
+        pub hitch_angle: CartesianAngle,
+    }
+    impl TrailerData {
+        pub fn new(
+            ref_point_id: Identifier1B,
+            hitch_point_offset: StandardLength1B,
+            front_overhang: Option<StandardLength1B>,
+            rear_overhang: Option<StandardLength1B>,
+            trailer_width: Option<VehicleWidth>,
+            hitch_angle: CartesianAngle,
+        ) -> Self {
+            Self {
+                ref_point_id,
+                hitch_point_offset,
+                front_overhang,
+                rear_overhang,
+                trailer_width,
+                hitch_angle,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE provides information about the presence of a trailer. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `noTrailerPresent`                - to indicate that no trailer is present, i.e. either the vehicle is physically not enabled to tow a trailer or it has been detected that no trailer is present."]
+    #[doc = " * - 1 `trailerPresentWithKnownLength`   - to indicate that a trailer has been detected as present and the length is included in the vehicle length value."]
+    #[doc = " * - 2 `trailerPresentWithUnknownLength` - to indicate that a trailer has been detected as present and the length is not included in the vehicle length value."]
+    #[doc = " * - 3 `trailerPresenceIsUnknown`        - to indicate that information about the trailer presence is unknown, i.e. the vehicle is physically enabled to tow a trailer but the detection of trailer presence/absence is not possible."]
+    #[doc = " * - 4 `unavailable`                     - to indicate that the information about the presence of a trailer is not available, i.e. it is neither known whether the vehicle is able to tow a trailer "]
+    #[doc = " *                                         nor the detection of trailer presence/absence is possible."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1 based on VehicleLengthConfidenceIndication"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TrailerPresenceInformation {
+        noTrailerPresent = 0,
+        trailerPresentWithKnownLength = 1,
+        trailerPresentWithUnknownLength = 2,
+        trailerPresenceIsUnknown = 3,
+        unavailable = 4,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE  defines  the  confidence level of the trajectoryInterceptionProbability."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` - to indicate confidence level less than 50 %,"]
+    #[doc = " * - `1` - to indicate confidence level greater than or equal to 50 % and less than 70 %,"]
+    #[doc = " * - `2` - to indicate confidence level greater than or equal to 70 % and less than 90 %,"]
+    #[doc = " * - `3` - to indicate confidence level greater than or equal to 90%."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=3"))]
+    pub struct TrajectoryInterceptionConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF  provides the trajectory  interception  indication  of  ego-VRU  ITS-S  with another ITS-Ss. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field subjectStation: indicates the subject station."]
+    #[doc = " * "]
+    #[doc = " * @field trajectoryInterceptionProbability: indicates the propbability of the interception of the subject station trajectory "]
+    #[doc = " * with the trajectory of the station indicated in the component subjectStation."]
+    #[doc = " *"]
+    #[doc = " * @field trajectoryInterceptionConfidence: indicates the confidence of interception of the subject station trajectory "]
+    #[doc = " * with the trajectory of the station indicated in the component subjectStation."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TrajectoryInterceptionIndication {
+        #[rasn(identifier = "subjectStation")]
+        pub subject_station: Option<StationId>,
+        #[rasn(identifier = "trajectoryInterceptionProbability")]
+        pub trajectory_interception_probability: TrajectoryInterceptionProbability,
+        #[rasn(identifier = "trajectoryInterceptionConfidence")]
+        pub trajectory_interception_confidence: Option<TrajectoryInterceptionConfidence>,
+    }
+    impl TrajectoryInterceptionIndication {
+        pub fn new(
+            subject_station: Option<StationId>,
+            trajectory_interception_probability: TrajectoryInterceptionProbability,
+            trajectory_interception_confidence: Option<TrajectoryInterceptionConfidence>,
+        ) -> Self {
+            Self {
+                subject_station,
+                trajectory_interception_probability,
+                trajectory_interception_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This  DE  defines  the  probability  that the ego trajectory  intercepts  with any  other object's  trajectory  on the  road. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 0` and `n <= 50`) to indicate the actual probability,"]
+    #[doc = " * - the values between 51 and 62 are reserved,"]
+    #[doc = " * - `63`: to indicate that the information is unavailable. "]
+    #[doc = " *"]
+    #[doc = " * @unit: 2 %"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=63"))]
+    pub struct TrajectoryInterceptionProbability(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the time interval between two consecutive message transmissions."]
+    #[doc = " * "]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref DeltaTimeMilliSecondPos instead."]
+    #[doc = " * @unit: 0,001 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=10000"))]
+    pub struct TransmissionInterval(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE provides the turning direction. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `left`  for turning to te left."]
+    #[doc = " * - `right` for turing to the right."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TurningDirection {
+        left = 0,
+        right = 1,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the smallest circular turn (i.e. U-turn) that the vehicle is capable of making."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 254`) to indicate the applicable value is equal to or less than n x 0,4 metre, and greater than (n-1) x 0,4 metre,"]
+    #[doc = " * - `254` to indicate that the turning radius is  greater than 253 x 0,4 metre = 101.2 metres,"]
+    #[doc = " * - `255` to indicate that the information is unavailable."]
+    #[doc = " * "]
+    #[doc = " * For vehicle with tracker, the turning radius applies to the vehicle only."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @unit 0,4 metre"]
+    #[doc = " * @revision: Description revised V2.1.1 (the meaning of 254 has changed slightly)"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=255"))]
+    pub struct TurningRadius(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents an indication of how a certain path or area will be used. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0  - ` noIndication `     - in case it will remain free to be used,"]
+    #[doc = " * - 1  - ` specialUse `       - in case it will be physically blocked by special use,"]
+    #[doc = " * - 2  - ` rescueOperation`   - in case it is intended to be used for rescue operations,"]
+    #[doc = " * - 3  - ` railroad `         - in case it is intended to be used for rail traffic,"]
+    #[doc = " * - 4  - ` fixedRoute `       - in case it is intended to be used for fixed route traffic (e.g. bus line in service, delivery services, garbage truck in service etc.),"]
+    #[doc = " * - 5  - ` restrictedRoute `  - in case it is intended to be used for driving on restricted routes (e.g dedicated lanes/routes for heavy trucks or buses),"]
+    #[doc = " * - 6  - ` adasAd `           - in case it is intended to be used for driving with an active ADAS or AD system (see DE AccelerationControl or AutomationControl),"]
+    #[doc = " * - 7  - ` navigation `       - in case it is intended to be used for driving with an active navigation system."]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.2.1, extension 3-7 added in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum UsageIndication {
+        noIndication = 0,
+        specialUse = 1,
+        rescueOperation = 2,
+        #[rasn(extension_addition)]
+        railroad = 3,
+        #[rasn(extension_addition)]
+        fixedRoute = 4,
+        #[rasn(extension_addition)]
+        restrictedRoute = 5,
+        #[rasn(extension_addition)]
+        adasAd = 6,
+        #[rasn(extension_addition)]
+        navigation = 7,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the Vehicle Descriptor Section (VDS). The values are assigned according to ISO 3779 [6]."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("6"))]
+    pub struct VDS(pub Ia5String);
+    #[doc = "* "]
+    #[doc = " * This DE represents the duration of a traffic event validity. "]
+    #[doc = " *"]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref DeltaTimeSecond instead."]
+    #[doc = " * @unit: 1 s"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=86400"))]
+    pub struct ValidityDuration(pub u32);
+    #[doc = "*"]
+    #[doc = " * This DF together with its sub DFs Ext1, Ext2 and the DE Ext3 provides the custom (i.e. not ASN.1 standard) definition of an integer with variable lenght, that can be used for example to encode the ITS-AID. "]
+    #[doc = " *"]
+    #[doc = " * @category: Basic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum VarLengthNumber {
+        #[rasn(value("0..=127"), tag(context, 0))]
+        content(u8),
+        #[rasn(tag(context, 1))]
+        extension(Ext1),
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the value of the sub cause codes of the @ref CauseCode `vehicleBreakdown`. "]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`              - in case further detailed information on cause of vehicle break down is unavailable,"]
+    #[doc = " * - 1 `lackOfFuel`               - in case vehicle break down is due to lack of fuel,"]
+    #[doc = " * - 2 `lackOfBatteryPower`       - in case vehicle break down is caused by lack of battery power,"]
+    #[doc = " * - 3 `engineProblem`            - in case vehicle break down is caused by an engine problem,"]
+    #[doc = " * - 4 `transmissionProblem`      - in case vehicle break down is caused by transmission problem,"]
+    #[doc = " * - 5 `engineCoolingProblem`     - in case vehicle break down is caused by an engine cooling problem,"]
+    #[doc = " * - 6 `brakingSystemProblem`     - in case vehicle break down is caused by a braking system problem,"]
+    #[doc = " * - 7 `steeringProblem`          - in case vehicle break down is caused by a steering problem,"]
+    #[doc = " * - 8 `tyrePuncture-deprecated`  - deprecated since covered by `tyrePressureProblem`,"]
+    #[doc = " * - 9 `tyrePressureProblem`      - in case low tyre pressure in detected,"]
+    #[doc = " * - 10 `vehicleOnFire`           - in case the vehicle is on fire."]
+    #[doc = " * - 11-255                       - are reserved for future usage."]
+    #[doc = " *"]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 10 assigned in V2.1.1, value 8 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct VehicleBreakdownSubCauseCode(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents the height of the vehicle, measured from the ground to the highest point, excluding any antennas."]
+    #[doc = " * In case vehicles are equipped with adjustable ride heights, camper shells, and any other"]
+    #[doc = " * equipment which may result in varying height, the largest possible height shall be used."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >0` and `n < 127`) indicates the applicable value is equal to or less than n x 0,05 metre, and greater than (n-1) x 0,05 metre,"]
+    #[doc = " * - `127` indicates that the vehicle width is greater than 6,3 metres,"]
+    #[doc = " * - `128` indicates that the information in unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit: 0,05 metre "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=128"))]
+    pub struct VehicleHeight(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents the height of the vehicle, measured from the ground to the highest point, excluding any antennas."]
+    #[doc = " * In case vehicles are equipped with adjustable ride heights, camper shells, and any other"]
+    #[doc = " * equipment which may result in varying height, the largest possible height shall be used."]
+    #[doc = ""]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 61`) indicates the applicable value is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,"]
+    #[doc = " * - `61` indicates that the vehicle height is greater than 6,0 metres,"]
+    #[doc = " * - `62` indicates that the information in unavailable."]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Vehicle information "]
+    #[doc = " * @revision: created in V2.3.1 based on VehicleHeight but better aligned in unit and range with VehicleWidth."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=62"))]
+    pub struct VehicleHeight2(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF provides information related to the identification of a vehicle."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field wMInumber: World Manufacturer Identifier (WMI) code."]
+    #[doc = " * "]
+    #[doc = " * @field vDS: Vehicle Descriptor Section (VDS). "]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct VehicleIdentification {
+        #[rasn(identifier = "wMInumber")]
+        pub w_minumber: Option<WMInumber>,
+        #[rasn(identifier = "vDS")]
+        pub v_ds: Option<VDS>,
+    }
+    impl VehicleIdentification {
+        pub fn new(w_minumber: Option<WMInumber>, v_ds: Option<VDS>) -> Self {
+            Self { w_minumber, v_ds }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents the length of vehicle and accuracy indication information."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field vehicleLengthValue: length of vehicle. "]
+    #[doc = " * "]
+    #[doc = " * @field vehicleLengthConfidenceIndication: indication of the length value confidence."]
+    #[doc = " * "]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref VehicleLengthV2 instead."]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VehicleLength {
+        #[rasn(identifier = "vehicleLengthValue")]
+        pub vehicle_length_value: VehicleLengthValue,
+        #[rasn(identifier = "vehicleLengthConfidenceIndication")]
+        pub vehicle_length_confidence_indication: VehicleLengthConfidenceIndication,
+    }
+    impl VehicleLength {
+        pub fn new(
+            vehicle_length_value: VehicleLengthValue,
+            vehicle_length_confidence_indication: VehicleLengthConfidenceIndication,
+        ) -> Self {
+            Self {
+                vehicle_length_value,
+                vehicle_length_confidence_indication,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE provides information about the presence of a trailer. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `noTrailerPresent`                - to indicate that no trailer is present, i.e. either the vehicle is physically not enabled to tow a trailer or it has been detected that no trailer is present,"]
+    #[doc = " * - 1 `trailerPresentWithKnownLength`   - to indicate that a trailer has been detected as present and the length is  included in the vehicle length value,"]
+    #[doc = " * - 2 `trailerPresentWithUnknownLength` - to indicate that a trailer has been detected as present and the length is not included in the vehicle length value,"]
+    #[doc = " * - 3 `trailerPresenceIsUnknown`        - to indicate that information about the trailer presence is unknown, i.e. the vehicle is physically enabled to tow a trailer but the detection of trailer presence/absence is not possible,"]
+    #[doc = " * - 4 `unavailable`                     - to indicate that the information about the presence of a trailer is not available, i.e. it is neither known whether the vehicle is able to tow a trailer, "]
+    #[doc = " *                                        nor the detection of trailer presence/absence is possible."]
+    #[doc = " * "]
+    #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref TrailerPresenceInformation instead. "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum VehicleLengthConfidenceIndication {
+        noTrailerPresent = 0,
+        trailerPresentWithKnownLength = 1,
+        trailerPresentWithUnknownLength = 2,
+        trailerPresenceIsUnknown = 3,
+        unavailable = 4,
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents the length of vehicle and accuracy indication information."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field vehicleLengthValue: length of vehicle. "]
+    #[doc = " * "]
+    #[doc = " * @field trailerPresenceInformation: information about the trailer presence."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: created in V2.1.1 based on @ref VehicleLength but using @ref TrailerPresenceInformation."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VehicleLengthV2 {
+        #[rasn(identifier = "vehicleLengthValue")]
+        pub vehicle_length_value: VehicleLengthValue,
+        #[rasn(identifier = "trailerPresenceInformation")]
+        pub trailer_presence_information: TrailerPresenceInformation,
+    }
+    impl VehicleLengthV2 {
+        pub fn new(
+            vehicle_length_value: VehicleLengthValue,
+            trailer_presence_information: TrailerPresenceInformation,
+        ) -> Self {
+            Self {
+                vehicle_length_value,
+                trailer_presence_information,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the length of a vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 1022`) to indicate the applicable value n is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,"]
+    #[doc = " * - `1 022` to indicate that the vehicle length is greater than 102.1 metres,"]
+    #[doc = " * - `1 023` to indicate that the information in unavailable."]
+    #[doc = " * "]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description updated in V2.1.1 (the meaning of 1 022 has changed slightly)."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=1023"))]
+    pub struct VehicleLengthValue(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE represents the mass of an empty loaded vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to: "]
+    #[doc = " * - `n` (`n > 0` and `n < 1023`) to indicate that the applicable value is equal to or less than n x 10^5 gramm, and greater than (n-1) x 10^5 gramm,"]
+    #[doc = " * - `1 023` indicates that the vehicle mass is greater than 102 200 000 g,"]
+    #[doc = " * - `1 024` indicates  the vehicle mass information is unavailable."]
+    #[doc = " * "]
+    #[doc = " * @note:\tThe empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " * "]
+    #[doc = " * @unit: 10^5 gramm"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description updated in V2.1.1 (the meaning of 1 023 has changed slightly)."]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=1024"))]
+    pub struct VehicleMass(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DF provides information about the status of the vehicleÂ´s movement control mechanisms. "]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field accelerationPedalStatus: information about the status of the acceleration pedal. "]
+    #[doc = " * "]
+    #[doc = " * @field brakePedalPostionStatus information about the status of the brake pedal. "]
+    #[doc = " *"]
+    #[doc = " * @field saeAutomationLevel: optional information about the level of driving automation. "]
+    #[doc = " *"]
+    #[doc = " * @field automationControl: optional information about the controlling mechanism for lateral, or combined lateral and longitudinal movement."]
+    #[doc = " *"]
+    #[doc = " * @field accelerationControl: optional information about the controlling mechanism for longitudinal movement. "]
+    #[doc = " *"]
+    #[doc = " * @field accelerationControlExtension: optional extended information about the controlling mechanism for longitudinal movement. "]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: created in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct VehicleMovementControl {
+        #[rasn(identifier = "accelerationPedalStatus")]
+        pub acceleration_pedal_status: PedalStatus,
+        #[rasn(identifier = "brakePedalStatus")]
+        pub brake_pedal_status: PedalStatus,
+        #[rasn(identifier = "saeAutomationLevel")]
+        pub sae_automation_level: Option<SaeAutomationLevel>,
+        #[rasn(identifier = "automationControl")]
+        pub automation_control: Option<AutomationControl>,
+        #[rasn(identifier = "accelerationControl")]
+        pub acceleration_control: Option<AccelerationControl>,
+        #[rasn(identifier = "accelerationControlExtension")]
+        pub acceleration_control_extension: Option<AccelerationControlExtension>,
+    }
+    impl VehicleMovementControl {
+        pub fn new(
+            acceleration_pedal_status: PedalStatus,
+            brake_pedal_status: PedalStatus,
+            sae_automation_level: Option<SaeAutomationLevel>,
+            automation_control: Option<AutomationControl>,
+            acceleration_control: Option<AccelerationControl>,
+            acceleration_control_extension: Option<AccelerationControlExtension>,
+        ) -> Self {
+            Self {
+                acceleration_pedal_status,
+                brake_pedal_status,
+                sae_automation_level,
+                automation_control,
+                acceleration_control,
+                acceleration_control_extension,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the role played by a vehicle at a point in time."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `default`          - to indicate the default vehicle role as indicated by the vehicle type,"]
+    #[doc = " * - 1 `publicTransport`  - to indicate that the vehicle is used to operate public transport service,"]
+    #[doc = " * - 2 `specialTransport` - to indicate that the vehicle is used for special transport purpose, e.g. oversized trucks,"]
+    #[doc = " * - 3 `dangerousGoods`   - to indicate that the vehicle is used for dangerous goods transportation,"]
+    #[doc = " * - 4 `roadWork`         - to indicate that the vehicle is used to realize roadwork or road maintenance mission,"]
+    #[doc = " * - 5 `rescue`           - to indicate that the vehicle is used for rescue purpose in case of an accident, e.g. as a towing service,"]
+    #[doc = " * - 6 `emergency`        - to indicate that the vehicle is used for emergency mission, e.g. ambulance, fire brigade,"]
+    #[doc = " * - 7 `safetyCar`        - to indicate that the vehicle is used for public safety, e.g. patrol,"]
+    #[doc = " * - 8 `agriculture`      - to indicate that the vehicle is used for agriculture, e.g. farm tractor, "]
+    #[doc = " * - 9 `commercial`       - to indicate that the vehicle is used for transportation of commercial goods,"]
+    #[doc = " * - 10 `military`        - to indicate that the vehicle is used for military purpose, "]
+    #[doc = " * - 11 `roadOperator`    - to indicate that the vehicle is used in road operator missions,"]
+    #[doc = " * - 12 `taxi`            - to indicate that the vehicle is used to provide an authorized taxi service,"]
+    #[doc = " * - 13 `uvar`            - to indicate that the vehicle is authorized to enter a zone according to the applicable Urban Vehicle Access Restrictions."]
+    #[doc = " * - 14 `rfu1`            - is reserved for future usage."]
+    #[doc = " * - 15 `rfu2`            - is reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle Information"]
+    #[doc = " * @revision: Description updated in V2.1.1 (removed reference to CEN/TS 16157-3), value 13 assigned in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum VehicleRole {
+        default = 0,
+        publicTransport = 1,
+        specialTransport = 2,
+        dangerousGoods = 3,
+        roadWork = 4,
+        rescue = 5,
+        emergency = 6,
+        safetyCar = 7,
+        agriculture = 8,
+        commercial = 9,
+        military = 10,
+        roadOperator = 11,
+        taxi = 12,
+        uvar = 13,
+        rfu1 = 14,
+        rfu2 = 15,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the width of a vehicle, excluding side mirrors and possible similar extensions."]
+    #[doc = ""]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n > 0` and `n < 61`) indicates the applicable value is equal to or less than n x 0,1 metre, and greater than (n-1) x 0,1 metre,"]
+    #[doc = " * - `61` indicates that the vehicle width is greater than 6,0 metres,"]
+    #[doc = " * - `62` indicates that the information in unavailable."]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,1 metre"]
+    #[doc = " * @category: Vehicle information "]
+    #[doc = " * @revision: Description updated in V2.1.1 (the meaning of 61 has changed slightly)."]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=62"))]
+    pub struct VehicleWidth(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a velocity vector with associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * The following options are available:"]
+    #[doc = " * "]
+    #[doc = " * @field polarVelocity: the representation of the velocity vector in a polar or cylindrical coordinate system. "]
+    #[doc = " * "]
+    #[doc = " * @field cartesianVelocity: the representation of the velocity vector in a cartesian coordinate system."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum Velocity3dWithConfidence {
+        polarVelocity(VelocityPolarWithZ),
+        cartesianVelocity(VelocityCartesian),
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a velocity vector in a cartesian coordinate system."]
+    #[doc = " "]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field xVelocity: the x component of the velocity vector with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @field yVelocity: the y component of the velocity vector with the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * @field zVelocity: the optional z component of the velocity vector with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VelocityCartesian {
+        #[rasn(identifier = "xVelocity")]
+        pub x_velocity: VelocityComponent,
+        #[rasn(identifier = "yVelocity")]
+        pub y_velocity: VelocityComponent,
+        #[rasn(identifier = "zVelocity")]
+        pub z_velocity: Option<VelocityComponent>,
+    }
+    impl VelocityCartesian {
+        pub fn new(
+            x_velocity: VelocityComponent,
+            y_velocity: VelocityComponent,
+            z_velocity: Option<VelocityComponent>,
+        ) -> Self {
+            Self {
+                x_velocity,
+                y_velocity,
+                z_velocity,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DF represents a component of the velocity vector and the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field value: the value of the component."]
+    #[doc = " * "]
+    #[doc = " * @field confidence: the confidence value of the value."]
+    #[doc = " *"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VelocityComponent {
+        pub value: VelocityComponentValue,
+        pub confidence: SpeedConfidence,
+    }
+    impl VelocityComponent {
+        pub fn new(value: VelocityComponentValue, confidence: SpeedConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE represents the value of a velocity component in a defined coordinate system."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-16 383` if the velocity is equal to or smaller than -163,83 m/s,"]
+    #[doc = " * - `n` (`n > -16 383` and `n < 16 382`) if the applicable value is equal to or less than n x 0,01 m/s, and greater than (n-1) x 0,01 m/s,"]
+    #[doc = " * - `16 382` for velocity values equal to or greater than 163,81 m/s,"]
+    #[doc = " * - `16 383` if the velocity information is not available."]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,01 m/s"]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-16383..=16383"))]
+    pub struct VelocityComponentValue(pub i16);
+    #[doc = "*"]
+    #[doc = " * This DF represents a velocity vector in a polar or cylindrical coordinate system."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field velocityMagnitude: magnitude of the velocity vector on the reference plane, with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @field velocityDirection: polar angle of the velocity vector on the reference plane, with the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * @field zVelocity: the optional z component of the velocity vector along the reference axis of the cylindrical coordinate system, with the associated confidence value."]
+    #[doc = " * "]
+    #[doc = " * @category: Kinematic information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VelocityPolarWithZ {
+        #[rasn(identifier = "velocityMagnitude")]
+        pub velocity_magnitude: Speed,
+        #[rasn(identifier = "velocityDirection")]
+        pub velocity_direction: CartesianAngle,
+        #[rasn(identifier = "zVelocity")]
+        pub z_velocity: Option<VelocityComponent>,
+    }
+    impl VelocityPolarWithZ {
+        pub fn new(
+            velocity_magnitude: Speed,
+            velocity_direction: CartesianAngle,
+            z_velocity: Option<VelocityComponent>,
+        ) -> Self {
+            Self {
+                velocity_magnitude,
+                velocity_direction,
+                z_velocity,
+            }
+        }
+    }
+    #[doc = " four and more octets length"]
+    #[doc = "*"]
+    #[doc = " * This DF indicates the vehicle acceleration at vertical direction and the associated confidence value."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field verticalAccelerationValue: vertical acceleration value at a point in time."]
+    #[doc = " * "]
+    #[doc = " * @field verticalAccelerationConfidence: confidence value of the vertical acceleration value with a predefined confidence level."]
+    #[doc = " * "]
+    #[doc = " * @note: this DF is kept for backwards compatibility reasons only. It is recommended to use @ref AccelerationComponent instead."]
+    #[doc = " * @category Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct VerticalAcceleration {
+        #[rasn(identifier = "verticalAccelerationValue")]
+        pub vertical_acceleration_value: VerticalAccelerationValue,
+        #[rasn(identifier = "verticalAccelerationConfidence")]
+        pub vertical_acceleration_confidence: AccelerationConfidence,
+    }
+    impl VerticalAcceleration {
+        pub fn new(
+            vertical_acceleration_value: VerticalAccelerationValue,
+            vertical_acceleration_confidence: AccelerationConfidence,
+        ) -> Self {
+            Self {
+                vertical_acceleration_value,
+                vertical_acceleration_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the vehicle acceleration at vertical direction in the centre of the mass of the empty vehicle."]
+    #[doc = " * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-160` for acceleration values equal to or less than -16 m/s^2,"]
+    #[doc = " * - `n` (`n > -160` and `n <= 0`) to indicate downwards acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `n` (`n > 0` and `n < 160`) to indicate upwards acceleration equal to or less than n x 0,1 m/s^2, and greater than (n-1) x 0,1 m/s^2,"]
+    #[doc = " * - `160` for acceleration values greater than 15,9 m/s^2,"]
+    #[doc = " * - `161` when the data is unavailable."]
+    #[doc = " * "]
+    #[doc = " * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @unit: 0,1 m/s^2"]
+    #[doc = " * @revision: Desciption updated in V2.1.1 (the meaning of 160 has changed slightly)."]
+    #[doc = " *  "]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-160..=161"))]
+    pub struct VerticalAccelerationValue(pub i16);
+    #[doc = "* "]
+    #[doc = " * This DF provides information about a VRU cluster."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field clusterId: optional identifier of a VRU cluster."]
+    #[doc = " *"]
+    #[doc = " * @field clusterBoundingBoxShape: optionally indicates the shape of the cluster bounding box, per default inside an East-North-Up coordinate system "]
+    #[doc = " * centered around a reference point defined outside of the context of this DF."]
+    #[doc = " *"]
+    #[doc = " * @field clusterCardinalitySize: indicates an estimation of the number of VRUs in the group, e.g. the known members in the cluster + 1 (for the cluster leader) ."]
+    #[doc = " *"]
+    #[doc = " * @field clusterProfiles: optionally identifies all the VRU profile types that are estimated to be within the cluster."]
+    #[doc = " * if this component is absent it means that the information is unavailable. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, description revised in V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct VruClusterInformation {
+        #[rasn(identifier = "clusterId")]
+        pub cluster_id: Option<Identifier1B>,
+        #[rasn(value("0.."), identifier = "clusterBoundingBoxShape")]
+        pub cluster_bounding_box_shape: Option<Shape>,
+        #[rasn(identifier = "clusterCardinalitySize")]
+        pub cluster_cardinality_size: CardinalNumber1B,
+        #[rasn(identifier = "clusterProfiles")]
+        pub cluster_profiles: Option<VruClusterProfiles>,
+    }
+    impl VruClusterInformation {
+        pub fn new(
+            cluster_id: Option<Identifier1B>,
+            cluster_bounding_box_shape: Option<Shape>,
+            cluster_cardinality_size: CardinalNumber1B,
+            cluster_profiles: Option<VruClusterProfiles>,
+        ) -> Self {
+            Self {
+                cluster_id,
+                cluster_bounding_box_shape,
+                cluster_cardinality_size,
+                cluster_profiles,
+            }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE Identifies all the VRU profile types within a cluster."]
+    #[doc = " * It consist of a Bitmap encoding VRU profiles, to allow multiple profiles to be indicated in a single cluster (heterogeneous cluster if more than one profile)."]
+    #[doc = " * "]
+    #[doc = " * The corresponding bit shall be set to 1 under the following conditions:"]
+    #[doc = " * - 0 `pedestrian`  - indicates that the VRU cluster contains at least one pedestrian VRU,"]
+    #[doc = " * - 1 `bicycle`     - indicates that the VRU cluster contains at least one bicycle VRU member,"]
+    #[doc = " * - 2 `motorcyclist`- indicates that the VRU cluster contains at least one motorcycle VRU member,"]
+    #[doc = " * - 3 `animal`      - indicates that the VRU cluster contains at least one animal VRU member."]
+    #[doc = " * "]
+    #[doc = " * Otherwise, the corresponding bit shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct VruClusterProfiles(pub FixedBitString<4usize>);
+    #[doc = "*"]
+    #[doc = " * This DE represents the possible usage conditions of the VRU device."]
+    #[doc = ""]
+    #[doc = " * - The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`      - to indicate that the usage conditions are unavailable,"]
+    #[doc = " * - 1 `other`            - to indicate that the VRU device is in a state not defined below,"]
+    #[doc = " * - 2 `idle`             - to indicate that the human is currently not interacting with the device,"]
+    #[doc = " * - 3 `listeningToAudio` - to indicate that any audio source other than calling is in use,"]
+    #[doc = " * - 4 `typing`           - to indicate that the human is texting or performaing any other manual input activity,"]
+    #[doc = " * - 5 `calling`          - to indicate that the VRU device is currently receiving a call,"]
+    #[doc = " * - 6 `playingGames`     - to indicate that the human is playing games,"]
+    #[doc = " * - 7 `reading`          - to indicate that the human is reading on the VRU device,"]
+    #[doc = " * - 8 `viewing`          - to indicate that the human is watching dynamic content, including following navigation prompts, viewing videos or other visual contents that are not static."]
+    #[doc = " * - value 9 to 15        - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruDeviceUsage(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the possible VRU environment conditions."]
+    #[doc = " *"]
+    #[doc = " * - The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`            - to indicate that the information on the type of environment is unavailable,"]
+    #[doc = " * - 1 `intersectionCrossing`   - to indicate that the VRU is on an intersection or crossing,"]
+    #[doc = " * - 2 `zebraCrossing`          - to indicate that the VRU is on a  zebra crossing (crosswalk),"]
+    #[doc = " * - 3 `sidewalk`               - to indicate that the VRU is on a sidewalk,"]
+    #[doc = " * - 4 `onVehicleRoad`          - to indicate that the VRU is on a traffic lane,"]
+    #[doc = " * - 5 `protectedGeographicArea`- to indicate that the VRU is in a protected area."]
+    #[doc = " * - value 6 to 15              - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruEnvironment(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents the status of the exterior light switches of a VRU."]
+    #[doc = " * This DF is an extension of the vehicular DE @ref ExteriorLights."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field vehicular:  represents the status of the exterior light switches of a road vehicle."]
+    #[doc = " * "]
+    #[doc = " * @field vruSpecific: represents the status of the exterior light switches of a VRU."]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct VruExteriorLights {
+        pub vehicular: ExteriorLights,
+        #[rasn(identifier = "vruSpecific")]
+        pub vru_specific: VruSpecificExteriorLights,
+    }
+    impl VruExteriorLights {
+        pub fn new(vehicular: ExteriorLights, vru_specific: VruSpecificExteriorLights) -> Self {
+            Self {
+                vehicular,
+                vru_specific,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " *  This DE indicates the status of the possible human control over a VRU vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`                 - to indicate that the information is unavailable,"]
+    #[doc = " * - 1 `braking`                     - to indicate that the VRU is braking,"]
+    #[doc = " * - 2 `hardBraking`                 - to indicate that the VRU is braking hard,"]
+    #[doc = " * - 3 `stopPedaling`                - to indicate that the VRU stopped pedaling,"]
+    #[doc = " * - 4 `brakingAndStopPedaling`      - to indicate that the VRU stopped pedaling an is braking,"]
+    #[doc = " * - 5 `hardBrakingAndStopPedaling`  - to indicate that the VRU stopped pedaling an is braking hard,"]
+    #[doc = " * - 6 `noReaction`                  - to indicate that the VRU is not changing its behavior."]
+    #[doc = " * - 7 to 15                         - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1 and range changed from 0..255 to 0..15"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruMovementControl(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF indicates the profile of a VRU including sub-profile information"]
+    #[doc = " * It identifies four options corresponding to the four types of VRU profiles specified in ETSI TS 103 300-2 [18]:"]
+    #[doc = " *"]
+    #[doc = " * @field pedestrian: VRU Profile 1 - Pedestrian."]
+    #[doc = " *"]
+    #[doc = " * @field bicyclistAndLightVruVehicle: VRU Profile  2 - Bicyclist."]
+    #[doc = " *"]
+    #[doc = " * @field motorcyclist: VRU Profile 3  - Motorcyclist."]
+    #[doc = " *"]
+    #[doc = " * @field animal: VRU Profile  4 -  Animal."]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum VruProfileAndSubprofile {
+        pedestrian(VruSubProfilePedestrian),
+        bicyclistAndLightVruVehicle(VruSubProfileBicyclist),
+        motorcyclist(VruSubProfileMotorcyclist),
+        animal(VruSubProfileAnimal),
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the approximate size of a VRU including the VRU vehicle used."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`    - to indicate that there is no matched size class or due to privacy reasons in profile 1, "]
+    #[doc = " * - 1 `low`            - to indicate that the VRU size class is low depending on the VRU profile,"]
+    #[doc = " * - 2 `medium`         - to indicate that the VRU size class is medium depending on the VRU profile,"]
+    #[doc = " * - 3 `high`           - to indicate that the VRU size class is high depending on the VRU profile."]
+    #[doc = " * - 4 to 15            - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruSizeClass(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE describes the status of the exterior light switches of a VRU."]
+    #[doc = " *"]
+    #[doc = " * The value of each bit indicates the state of the switch, which commands the corresponding light. "]
+    #[doc = " * The bit corresponding to a specific light shall be set to 1, when the corresponding switch is turned on, either manually by the driver or VRU "]
+    #[doc = " * or automatically by a vehicle or VRU system: "]
+    #[doc = " * - 0 `unavailable`     - indicates no information available, "]
+    #[doc = " * - 1 `backFlashLight ` - indicates the status of the back flash light,"]
+    #[doc = " * - 2 `helmetLight`     - indicates the status of the helmet light,"]
+    #[doc = " * - 3 `armLight`        - indicates the status of the arm light,"]
+    #[doc = " * - 4 `legLight`        - indicates the status of the leg light,"]
+    #[doc = " * - 5 `wheelLight`      - indicates the status of the wheel light. "]
+    #[doc = " * - Bits 6 to 8         - are reserved for future use. "]
+    #[doc = " * The bit values do not indicate if the corresponding lamps are alight or not."]
+    #[doc = " * If  VRU is not equipped with a certain light or if the light switch status information is not available, the corresponding bit shall be set to 0."]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct VruSpecificExteriorLights(pub FixedBitString<8usize>);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the profile of an animal"]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`     - to indicate that the information  is unavailable,"]
+    #[doc = " * - 1 `wild-animal`     - to indicate a animal living in the wildness, "]
+    #[doc = " * - 2 `farm-animal`     - to indicate an animal beloning to a farm,"]
+    #[doc = " * - 3 `service-animal`  - to indicate an animal that supports a human being."]
+    #[doc = " * - 4 to 15             - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruSubProfileAnimal(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the profile of a VRU and its light VRU vehicle / mounted animal. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`           - to indicate that the information  is unavailable,"]
+    #[doc = " * - 1 `bicyclist `            - to indicate a cycle and bicyclist to which no more-specific profile applies, "]
+    #[doc = " * - 2 `wheelchair-user`       - to indicate a wheelchair and its user,"]
+    #[doc = " * - 3 `horse-and-rider`       - to indicate a horse and rider,"]
+    #[doc = " * - 4 `rollerskater`          - to indicate a roller-skater and skater,"]
+    #[doc = " * - 5 `e-scooter`             - to indicate an e-scooter and rider,"]
+    #[doc = " * - 6 `personal-transporter`  - to indicate a personal-transporter and rider,"]
+    #[doc = " * - 7 `pedelec`               - to indicate a pedelec and rider to which no more-specific profile applies,"]
+    #[doc = " * - 8 `speed-pedelec`         - to indicate a speed-pedelec and rider."]
+    #[doc = " * - 9 `roadbike`              - to indicate a road bicycle (or road pedelec) and rider,"]
+    #[doc = " * - 10 `childrensbike`        - to indicate a childrenÂ´s bicycle (or childrenÂ´s pedelec) and rider,"]
+    #[doc = " * - 11 `racebike`             - to indicate a race bicycle (according to local applicable regulations) and rider. "]
+    #[doc = " * - 12 to 15                  - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, values 9 and 10 assigned in V2.2.1, value 11 assigned in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruSubProfileBicyclist(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the profile of a motorcyclist and corresponding vehicle."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable `                  - to indicate that the information  is unavailable,"]
+    #[doc = " * - 1 `moped`                         - to indicate a moped and rider,"]
+    #[doc = " * - 2 `motorcycle`                    - to indicate a motorcycle and rider,"]
+    #[doc = " * - 3 `motorcycle-and-sidecar-right`  - to indicate a motorcycle with sidecar on the right and rider,"]
+    #[doc = " * - 4 `motorcycle-and-sidecar-left`   - to indicate  a motorcycle with sidecar on the left and rider."]
+    #[doc = " * - 5 to 15                           - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruSubProfileMotorcyclist(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the profile of a pedestrian."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`             - to indicate that the information on is unavailable,"]
+    #[doc = " * - 1 `ordinary-pedestrian`     - to indicate a pedestrian to which no more-specific profile applies,"]
+    #[doc = " * - 2 `road-worker`             - to indicate a pedestrian with the role of a road worker,"]
+    #[doc = " * - 3 `first-responder`         - to indicate a pedestrian with the role of a first responder."]
+    #[doc = " * - value 4 to 15               - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @category: VRU information"]
+    #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct VruSubProfilePedestrian(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the World Manufacturer Identifier (WMI). The values are assigned according to ISO 3779 [6]."]
+    #[doc = " * "]
+    #[doc = " *"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=3"))]
+    pub struct WMInumber(pub Ia5String);
+    #[doc = "* "]
+    #[doc = " * This DF represents an angular component along with a confidence value in the WGS84 coordinate system."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " *"]
+    #[doc = " * @field value: the angle value, which can be estimated as the mean of the current distribution."]
+    #[doc = " *"]
+    #[doc = " * @field confidence: the confidence value associated to the angle value."]
+    #[doc = " *"]
+    #[doc = " * @category: GeoReference information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Wgs84Angle {
+        pub value: Wgs84AngleValue,
+        pub confidence: Wgs84AngleConfidence,
+    }
+    impl Wgs84Angle {
+        pub fn new(value: Wgs84AngleValue, confidence: Wgs84AngleConfidence) -> Self {
+            Self { value, confidence }
+        }
+    }
+    #[doc = "* "]
+    #[doc = " * This DE indicates the angle confidence value which represents the estimated accuracy of an angle value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 1` and `n < 126`) if the confidence value is equal to or less than n x 0,1 degrees and more than (n-1) x 0,1 degrees,"]
+    #[doc = " * - `126` if the confidence value is out of range, i.e. greater than 12,5 degrees,"]
+    #[doc = " * - `127` if the confidence value is not available."]
+    #[doc = " *"]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 degrees"]
+    #[doc = " * @category: GeoReference Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct Wgs84AngleConfidence(pub u8);
+    #[doc = "* "]
+    #[doc = " * This DE represents an angle value in degrees described in the WGS84 reference system with respect to the WGS84 north."]
+    #[doc = " * The specific WGS84 coordinate system is specified by the corresponding standards applying this DE."]
+    #[doc = " * When the information is not available, the DE shall be set to 3 601. The value 3600 shall not be used."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 degrees"]
+    #[doc = " * @category: GeoReference Information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=3601"))]
+    pub struct Wgs84AngleValue(pub u16);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the perpendicular distance between front and rear axle of the wheel base of vehicle."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `n` (`n >= 1` and `n < 126`) if the value is equal to or less than n x 0,1 metre  and more than (n-1) x 0,1 metre,"]
+    #[doc = " * - `126` indicates that the wheel base distance is equal to or greater than 12,5 metres,"]
+    #[doc = " * - `127` indicates that the information is unavailable."]
+    #[doc = " *"]
+    #[doc = " * @unit 0,1 metre"]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Created in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=127"))]
+    pub struct WheelBaseVehicle(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE indicates the actual status of the front wipers of the vehicle. "]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`   - to indicate that the information is unavailable,"]
+    #[doc = " * - 1 `off`           - to indicate that the wipers are switched off,"]
+    #[doc = " * - 2 `intermittent`  - to indicate that the wipers are moving intermittently,"]
+    #[doc = " * - 3 `low`           - to indicate that the wipers are moving at low speed,"]
+    #[doc = " * - 4 `high`          - to indicate that the wipers are moving at high speed,"]
+    #[doc = " * - values 5 to 7      - are reserved for future usage. "]
+    #[doc = " *"]
+    #[doc = " * @note:  the status can be either set manually by the driver or automatically by e.g. a rain sensor. The way the status is set does not affect the status itself. "]
+    #[doc = " * @category: Vehicle information "]
+    #[doc = " * @revision: created in V2.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=7"))]
+    pub struct WiperStatus(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DE represents the sub cause codes of the @ref CauseCode `wrongWayDriving` ."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - 0 `unavailable`           - in case further detailed information on wrong way driving event is unavailable,"]
+    #[doc = " * - 1 `wrongLane-deprecated`   - deprecated since not pertinent to wrong way driving,"]
+    #[doc = " * - 2 `wrongDirection`        - in case vehicle is driving in a direction that it is not allowed,"]
+    #[doc = " * - 3-255                     - reserved for future usage."]
+    #[doc = " * "]
+    #[doc = " * @category: Traffic information"]
+    #[doc = " * @revision: V1.3.1, value 1 deprecated in V2.4.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct WrongWayDrivingSubCauseCode(pub u8);
+    #[doc = "*"]
+    #[doc = " * This DF represents a yaw rate of vehicle at a point in time."]
+    #[doc = " *"]
+    #[doc = " * It shall include the following components: "]
+    #[doc = " * "]
+    #[doc = " * @field yawRateValue: yaw rate value at a point in time."]
+    #[doc = " * "]
+    #[doc = " * @field yawRateConfidence: confidence value associated to the yaw rate value."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle Information"]
+    #[doc = " * @revision: V1.3.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct YawRate {
+        #[rasn(identifier = "yawRateValue")]
+        pub yaw_rate_value: YawRateValue,
+        #[rasn(identifier = "yawRateConfidence")]
+        pub yaw_rate_confidence: YawRateConfidence,
+    }
+    impl YawRate {
+        pub fn new(yaw_rate_value: YawRateValue, yaw_rate_confidence: YawRateConfidence) -> Self {
+            Self {
+                yaw_rate_value,
+                yaw_rate_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = " * This DE indicates the yaw rate confidence value which represents the estimated accuracy for a yaw rate value with a default confidence level of 95 %."]
+    #[doc = " * If required, the confidence level can be defined by the corresponding standards applying this DE."]
+    #[doc = " * "]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `0` if the confidence value is equal to or less than 0,01 degree/second,"]
+    #[doc = " * - `1` if the confidence value is equal to or less than 0,05 degrees/second or greater than 0,01 degree/second,"]
+    #[doc = " * - `2` if the confidence value is equal to or less than 0,1 degree/second or greater than 0,05 degree/second,"]
+    #[doc = " * - `3` if the confidence value is equal to or less than 1 degree/second or greater than 0,1 degree/second,"]
+    #[doc = " * - `4` if the confidence value is equal to or less than 5 degrees/second or greater than 1 degrees/second,"]
+    #[doc = " * - `5` if the confidence value is equal to or less than 10 degrees/second or greater than 5 degrees/second,"]
+    #[doc = " * - `6` if the confidence value is equal to or less than 100 degrees/second or greater than 10 degrees/second,"]
+    #[doc = " * - `7` if the confidence value is out of range, i.e. greater than 100 degrees/second,"]
+    #[doc = " * - `8` if the confidence value is unavailable."]
+    #[doc = " * "]
+    #[doc = " * NOTE: The fact that a yaw rate value is received with confidence value set to `unavailable(8)` can be caused by"]
+    #[doc = " * several reasons, such as:"]
+    #[doc = " * - the sensor cannot deliver the accuracy at the defined confidence level because it is a low-end sensor,"]
+    #[doc = " * - the sensor cannot calculate the accuracy due to lack of variables, or"]
+    #[doc = " * - there has been a vehicle bus (e.g. CAN bus) error."]
+    #[doc = " * In all 3 cases above, the yaw rate value may be valid and used by the application."]
+    #[doc = " * "]
+    #[doc = " * If a yaw rate value is received and its confidence value is set to `outOfRange(7)`, it means that the "]
+    #[doc = " * yaw rate value is not valid and therefore cannot be trusted. Such value is not useful the application."]
+    #[doc = " * "]
+    #[doc = " * @category: Vehicle information"]
+    #[doc = " * @revision: Description revised in V2.1.1"]
+    #[doc = " "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum YawRateConfidence {
+        #[rasn(identifier = "degSec-000-01")]
+        degSec_000_01 = 0,
+        #[rasn(identifier = "degSec-000-05")]
+        degSec_000_05 = 1,
+        #[rasn(identifier = "degSec-000-10")]
+        degSec_000_10 = 2,
+        #[rasn(identifier = "degSec-001-00")]
+        degSec_001_00 = 3,
+        #[rasn(identifier = "degSec-005-00")]
+        degSec_005_00 = 4,
+        #[rasn(identifier = "degSec-010-00")]
+        degSec_010_00 = 5,
+        #[rasn(identifier = "degSec-100-00")]
+        degSec_100_00 = 6,
+        outOfRange = 7,
+        unavailable = 8,
+    }
+    #[doc = "*"]
+    #[doc = " * This DE represents the vehicle rotation around z-axis of the coordinate system centred on the centre of mass of the empty-loaded"]
+    #[doc = " * vehicle. The leading sign denotes the direction of rotation."]
+    #[doc = " * "]
+    #[doc = " * The value shall be provided in the vehicle coordinate system as defined in ISO 8855 [21], clause 2.11."]
+    #[doc = " *"]
+    #[doc = " * The value shall be set to:"]
+    #[doc = " * - `-32 766` to indicate that the yaw rate is equal to or greater than 327,66 degrees/second to the right,"]
+    #[doc = " * - `n` (`n > -32 766` and `n <= 0`) to indicate that the rotation is clockwise (i.e. to the right) and is equal to or less than n x 0,01 degrees/s, "]
+    #[doc = "      and greater than (n-1) x 0,01 degrees/s,"]
+    #[doc = " * - `n` (`n > 0` and `n < 32 766`) to indicate that the rotation is anti-clockwise (i.e. to the left) and is equal to or less than n x 0,01 degrees/s, "]
+    #[doc = "      and greater than (n-1) x 0,01 degrees/s,"]
+    #[doc = " * - `32 766` to indicate that the yaw rate is greater than 327.65 degrees/second to the left,"]
+    #[doc = " * - `32 767` to indicate that the information is not available."]
+    #[doc = " * "]
+    #[doc = " * The reading instant should be the same as for the vehicle acceleration."]
+    #[doc = " * "]
+    #[doc = " * @note: The empty load vehicle is defined in ISO 1176 [8], clause 4.6."]
+    #[doc = " * "]
+    #[doc = " * @unit: 0,01 degree per second. "]
+    #[doc = " * @category: Vehicle Information"]
+    #[doc = " * @revision: Description revised in V2.1.1 (the meaning of 32766 has changed slightly). Requirement on raw data deleted in V2.4.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-32766..=32767"))]
+    pub struct YawRateValue(pub i16);
+}

--- a/standards/its/src/ts102894_2/mod.rs
+++ b/standards/its/src/ts102894_2/mod.rs
@@ -118,7 +118,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum AccelerationChange {
@@ -290,7 +289,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 m/s^2"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=161"))]
     pub struct AccelerationMagnitudeValue(pub u8);
@@ -345,7 +343,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 m/s^2"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-160..=161"))]
     pub struct AccelerationValue(pub i16);
@@ -454,7 +451,6 @@ pub mod etsi_its_cdd {
     #[doc = ""]
     #[doc = " * @category: Communication Information"]
     #[doc = " * @revision: Created in V2.1.1 based on ReferenceDenms from DENM Release 1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct ActionIdList(pub SequenceOf<ActionId>);
@@ -694,7 +690,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,1 degrees"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=127"))]
     pub struct AngleConfidence(pub u8);
@@ -715,7 +710,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum AngularAccelerationConfidence {
@@ -751,7 +745,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum AngularSpeedConfidence {
@@ -788,7 +781,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("6", extensible))]
     pub struct AutomationControl(pub BitString);
@@ -804,7 +796,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: Number of axles"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("2..=1002"))]
     pub struct AxlesCount(pub u16);
@@ -820,7 +811,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @category: Basic information"]
     #[doc = " * @unit: 10 Pascal"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("2999..=12002"))]
     pub struct BarometricPressure(pub u16);
@@ -835,7 +825,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -861,7 +850,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16", extensible))]
     pub struct BasicLaneConfiguration(pub SequenceOf<BasicLaneInformation>);
@@ -883,7 +871,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -926,7 +913,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: Number of bogies"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("2..=101"))]
     pub struct BogiesCount(pub u8);
@@ -952,7 +938,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct CardinalNumber1B(pub u8);
@@ -961,7 +946,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=8"))]
     pub struct CardinalNumber3b(pub u8);
@@ -1001,7 +985,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 degrees"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1, description and value for 3601 corrected in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=3601"))]
     pub struct CartesianAngleValue(pub u16);
@@ -1045,7 +1028,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit:  degree/s^2 (degrees per second squared)"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-255..=256"))]
     pub struct CartesianAngularAccelerationComponentValue(pub i16);
@@ -1088,7 +1070,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: degree/s"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-255..=256"))]
     pub struct CartesianAngularVelocityComponentValue(pub i16);
@@ -1103,7 +1084,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,01 m"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-32768..=32767"))]
     pub struct CartesianCoordinate(pub i16);
@@ -1118,7 +1098,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,01 m"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-131072..=131071"))]
     pub struct CartesianCoordinateLarge(pub i32);
@@ -1133,7 +1112,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,01 m"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-3094..=1001"))]
     pub struct CartesianCoordinateSmall(pub i16);
@@ -1148,7 +1126,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct CartesianCoordinateWithConfidence {
@@ -1173,7 +1150,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct CartesianPosition3d {
@@ -1210,7 +1186,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct CartesianPosition3dWithConfidence {
@@ -1713,7 +1688,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Cluster information"]
     #[doc = " * @revision: Created in V2.1.1, type changed from ENUMERATED to INTEGER in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=15"))]
     pub struct ClusterBreakupReason(pub u8);
@@ -1830,7 +1804,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit Percent "]
     #[doc = " * @category: Basic information "]
     #[doc = " * @revision: Created in V2.1.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=101"))]
     pub struct ConfidenceLevel(pub u8);
@@ -1839,7 +1812,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: Basic information"]
     #[doc = "* @revision: created in V2.3.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32", extensible))]
     pub struct ConfidenceLevels(pub SequenceOf<ConfidenceLevel>);
@@ -1855,7 +1827,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,01 m"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=4096"))]
     pub struct CoordinateConfidence(pub u16);
@@ -1873,7 +1844,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: the value is scaled by 100"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1, corrected the value to n/100 on V2.4.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-100..=101"))]
     pub struct CorrelationCellValue(pub i8);
@@ -1885,7 +1855,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing Information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=13", extensible))]
     pub struct CorrelationColumn(pub SequenceOf<CorrelationCellValue>);
@@ -1894,7 +1863,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.2.1 based on ISO 14816 [23]"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct CountryCode(pub FixedBitString<10usize>);
@@ -1975,7 +1943,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Description revised in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum CurvatureConfidence {
@@ -2231,7 +2198,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct DeltaPosition {
@@ -2253,7 +2219,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaPosition)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32", extensible))]
     pub struct DeltaPositions(pub SequenceOf<DeltaPosition>);
@@ -2299,7 +2264,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF DeltaReferencePositions)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32", extensible))]
     pub struct DeltaReferencePositions(pub SequenceOf<DeltaReferencePosition>);
@@ -2329,7 +2293,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,001 s"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-2048..=2047"))]
     pub struct DeltaTimeMilliSecondSigned(pub i16);
@@ -2355,7 +2318,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 1 s"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1 from ValidityDuration"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=86400"))]
     pub struct DeltaTimeSecond(pub u32);
@@ -2369,7 +2331,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 10 s"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=127"))]
     pub struct DeltaTimeTenSeconds(pub u8);
@@ -2383,7 +2344,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,1 s"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=127"))]
     pub struct DeltaTimeTenthOfSecond(pub u8);
@@ -2474,7 +2434,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1, the type of the field orientation changed and the description revised in V2.2.1, added note on orientation in V2.4.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct EllipticalShape {
@@ -2572,7 +2531,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     pub enum EuVehicleCategoryCode {
@@ -2663,7 +2621,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct EulerAnglesWithConfidence {
@@ -2863,7 +2820,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1 based on ETSI TS 103 900 [1]"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct GenerationDeltaTime(pub u16);
@@ -2878,7 +2834,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @field altitude: the altitude of the geographical position with default value unavailable."]
     #[doc = " *"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct GeoPosition {
@@ -2912,7 +2867,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionWAltitude)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct GeoPositionWAltitude {
@@ -2940,7 +2894,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePosition)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct GeoPositionWoAltitude {
@@ -2960,7 +2913,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (DF AbsolutePositionsWAltitude)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct GeoPositionsWAltitude(pub SequenceOf<GeoPositionWAltitude>);
@@ -2969,7 +2921,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321 (AbsolutePositions)"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct GeoPositionsWoAltitude(pub SequenceOf<GeoPositionWoAltitude>);
@@ -3190,7 +3141,6 @@ pub mod etsi_its_cdd {
     #[doc = " * Unit: 0,1 degree"]
     #[doc = " * Categories: GeoReference information"]
     #[doc = " * @revision: Description revised in V2.1.1 (usage of value 3600 specified) "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=3601"))]
     pub struct HeadingValue(pub u16);
@@ -3265,7 +3215,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct Identifier1B(pub u8);
@@ -3274,7 +3223,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct Identifier2B(pub u16);
@@ -3304,7 +3252,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Traffic information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct ImpassabilitySubCauseCode(pub u8);
@@ -3337,7 +3284,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Communication information"]
     #[doc = " * @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct InterferenceManagementChannel {
@@ -3610,7 +3556,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.2.1 based on ISO 14816 [23]"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=16383"))]
     pub struct IssuerIdentifier(pub u16);
@@ -3666,7 +3611,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.2.1 based on ETSI TS 103 301 [15]"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=32767", extensible))]
     pub struct IviIdentificationNumber(pub Integer);
@@ -3706,7 +3650,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Communication information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct IvimReferences(pub SequenceOf<IvimReference>);
@@ -3739,7 +3682,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Description of the legal separation of carriageways added in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-1..=14"))]
     pub struct LanePosition(pub i8);
@@ -3905,7 +3847,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.1.1, named value 21 added in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=31"))]
     pub struct LaneType(pub u8);
@@ -4132,7 +4073,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 metre"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=1023"))]
     pub struct LongitudinalLanePositionConfidence(pub u16);
@@ -4147,7 +4087,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 metre"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=32767"))]
     pub struct LongitudinalLanePositionValue(pub u16);
@@ -4156,7 +4095,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=4"))]
     pub struct LowerTriangularPositiveSemidefiniteMatrices(
@@ -4178,7 +4116,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct LowerTriangularPositiveSemidefiniteMatrix {
@@ -4203,7 +4140,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1, extension indicator added in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=13", extensible))]
     pub struct LowerTriangularPositiveSemidefiniteMatrixColumns(pub SequenceOf<CorrelationColumn>);
@@ -4276,7 +4212,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct MapReferences(pub SequenceOf<MapReference>);
@@ -4285,7 +4220,6 @@ pub mod etsi_its_cdd {
     #[doc = ""]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16", extensible))]
     pub struct MapemConfiguration(pub SequenceOf<MapemElementReference>);
@@ -4295,7 +4229,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct MapemConnectionList(pub SequenceOf<Identifier1B>);
@@ -4312,7 +4245,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4342,7 +4274,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in 2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct MapemLaneList(pub SequenceOf<Identifier1B>);
@@ -4474,7 +4405,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4504,7 +4434,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Communication information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8"))]
     pub struct MitigationForTechnologies(pub SequenceOf<MitigationPerTechnologyClass>);
@@ -4642,7 +4571,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8"))]
     pub struct ObjectClassDescription(pub SequenceOf<ObjectClassWithConfidence>);
@@ -4657,7 +4585,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct ObjectClassWithConfidence {
@@ -4684,7 +4611,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct ObjectDimension {
@@ -4708,7 +4634,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 m"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=32"))]
     pub struct ObjectDimensionConfidence(pub u8);
@@ -4723,7 +4648,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 m"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1, corrected the wording in V2.4.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=256"))]
     pub struct ObjectDimensionValue(pub u16);
@@ -4739,7 +4663,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum ObjectFace {
@@ -4761,7 +4684,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit n/a"]
     #[doc = " * @category: Sensing information"]
     #[doc = " * @revision: Created in V2.1.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=15"))]
     pub struct ObjectPerceptionQuality(pub u8);
@@ -4828,7 +4750,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct OrdinalNumber1B(pub u8);
@@ -4837,7 +4758,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=8"))]
     pub struct OrdinalNumber3b(pub u8);
@@ -4869,7 +4789,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=7"))]
     pub struct ParkingAreaArrangementType(pub u8);
@@ -4894,7 +4813,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road Topology information"]
     #[doc = " * @revision: Created in V2.3.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -4931,7 +4849,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.3.1, value 14 assigned in V2.4.1."]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=31"))]
     pub struct ParkingReservationType(pub u8);
@@ -4948,7 +4865,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road Topology information"]
     #[doc = " * @revision: Created in V2.3.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct ParkingSpaceBasic {
@@ -4995,7 +4911,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road Topology information"]
     #[doc = " * @revision: Created in V2.3.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -5073,7 +4988,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road Topology information"]
     #[doc = " * @revision: Created in V2.3.1 "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -5147,7 +5061,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct PathExtended {
@@ -5187,7 +5100,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=14"))]
     pub struct PathId(pub u8);
@@ -5368,7 +5280,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=14"))]
     pub struct PathReferences(pub SequenceOf<PathId>);
@@ -5378,7 +5289,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 10%"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=11"))]
     pub struct PedalPositionValue(pub u8);
@@ -5569,7 +5479,6 @@ pub mod etsi_its_cdd {
     #[doc = "*"]
     #[doc = "* @category: GeoReference information"]
     #[doc = "* @revision: created in V2.3.1 based on ISO TS 19321"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -5889,7 +5798,6 @@ pub mod etsi_its_cdd {
     #[doc = "* @unit: 0,1 mm/h "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=2001"))]
     pub struct PrecipitationIntensity(pub u16);
@@ -6137,7 +6045,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category GeoReference information"]
     #[doc = " * @revision: created in V2.1.1, names and types of the horizontal opening angles changed, constraint added and description revised in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RadialShape {
@@ -6559,7 +6466,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -6619,7 +6525,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Road topology information"]
     #[doc = " * @revision: Created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -6751,7 +6656,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: created in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=5"))]
     pub struct SaeAutomationLevel(pub u8);
@@ -6810,7 +6714,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Traffic information, Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(delegate)]
     pub struct SafeDistanceIndicator(pub bool);
@@ -6840,7 +6743,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing Information"]
     #[doc = " * @revision: created in V2.1.1, description of value 5 changed and value 14 added in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=31"))]
     pub struct SensorType(pub u8);
@@ -6869,7 +6771,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Sensing Information"]
     #[doc = " * @revision: created in V2.2.1, description of value 5 changed and value 14 added in V2.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("16", extensible))]
     pub struct SensorTypes(pub BitString);
@@ -6896,7 +6797,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=128", extensible))]
     pub struct SequenceOfIdentifier1B(pub SequenceOf<Identifier1B>);
@@ -6905,7 +6805,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Traffic information, Kinematic information"]
     #[doc = " * @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct SequenceOfSafeDistanceIndication(pub SequenceOf<SafeDistanceIndication>);
@@ -6914,7 +6813,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Traffic information, Kinematic information"]
     #[doc = " * @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8", extensible))]
     pub struct SequenceOfTrajectoryInterceptionIndication(
@@ -7083,7 +6981,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,01 m/s"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Description revised in V2.1.1 (the meaning of 16382 has changed slightly) "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=16383"))]
     pub struct SpeedValue(pub u16);
@@ -7329,7 +7226,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 1,5 degree"]
     #[doc = " * @category: Vehicle Information"]
     #[doc = " * @revision: Description revised in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=127"))]
     pub struct SteeringWheelAngleConfidence(pub u8);
@@ -7368,7 +7264,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Basic Information"]
     #[doc = " * @revision: created in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("8", extensible))]
     pub struct StoredInformationType(pub BitString);
@@ -7595,7 +7490,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -7645,7 +7539,6 @@ pub mod etsi_its_cdd {
     #[doc = " * "]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Created in V2.1.1 based on VehicleLengthConfidenceIndication"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum TrailerPresenceInformation {
@@ -7819,7 +7712,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 1 s"]
     #[doc = " * @category: Basic information"]
     #[doc = " * @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=86400"))]
     pub struct ValidityDuration(pub u32);
@@ -7873,7 +7765,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,05 metre "]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=128"))]
     pub struct VehicleHeight(pub u8);
@@ -7966,7 +7857,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @note: this DE is kept for backwards compatibility reasons only. It is recommended to use the @ref TrailerPresenceInformation instead. "]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Description revised in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum VehicleLengthConfidenceIndication {
@@ -8036,7 +7926,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 10^5 gramm"]
     #[doc = " * @category: Vehicle information"]
     #[doc = " * @revision: Description updated in V2.1.1 (the meaning of 1 023 has changed slightly)."]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=1024"))]
     pub struct VehicleMass(pub u16);
@@ -8245,7 +8134,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,01 m/s"]
     #[doc = " * @category: Kinematic information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-16383..=16383"))]
     pub struct VelocityComponentValue(pub i16);
@@ -8336,7 +8224,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,1 m/s^2"]
     #[doc = " * @revision: Desciption updated in V2.1.1 (the meaning of 160 has changed slightly)."]
     #[doc = " *  "]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-160..=161"))]
     pub struct VerticalAccelerationValue(pub i16);
@@ -8357,7 +8244,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: VRU information"]
     #[doc = " * @revision: Created in V2.1.1, description revised in V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -8400,7 +8286,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: VRU information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct VruClusterProfiles(pub FixedBitString<4usize>);
@@ -8648,7 +8533,6 @@ pub mod etsi_its_cdd {
     #[doc = " *"]
     #[doc = " * @category: GeoReference information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct Wgs84Angle {
@@ -8673,7 +8557,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 degrees"]
     #[doc = " * @category: GeoReference Information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=127"))]
     pub struct Wgs84AngleConfidence(pub u8);
@@ -8685,7 +8568,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit 0,1 degrees"]
     #[doc = " * @category: GeoReference Information"]
     #[doc = " * @revision: Created in V2.1.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=3601"))]
     pub struct Wgs84AngleValue(pub u16);
@@ -8835,7 +8717,6 @@ pub mod etsi_its_cdd {
     #[doc = " * @unit: 0,01 degree per second. "]
     #[doc = " * @category: Vehicle Information"]
     #[doc = " * @revision: Description revised in V2.1.1 (the meaning of 32766 has changed slightly). Requirement on raw data deleted in V2.4.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-32766..=32767"))]
     pub struct YawRateValue(pub i16);

--- a/standards/its/src/ts103301/README.md
+++ b/standards/its/src/ts103301/README.md
@@ -1,0 +1,3 @@
+# `rasn` implementation of ETSI TS 103 301
+
+Based on ASN.1 defined in [here](https://forge.etsi.org/rep/ITS/asn1/is_ts103301).

--- a/standards/its/src/ts103301/asn1/DSRC-addgrp-C.asn
+++ b/standards/its/src/ts103301/asn1/DSRC-addgrp-C.asn
@@ -1,0 +1,411 @@
+--! @options: no-fields-header
+
+ETSI-ITS-DSRC-AddGrpC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) addgrpc (0) major-version-2 (2) minor-version-1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS::= BEGIN
+
+IMPORTS
+
+DeltaTime, FuelType, IntersectionID, LaneConnectionID, LaneID, NodeOffsetPointXY, NodeSetXY, PrioritizationResponseStatus, SignalGroupID, VehicleHeight
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+Altitude, DeltaAltitude, StationID, VehicleMass
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* This DF adds positioning support from the infrastructure to the vehicle.
+*
+* @field itsStationPositions: defines a list of ITS stations (e.g. vehicles) and their corresponding position on
+*                             the driving lane as defined in the lane topology of the MapData message or the GNSS position
+*                             deviation of the ITS Station from the high precision reference position in X/Y coordinates. It
+*                             enables accurate, real-time positioning support to the moving ITS entities by the infrastructure.*
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ConnectionManeuverAssist-addGrpC ::=	SEQUENCE {
+  itsStationPosition ItsStationPositionList OPTIONAL,
+  ...
+}
+
+/**
+* This DF defines the trajectory for travelling through the conflict area of an intersection and connects 
+* e.g an ingress with an egress lane. The trajectory is defined by two or more nodes. 
+* The starting node overlaps e.g. with the node of the ingress lane towards the
+* conflict zone. The ending node overlaps e.g. with the first node of the connected egress lane. 
+* See the example in clause [ISO TS 19091] G.8.2.5.
+*
+* @field nodes: defines a list of nodes for the trajectory. It defines e.g. a geometric trajectory from an ingressing
+*               to a connected egressing lane and the X/Y position value of the first node of the trajectory is the same as
+*               the node of the ingress lane. The X/Y position of the last node is the same as the X/Y position of the first
+*               node of the egressing lane.
+* @field connectionID: defines the identifier of an allowed `maneuver` (e.g. ingress / egress relation). 
+*               A generic Lane offers one or more allowed `maneuvers`, therefore the trajectory is reference to the related `maneuver`.
+*
+* @note: @ref Reg-GenericLane allows providing up to 4 connecting trajectories. In case a lane has more than 4 connecting trajectories,
+* priority should be given to connecting trajectories of motorized traffic and complex manoeuvres.
+*
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ConnectionTrajectory-addGrpC ::= SEQUENCE {
+  nodes         NodeSetXY,
+  connectionID  LaneConnectionID,
+  ...
+}
+
+/**
+* This DF defines a list of prioritization responses e.g. public transport acceleration.
+* The signal prioritization (e.g. public transport) procedure in this profile follows two strategies.
+* - For simple prioritization requests, the CAM/SPAT messages are used. 
+*   This allows the migration of old legal systems towards C-ITS.
+*   In this case, the CAM message is used to trigger the request towards the traffic light controller. 
+*   The traffic light controller checks the request and broadcasts the status for the priority request with this DF (see [ISO TS 19091] G.5.1.9).
+* - For more complex signal requests, the SignalRequestMessage/SignalStatusMessage messages are to be used.
+*
+* @field activePrioritizations: list of Prioritizations.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionState-addGrpC ::=	SEQUENCE {
+  activePrioritizations  PrioritizationResponseList	OPTIONAL,
+  ...
+}
+
+/**
+* Lanes may have limitations regarding vehicle height (e.g. due to a tunnel) and vehicle weight (e.g. due to a bridge). 
+*
+* @field maxVehicleHeight: maximum allowed vehicle height
+* @field maxVehicleWeight: maximum allowed vehicle mass
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-addGrpC ::= SEQUENCE {
+  maxVehicleHeight  VehicleHeight OPTIONAL,
+  maxVehicleWeight  VehicleMass   OPTIONAL,
+  ...
+}
+
+/**
+* This DF defines a list of three-dimensional positions of signal heads in an intersection. 
+* It enables vehicles to identify the signal head location for optical evaluation of the traffic light. 
+* Combined with the SPAT/MapData messages, it enables e.g. driving vehicles to enhance safety decision in critical situations.
+*
+* @field signalHeadLocations: list of geo positions
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MapData-addGrpC ::=	SEQUENCE {
+  signalHeadLocations  SignalHeadLocationList	OPTIONAL,
+  ...
+}
+
+/**
+* Priority and preemption have a considerable impact to the timing parameters in the SPAT message (eventState).
+* User acceptance is expected to increase if the reason for sudden changes in timing parameters is communicated to them.
+*
+* @field stateChangeReason: reason code
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementEvent-addGrpC ::= SEQUENCE {
+  stateChangeReason  ExceptionalCondition OPTIONAL,
+  ...
+}
+
+/**
+* This DF defines additional attributes to support public transport and to enable a simple way of defining lane links.
+*
+* @field ptvRequest: defines control types attached to a node on a lane used by public transport for triggering
+*                    the transmission of messages (e.g. prioritization request). It includes control points for public transport prioritization. 
+*                    These control points are currently implemented by legacy systems using hardware sensors mounted on the roadside.
+* @field nodeLink:   defines a link to one or to a set of another node/lane from this node. The nodeLink allows to set a link between specific nodes 
+*                    of generic lanes or trajectories. This supports e.g. lane merging/diverging situations ([ISO TS 19091] G.8.2.7) and the linking of trajectories 
+*                    in the conflict zone to lanes (see example [ISO TS 19091] G.8.2.5).
+* @field node:       defines an identifier of this node.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeAttributeSet-addGrpC  ::=	SEQUENCE {
+  ptvRequest  PtvRequestType  OPTIONAL,
+  nodeLink    NodeLink        OPTIONAL,
+  node        Node            OPTIONAL,
+  ...
+}
+
+/**
+* This DF includes the altitude data element defined in the common data dictionary [ETSI CDD].
+*
+* @field elevation: the data element is replaced by the ETSI `altitude` data element using the regional extension. 
+*                   The `altitude` data element is defined in Position3D-addGrpC of this profile.
+*                   Position3D-addGrpC extends the @ref Position3D using the regional extension framework.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Position3D-addGrpC ::=	SEQUENCE {
+  altitude  Altitude,
+  ...
+}
+
+/**
+* This DF defines the driving restriction based on toxic emission type. 
+* The meaning of the word `restriction` is ambiguous as it may have a double interpretation, being:
+*  - only these vehicles are allowed OR 
+*  - these vehicles are not allowed and all others are. 
+* The former is what is intended by the base standard.
+*
+* @field emission: restriction baesed on emission.
+* @field fuel: restriction baesed on fuel.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionUserType-addGrpC ::=	SEQUENCE {
+  emission  EmissionType OPTIONAL,
+  fuel      FuelType     OPTIONAL,
+  ...
+}
+
+/**
+* Some road authorities like to give priority to vehicles based on the type of fuel they use. In addition,
+* electric vehicles may receive priority based on their battery status.
+*
+* @field fuel: fuel used by vehicle.
+* @field batteryStatus: current batter status of vehicle.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestorDescription-addGrpC ::= SEQUENCE {
+  fuel           FuelType      OPTIONAL,
+  batteryStatus  BatteryStatus OPTIONAL,
+  ...
+}
+
+/**
+* The traffic control centre (TCC) may advice a public transport vehicle (e.g. bus) to synchronize his travel time. 
+* This may happen when, for example, two busses, due to special traffic conditions, are out of schedule. 
+* The first might be too late, the second too fast. The consequence is that the second is driving
+* just behind the first and is empty as all passengers are within the first one. To avoid this often-occurring
+* situation, the TCC transmits time synchronization advices to the public transport vehicles using the
+* signal status message. 
+*
+* @field synchToSchedule: DeltaTime.
+* @field rejectedReason: RejectedReason.
+*
+* @Note: The @ref PrioritizationResponseStatus provides optionally the reason for prioritization response rejection.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatusPackage-addGrpC ::= SEQUENCE {
+  synchToSchedule  DeltaTime      OPTIONAL,
+  rejectedReason   RejectedReason OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to provide real-time positioning information feedback to a specific ITS station 
+* (e.g. vehicle, pedestrian, bicycle) by infrastructure equipment.
+*  The position information includes, for example, the driving, crossing lane and/or the X/Y coordinates in relation to
+* the reference position of the MapData. The `timeReference` indicates the time stamp of the the
+* message (received from an ITS station) for which the positioning feedback has been computed.
+* 
+* @field stationID: unique identifier.
+* @field laneID: LaneID.
+* @field nodeXY: NodeOffsetPointXY.
+* @field timeReference: TimeReference.
+*
+* @note: The computation of the positioning feedback is out of focus of this standard.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ItsStationPosition ::=	SEQUENCE {
+  stationID      StationID,
+  laneID         LaneID             OPTIONAL,
+  nodeXY         NodeOffsetPointXY  OPTIONAL,
+  timeReference  TimeReference      OPTIONAL,
+  ...
+}
+
+ItsStationPositionList ::=	SEQUENCE SIZE(1..5) OF ItsStationPosition
+
+/**
+* This DF is used to to identify a node of a lane (waypoint) by its `lane` and node identifier `id`. 
+*
+* The `intersectionID` is used if the referenced lane belongs to an adjacent intersection. If the node
+* belongs to a connection trajectory ([ISO TS 19091] G.5.1.2) the `connectionID` is used.
+*
+* @field id: unique identifier.
+* @field lane: identifier from lane.
+* @field connectionID: identifier from connection.
+* @field intersectionID: identifier from intersection.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node ::= SEQUENCE {
+  id              INTEGER,
+  lane            LaneID           OPTIONAL,
+  connectionID    LaneConnectionID OPTIONAL,
+  intersectionID  IntersectionID   OPTIONAL,
+  ...
+}
+
+NodeLink ::= SEQUENCE SIZE (1..5) OF Node
+
+/**
+* This DF is used to provide the prioritization status response and the
+* signal group identifier for a specific ITS station (e.g. vehicle).
+*
+* @field stationID: StationID.
+* @field priorState: PrioritizationResponseStatus.
+* @field signalGroup: SignalGroupID.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PrioritizationResponse ::=	SEQUENCE {
+  stationID    StationID,
+  priorState   PrioritizationResponseStatus,
+  signalGroup  SignalGroupID,
+  ...
+}
+
+PrioritizationResponseList ::=	SEQUENCE SIZE(1..10) OF PrioritizationResponse
+
+/**
+* This DF defines the XYZ position of a signal head within an intersection
+* and indicates the related signal group identifier.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalHeadLocation ::=	SEQUENCE {
+  nodeXY         NodeOffsetPointXY,
+  nodeZ          DeltaAltitude,
+  signalGroupID  SignalGroupID,
+  ...
+}
+
+SignalHeadLocationList ::=	SEQUENCE (SIZE(1..64)) OF	SignalHeadLocation
+
+/**
+* This DE defines an enumerated list of battery states.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+BatteryStatus ::= ENUMERATED {
+  unknown,
+  critical,
+  low,
+  good,
+  ...
+}
+
+/**
+* This DE defines an enumerated list of toxic emission types for vehicles.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+EmissionType ::= ENUMERATED {
+  euro1,
+  euro2,
+  euro3,
+  euro4,
+  euro5,
+  euro6,
+  ...
+}
+
+/**
+* This DE defines a list of reasons for sudden changes in
+* eventState parameters, thereby offering a reason for extended waiting times.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ExceptionalCondition ::= ENUMERATED {
+  unknown,
+  publicTransportPriority,
+  emergencyVehiclePriority,
+  trainPriority,
+  bridgeOpen,
+  vehicleHeight,
+  weather,
+  trafficJam,
+  tunnelClosure,
+  meteringActive,
+  truckPriority,
+  bicyclePlatoonPriority,
+  vehiclePlatoonPriority,
+  ...
+}
+
+/**
+* This DE defines a list of activation requests used for C-ITS migration of legacy public 
+* transport prioritization systems. 
+* The activation points are used while approaching to an intersection.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PtvRequestType  ::= ENUMERATED {
+  preRequest,
+  mainRequest,
+  doorCloseRequest,
+  cancelRequest,
+  emergencyRequest,
+  ...
+}
+
+/**
+* This DE defines a list of reasons for rejected priority requests.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RejectedReason ::= ENUMERATED {
+  unknown,
+  exceptionalCondition,
+  maxWaitingTimeExceeded,
+  ptPriorityDisabled,
+  higherPTPriorityGranted,
+  vehicleTrackingUnknown,
+  ...
+}
+
+/**
+* This DE defines a value in milliseconds in the current minute related to UTC time. 
+* The range of 60 000 covers one minute (60 seconds * 1 000 milliseconds)
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TimeReference ::= INTEGER { oneMilliSec(1) } (0..60000)
+
+/** 
+* ## References:
+* 1. [ISO TS 19091]: "Intelligent transport systems - Cooperative ITS - Using V2I and I2V communications for applications related to signalized intersections".
+* 2. [SAE J2735]: "SURFACE VEHICLE STANDARD - V2X Communications Message Set Dictionary"
+*/
+
+END

--- a/standards/its/src/ts103301/asn1/DSRC-region.asn
+++ b/standards/its/src/ts103301/asn1/DSRC-region.asn
@@ -1,0 +1,111 @@
+--! @options: no-fields-header
+
+ETSI-ITS-DSRC-REGION {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) region (1) major-version-2 (2) minor-version-1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS::= BEGIN
+
+IMPORTS
+
+addGrpC, REG-EXT-ID-AND-TYPE
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+ConnectionManeuverAssist-addGrpC, ConnectionTrajectory-addGrpC,
+IntersectionState-addGrpC, LaneAttributes-addGrpC, MapData-addGrpC,
+MovementEvent-addGrpC, NodeAttributeSet-addGrpC, Position3D-addGrpC, RequestorDescription-addGrpC, RestrictionUserType-addGrpC, SignalStatusPackage-addGrpC
+FROM ETSI-ITS-DSRC-AddGrpC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) addgrpc (0) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+Reg-AdvisorySpeed	            REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-ComputedLane	            REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-ConnectionManeuverAssist	REG-EXT-ID-AND-TYPE ::= {
+	{ConnectionManeuverAssist-addGrpC  IDENTIFIED BY addGrpC},
+	...
+}
+
+Reg-GenericLane	                REG-EXT-ID-AND-TYPE ::= {
+	{ConnectionTrajectory-addGrpC	IDENTIFIED BY addGrpC} ,
+	...
+}
+
+Reg-IntersectionGeometry  	    REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-IntersectionState           REG-EXT-ID-AND-TYPE ::= {
+	{IntersectionState-addGrpC IDENTIFIED BY addGrpC},
+	...
+}
+
+Reg-LaneAttributes	            REG-EXT-ID-AND-TYPE ::= {
+   {LaneAttributes-addGrpC IDENTIFIED BY addGrpC} ,
+   ...
+}
+Reg-LaneDataAttribute           REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-MapData	                    REG-EXT-ID-AND-TYPE ::= {
+	{MapData-addGrpC  IDENTIFIED BY addGrpC},
+	...
+}
+
+Reg-MovementEvent	            REG-EXT-ID-AND-TYPE ::= {
+   {MovementEvent-addGrpC IDENTIFIED BY addGrpC} ,
+   ...
+}
+Reg-MovementState               REG-EXT-ID-AND-TYPE ::= { ... }
+
+
+Reg-NodeAttributeSetXY          REG-EXT-ID-AND-TYPE ::= {
+	{NodeAttributeSet-addGrpC   IDENTIFIED BY addGrpC},
+	...
+}
+
+Reg-NodeOffsetPointXY	        REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-Position3D	                REG-EXT-ID-AND-TYPE ::= {
+	{Position3D-addGrpC  IDENTIFIED BY addGrpC} ,
+	...
+}
+
+Reg-RequestorDescription        REG-EXT-ID-AND-TYPE ::= {
+   { RequestorDescription-addGrpC IDENTIFIED BY addGrpC} ,
+   ...
+}
+
+Reg-RequestorType	            REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-RestrictionUserType	        REG-EXT-ID-AND-TYPE ::= {
+  {RestrictionUserType-addGrpC IDENTIFIED BY addGrpC} ,
+  ...
+}
+
+Reg-RoadSegment	                REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-RTCMcorrections             REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalControlZone           REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalRequest               REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalRequestMessage        REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalRequestPackage        REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalStatus	            REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalStatusMessage	        REG-EXT-ID-AND-TYPE ::= { ... }
+
+Reg-SignalStatusPackage	        REG-EXT-ID-AND-TYPE ::= {
+	{ SignalStatusPackage-addGrpC IDENTIFIED BY addGrpC },
+	...
+}
+
+Reg-SPAT	                    REG-EXT-ID-AND-TYPE ::= { ... }
+
+END

--- a/standards/its/src/ts103301/asn1/DSRC.asn
+++ b/standards/its/src/ts103301/asn1/DSRC.asn
@@ -1,0 +1,3926 @@
+--! @options: no-fields-header
+
+ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS::= BEGIN
+
+IMPORTS
+
+Longitude, Latitude, StationID, Iso3833VehicleType
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+Reg-AdvisorySpeed, Reg-ComputedLane, Reg-ConnectionManeuverAssist, Reg-GenericLane,
+Reg-IntersectionGeometry, Reg-IntersectionState, Reg-LaneAttributes, Reg-MapData,
+Reg-LaneDataAttribute, Reg-MovementEvent, Reg-MovementState,
+Reg-NodeAttributeSetXY, Reg-NodeOffsetPointXY, Reg-Position3D, Reg-RequestorDescription, Reg-RequestorType, Reg-RestrictionUserType, Reg-RoadSegment,
+Reg-RTCMcorrections, Reg-SignalControlZone, Reg-SignalRequestPackage, Reg-SignalRequest, Reg-SignalStatus, Reg-SignalStatusPackage, Reg-SignalRequestMessage,
+Reg-SignalStatusMessage, Reg-SPAT
+FROM ETSI-ITS-DSRC-REGION {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) region (1) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* This information object class is an abstract template to instantiate region extension.
+*
+* @field &id: the identifier of the region type.
+* @field &Type: the extension content
+*
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+REG-EXT-ID-AND-TYPE ::= CLASS {
+  &id     RegionId UNIQUE,
+  &Type
+} WITH SYNTAX {&Type IDENTIFIED BY &id}
+
+/**
+* This DF represents a Region extension preceded by its type identifier and a lenght indicator.
+*
+* It shall include the following components:
+*
+* @field regionId: the identifier of the region.
+* @field regExtValue: the extension content consistent with the region type.
+*
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+RegionalExtension {REG-EXT-ID-AND-TYPE : Set} ::= SEQUENCE {
+  regionId     REG-EXT-ID-AND-TYPE.&id( {Set} ),
+  regExtValue  REG-EXT-ID-AND-TYPE.&Type( {Set}{@regionId} )
+}
+
+/**
+* This DF is used to convey many types of geographic road information. At the current time its primary
+* use is to convey one or more intersection lane geometry maps within a single message. The map message content
+* includes such items as complex intersection descriptions, road segment descriptions, high speed curve outlines (used in
+* curve safety messages), and segments of roadway (used in some safety applications). A given single MapData message
+* may convey descriptions of one or more geographic areas or intersections. The contents of this message involve defining
+* the details of indexing systems that are in turn used by other messages to relate additional information (for example, the
+* signal phase and timing via the SPAT message) to events at specific geographic locations on the roadway.
+*
+* @field timeStamp: time reference
+* @field msgIssueRevision: The MapData revision is defined by the data element **revision** for each intersection
+*                          geometry (see [ISO TS 19091] G.8.2.4.1). Therefore, an additional revision indication of the overall
+*                          MapData message is not used in this profile. It shall be set to "0" for this profile.
+* @field layerType: There is no need to additionally identify the topological content by an additional identifier. The ASN.1
+*                   definition of the data frames **intersections** and **roadSegments** are clearly defined and need no
+*                   additional identifier. Therefore, this optional data element shall not be used in this profile.
+* @field layerID: This profile extends the purpose of the **layerID** data element as defined in SAE J2735 as follows: For
+*                 large intersections, the length of a MapData description may exceed the maximum data length of the
+*                 communication message. Therefore, a fragmentation of the MapData message (at application layer) in
+*                 two or more MapData fragments may be executed. If no MapData fragmentation is needed, the **layerID**
+*                 shall not be used. For more details, see the definition of the data element @ref LayerID.
+* @field intersections: All Intersection definitions.
+* @field roadSegments: All roadway descriptions.
+* @field dataParameters: Any meta data regarding the map contents.
+* @field restrictionList: Any restriction ID tables which have established for these map entries
+* @field regional: This profile extends the MapData message with the regional data element @ref MapData-addGrpC
+*
+* @category: Road topology information
+* @revision: V1.3.1
+*/
+MapData ::= SEQUENCE {
+  timeStamp         MinuteOfTheYear OPTIONAL,
+  msgIssueRevision  MsgCount,
+  layerType         LayerType OPTIONAL,
+  layerID           LayerID  OPTIONAL,
+  intersections     IntersectionGeometryList OPTIONAL,
+  roadSegments      RoadSegmentList OPTIONAL,
+  dataParameters    DataParameters OPTIONAL,
+  restrictionList   RestrictionClassList OPTIONAL,
+  regional          SEQUENCE (SIZE(1..4)) OF
+                    RegionalExtension {{Reg-MapData}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to encapsulate RTCM differential corrections for GPS and other radio
+* navigation signals as defined by the RTCM (Radio Technical Commission For Maritime Services) special committee
+* number 104 in its various standards. Here, in the work of DSRC, these messages are "wrapped" for transport on the
+* DSRC media, and then can be re-constructed back into the final expected formats defined by the RTCM standard and
+* used directly by various positioning systems to increase the absolute and relative accuracy estimates produced.
+*
+* @field msgCnt: monotonic incrementing identifier.
+* @field rev: the specific edition of the standard that is being sent.
+* @field timeStamp: time reference
+* @field anchorPoint: Observer position, if needed.
+* @field rtcmHeader: Precise antenna position and noise data for a rover
+* @field msgs: one or more RTCM messages.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RTCMcorrections ::= SEQUENCE {
+   msgCnt      MsgCount,
+   rev         RTCM-Revision,
+   timeStamp   MinuteOfTheYear  OPTIONAL,
+   anchorPoint FullPositionVector OPTIONAL,
+   rtcmHeader  RTCMheader OPTIONAL,
+   msgs        RTCMmessageList,
+   regional    SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-RTCMcorrections}} OPTIONAL,
+   ...
+}
+
+/**
+* This DF is used to convey the current status of one or more signalized
+* intersections. Along with the MapData message (which describes a full geometric layout of an intersection) the
+* receiver of this message can determine the state of the signal phasing and when the next expected phase will occur.
+* The SPAT message sends the current movement state of each active phase in the system as needed (such as values of
+* what states are active and values at what time a state has begun/does begin earliest, is expected to begin most likely and
+* will end latest). The state of inactive movements is not normally transmitted. Movements are mapped to specific
+* approaches and connections of ingress to egress lanes and by use of the SignalGroupID in the MapData message
+*
+* The current signal preemption and priority status values (when present or active) are also sent. A more complete
+* summary of any pending priority or preemption events can be found in the Signal Status message.
+*
+* @field timeStamp: time reference
+* @field name: human readable name for this collection. to be used only in debug mode.
+* @field intersections: sets of SPAT data (one per intersection)
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SPAT ::= SEQUENCE {
+  timeStamp     MinuteOfTheYear OPTIONAL,
+  name          DescriptiveName OPTIONAL,
+  intersections IntersectionStateList,
+  regional      SEQUENCE (SIZE(1..4)) OF
+                RegionalExtension {{Reg-SPAT}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is a message sent by a DSRC equipped entity (such as a vehicle) to the RSU in a
+* signalized intersection. It is used for either a priority signal request or a preemption signal request depending on the way
+* each request is set. Each request defines a path through the intersection which is desired in terms of lanes and
+* approaches to be used. Each request can also contain the time of arrival and the expected duration of the service.
+* Multiple requests to multiple intersections are supported. The requestor identifies itself in various ways (using methods
+* supported by the @refRequestorDescription data frame), and its current speed, heading and location can be placed in this
+* structure as well. The specific request for service is typically based on previously decoding and examining the list of lanes
+* and approaches for that intersection (sent in MAP messages). The outcome of all of the pending requests to a signal can
+* be found in the Signal Status Message (SSM), and may be reflected in the SPAT message contents if successful.
+*
+* @field timeStamp: time reference
+* @field second: time reference
+* @field sequenceNumber: monotonic incrementing identifier
+* @field requests: Request Data for one or more signalized intersections that support SRM dialogs
+* @field requestor: Requesting Device and other User Data contains vehicle ID (if from a vehicle) as well as type data and current
+*                   position and may contain additional transit data
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalRequestMessage ::= SEQUENCE {
+  timeStamp       MinuteOfTheYear  OPTIONAL,
+  second          DSecond,
+  sequenceNumber  MsgCount         OPTIONAL,
+  requests        SignalRequestList OPTIONAL,
+  requestor       RequestorDescription,
+  regional        SEQUENCE (SIZE(1..4)) OF
+                  RegionalExtension {{Reg-SignalRequestMessage}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is a message sent by an RSU in a signalized intersection. It is used to relate the current
+* status of the signal and the collection of pending or active preemption or priority requests acknowledged by the controller.
+* It is also used to send information about preemption or priority requests which were denied. This in turn allows a dialog
+* acknowledgment mechanism between any requester and the signal controller. The data contained in this message allows
+* other users to determine their "ranking" for any request they have made as well as to see the currently active events.
+* When there have been no recently received requests for service messages, this message may not be sent. While the
+* outcome of all pending requests to a signal can be found in the Signal Status Message, the current active event (if any)
+* will be reflected in the SPAT message contents.
+*
+* @field timeStamp: time reference
+* @field second: time reference
+* @field sequenceNumber: monotonic incrementing identifier
+* @field status: Status Data for one of more signalized intersections.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatusMessage ::= SEQUENCE {
+  timeStamp       MinuteOfTheYear  OPTIONAL,
+  second          DSecond,
+  sequenceNumber  MsgCount         OPTIONAL,
+  status          SignalStatusList,
+  regional        SEQUENCE (SIZE(1..4)) OF
+                  RegionalExtension {{Reg-SignalStatusMessage}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to convey a recommended traveling approach speed to an intersection
+* from the message issuer to various travelers and vehicle types. Besides support for various eco-driving applications, this
+* allows transmitting recommended speeds for specialty vehicles such as transit buses.
+*
+* @field type: the type of advisory which this is.
+* @field speed: See @ref SpeedAdvice for converting and translating speed expressed in mph into units of m/s.
+*               This element is optional ONLY when superceded by the presence of a regional speed element found in Reg-AdvisorySpeed entry
+* @field confidence: A confidence value for the above speed
+* @field distance: The distance indicates the region for which the advised speed is recommended, it is specified upstream from the stop bar
+*                  along the connected egressing lane. Unit = 1 meter 
+* @field class: the vehicle types to which it applies when absent, the AdvisorySpeed applies to all motor vehicle types
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+AdvisorySpeed ::= SEQUENCE {
+  type        AdvisorySpeedType,
+  speed       SpeedAdvice OPTIONAL,
+  confidence  SpeedConfidenceDSRC OPTIONAL,
+  distance    ZoneLength OPTIONAL,
+  class       RestrictionClassID OPTIONAL,
+  regional    SEQUENCE (SIZE(1..4)) OF
+              RegionalExtension {{Reg-AdvisorySpeed}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref AdvisorySpeed entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+AdvisorySpeedList ::= SEQUENCE (SIZE(1..16)) OF AdvisorySpeed
+
+/**
+* This DF is a collection of three offset values in an orthogonal coordinate system
+* which describe how far the electrical phase center of an antenna is in each axis from a nearby known anchor point in units of 1 cm.
+*
+* When the antenna being described is on a vehicle, the signed offset shall be in the coordinate system defined in section 11.4.
+*
+* @field antOffsetX: a range of +- 20.47 meters.
+* @field antOffsetY: a range of +- 2.55 meters.
+* @field antOffsetZ: a range of +- 5.11 meters.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+AntennaOffsetSet ::= SEQUENCE {
+   antOffsetX  Offset-B12,
+   antOffsetY  Offset-B09,
+   antOffsetZ  Offset-B10
+}
+
+/**
+* This DE is used to contain information needed to compute one lane from another
+* (hence the name). This concept is used purely as a means of saving size in the message payload. The new lane is
+* expressed as an X,Y offset from the first point of the source lane. It can be optionally rotated and scaled. Any attribute
+* information found within the node of the source lane list cannot be changed and must be reused.
+*
+* @field referenceLaneId: the lane ID upon which this computed lane will be based Lane Offset in X and Y direction
+* @field offsetXaxis: A path X offset value for translations of the path's points when creating translated lanes.
+* @field offsetYaxis: The values found in the reference lane are all offset based on the X and Y values from
+*                     the coordinates of the reference lane's initial path point.
+* @field rotateXY: A path rotation value for the entire lane
+*                  Observe that this rotates the existing orientation
+*                  of the referenced lane, it does not replace it.
+*                  Rotation occurs about the initial path point.
+* @field scaleXaxis: value for translations or zooming of the path's points. The values found in the reference lane
+* @field scaleYaxis: are all expanded or contracted based on the X and Y and width values from the coordinates of  the reference lane's initial path point.
+*                    The Z axis remains untouched.
+* @field regional: optional region specific data.
+*
+* @note: The specified transformation shall be applied to the reference lane without any intermediary loss of precision
+*        (truncation). The order of the transformations shall be: the East-West and North-South offsets, the scaling factors, and
+*        finally the rotation.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ComputedLane ::= SEQUENCE {
+  referenceLaneId    LaneID,
+  offsetXaxis        CHOICE {
+                        small   DrivenLineOffsetSm,
+                        large   DrivenLineOffsetLg
+                        },
+  offsetYaxis        CHOICE {
+                        small   DrivenLineOffsetSm,
+                        large   DrivenLineOffsetLg
+                        },
+  rotateXY           Angle OPTIONAL,
+  scaleXaxis         Scale-B12 OPTIONAL,
+  scaleYaxis         Scale-B12 OPTIONAL,
+  regional  SEQUENCE (SIZE(1..4)) OF
+            RegionalExtension {{Reg-ComputedLane}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used in the generic lane descriptions to provide a sequence of other defined
+* lanes to which each lane connects beyond its stop point. See the Connection data frame entry for details. Note that this
+* data frame is not used in some lane object types.
+*
+* @note: The assignment of lanes in the Connection structure shall start with the leftmost lane from the vehicle
+*   perspective (the u-turn lane in some cases) followed by subsequent lanes in a clockwise assignment order. Therefore, the
+*   rightmost lane to which this lane connects would always be listed last. Note that this order is observed regardless of which
+*   side of the road vehicles use. If this structure is used in the lane description, then all valid lanes to which the subject lane
+*   connects shall be listed.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ConnectsToList ::= SEQUENCE (SIZE(1..16)) OF Connection
+
+/**
+* The data concept ties a single lane to a single maneuver needed to reach it from another lane.
+* It is typically used to connect the allowed maneuver from the end of a lane to the outbound lane so that these can be
+* mapped to the SPAT message to which both lanes apply.
+*
+* @field lane: Index of the connecting lane.
+*
+* @field maneuver: This data element allows only the description of a subset of possible manoeuvres and therefore
+*    represents an incomplete list of possible travel directions. The connecting **lane** data element gives the
+*    exact information about the manoeuvre relation from ingress to egress lane. Therefore the "maneuver"
+*    data element may be used only additionally if the travel direction of the manoeuvre is unanmbigoulsy
+*    represented (e.g. left, right, straight, etc.).
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ConnectingLane ::= SEQUENCE {
+  lane      LaneID,
+  maneuver  AllowedManeuvers OPTIONAL
+}
+
+/**
+* This DF is used to combine/connect multiple physical lanes (i.e. within intersections or road
+* segments). For signalized movements, the **connectsTo** data frame defines e.g. the relation between
+* ingress and egress lanes within an intersection. It describes the allowed manoeuvres and includes the
+* link (**signalGroup** identifier) between the @ref MapData and the @ref SPAT message. The data frame is also used
+* to describe the relation of lanes within a non signalized intersection (e.g. ingress lanes which are
+* bypassing the conflict area and ending in an egress lane without signalization). Within a road segment,
+* it is used to combine two or multiple physical lanes into a single lane object.
+*
+* @field connectingLane: 
+* @field remoteIntersection: When the data element **remoteIntersection** is used, it indicates
+*                            that the connecting lane belongs to another intersection. 
+*                            (see clause [ISO TS 19091] G.9.1 for further explainations).
+* @field signalGroup: 
+* @field userClass: 
+* @field connectionID: 
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Connection ::= SEQUENCE {
+  connectingLane     ConnectingLane,
+  remoteIntersection IntersectionReferenceID OPTIONAL,
+  signalGroup        SignalGroupID OPTIONAL,
+  userClass          RestrictionClassID OPTIONAL,
+  connectionID       LaneConnectionID OPTIONAL
+}
+
+/**
+* This DF contains information about the the dynamic flow of traffic for the lane(s)
+* and maneuvers in question (as determined by the @ref LaneConnectionID). Note that this information can be sent regarding
+* any lane-to-lane movement; it need not be limited to the lanes with active (non-red) phases when sent.
+*
+* @field connectionID: the common connectionID used by all lanes to which this data applies
+*                     (this value traces to ConnectsTo entries in lanes)
+*
+* @field queueLength: The distance from the stop line to the back edge of the last vehicle in the queue,
+*                     as measured along the lane center line. (Unit = 1 meter, 0 = no queue)
+*
+* @field availableStorageLength: Distance (e.g. beginning from the downstream stop-line up to a given distance) with a high
+*                     probability for successfully executing the connecting maneuver between the two lanes
+*                     during the current cycle.
+*                     Used for enhancing the awareness of vehicles to anticipate if they can pass the stop line
+*                     of the lane. Used for optimizing the green wave, due to knowledge of vehicles waiting in front
+*                     of a red light (downstream).
+*                     The element nextTime in @ref TimeChangeDetails in the containing data frame contains the next
+*                     timemark at which an active phase is expected, a form of storage flush interval.
+*                     (Unit = 1 meter, 0 = no space remains)
+*
+* @field waitOnStop:  If true, the vehicles on this specific connecting
+*                     maneuver have to stop on the stop-line and not to enter the collision area
+*
+* @field pedBicycleDetect: true if ANY ped or bicycles are detected crossing the above lanes. Set to false ONLY if there is a
+*                     high certainty that there are none present, otherwise element is not sent.
+*
+* @field regional:    This data element includes additional data content @ref ConnectionManeuverAssist-addGrpC defined in
+*                     this profile (see [ISO TS 19091] G.5.1.1). The content is included using the regional extension framework as defined in
+*                     @ref ConnectionManeuverAssist-addGrpC is used for position feedback to moving ITS stations for executing
+*                     safe manoeuvres and is included for this purpose in the data element "intersectionState"
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ConnectionManeuverAssist ::= SEQUENCE {
+  connectionID         LaneConnectionID,
+  queueLength          ZoneLength OPTIONAL,
+  availableStorageLength ZoneLength OPTIONAL,
+  waitOnStop           WaitOnStopline OPTIONAL,
+  pedBicycleDetect     PedestrianBicycleDetect OPTIONAL,
+  regional  SEQUENCE (SIZE(1..4)) OF
+            RegionalExtension {{Reg-ConnectionManeuverAssist}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to provide basic (static) information on how a map fragment was processed or determined.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DataParameters ::= SEQUENCE {
+  processMethod     IA5String(SIZE(1..255)) OPTIONAL,
+  processAgency     IA5String(SIZE(1..255)) OPTIONAL,
+  lastCheckedDate   IA5String(SIZE(1..255)) OPTIONAL,
+  geoidUsed         IA5String(SIZE(1..255)) OPTIONAL,
+  ...
+}
+
+/**
+* The DSRC style date is a compound value consisting of finite-length sequences of integers (not characters) of the
+* form: "yyyy, mm, dd, hh, mm, ss (sss+)" - as defined below.
+*
+* @note: Note that some elements of this structure may not be sent when not needed. At least one element shall be present.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DDateTime ::= SEQUENCE {
+   year    DYear    OPTIONAL,
+   month   DMonth   OPTIONAL,
+   day     DDay     OPTIONAL,
+   hour    DHour    OPTIONAL,
+   minute  DMinute  OPTIONAL,
+   second  DSecond  OPTIONAL,
+   offset  DOffset  OPTIONAL
+ }
+
+/**
+* This DF is a sequence of lane IDs for lane objects that are activated in the current map
+* configuration. These lanes, unlike most lanes, have their RevocableLane bit set to one (asserted). Such lanes are not
+* considered to be part of the current map unless they are in the Enabled Lane List. This concept is used to describe all the
+* possible regulatory states for a given physical lane. For example, it is not uncommon to enable or disable the ability to
+* make a right hand turn on red during different periods of a day. Another similar example would be a lane which is used for
+* driving during one period and where parking is allowed at another. Traditionally, this information is conveyed to the vehicle
+* driver by local signage. By using the Enabled Lane List data frame in conjunction with the RevocableLane bit and
+* constructing a separate lane object in the intersection map for each different configuration, a single unified map can be
+* developed and used.
+*
+* Contents are the unique ID numbers for each lane object which is **active** as part of the dynamic map contents.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+EnabledLaneList ::= SEQUENCE (SIZE(1..16)) OF LaneID
+
+/**
+* A complete report of the vehicle's position, speed, and heading at an instant in time. Used in the probe vehicle
+* message (and elsewhere) as the initial position information. Often followed by other data frames that may provide offset
+* path data.
+*
+* @field utcTime:   time with mSec precision
+* @field long:      Longitude in 1/10th microdegree
+* @field lat:       Latitude in 1/10th microdegree
+* @field elevation: Elevation in units of 0.1 m
+* @field heading:   Heading value 
+* @field speed:     Speed value
+* @field posAccuracy:      position accuracy
+* @field timeConfidence:   time confidence
+* @field posConfidence:    position confidence
+* @field speedConfidence:  speed confidence 
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+FullPositionVector ::= SEQUENCE {
+   utcTime             DDateTime OPTIONAL,
+   long                Longitude,
+   lat                 Latitude,
+   elevation           Elevation  OPTIONAL,
+   heading             HeadingDSRC OPTIONAL,
+   speed               TransmissionAndSpeed OPTIONAL,
+   posAccuracy         PositionalAccuracy OPTIONAL,
+   timeConfidence      TimeConfidence OPTIONAL,
+   posConfidence       PositionConfidenceSet OPTIONAL,
+   speedConfidence     SpeedandHeadingandThrottleConfidence OPTIONAL,
+   ...
+}
+
+/**
+* This DF is used for all types of lanes, e.g. motorized vehicle lanes, crosswalks, medians. The
+* GenericLane describes the basic attribute information of the lane. The LaneID value for each lane is unique within an
+* intersection. One use for the LaneID is in the SPAT message, where a given signal or movement phase is mapped to a
+* set of applicable lanes using their respective LaneIDs. The NodeList2 data frame includes a sequence of offset points (or
+* node points) representing the center line path of the lane. As described in this standard, node points are sets of variable
+* sized delta orthogonal offsets from the prior point in the node path. (The initial point is offset from the LLH anchor point
+* used in the intersection.) Each node point may convey optional attribute data as well. The use of attributes is described
+* further in the Node definition, and in a later clause, but an example use would be to indicate a node point where the lane
+* width changes.
+*
+* It should be noted that a "lane" is an abstract concept that can describe objects other than motorized vehicle lanes, and
+* that the generic lane structure (using features drawn from Japanese usage) also allows combining multiple physical lanes
+* into a single lane object. In addition, such lanes can describe connectivity points with other lanes beyond a single
+* intersection, extending such a lane description over multiple nearby physical intersections and side streets which
+* themselves may not be equipped or assigned an index number in the regional intersection numbering system. (See the
+* ConnectsTo entry for details) This has value when describing a broader service area in terms of the roadway network,
+* probably with less precision and detail.
+*
+* @field laneID:  The unique ID number assigned to this lane object
+* @field name:    often for debug use only but at times used to name ped crossings
+* @field ingressApproach:  inbound Approach ID to which this lane belongs
+* @field egressApproach: outbound Approach ID to which this lane belongs
+* @field laneAttributes: All Attribute information about the basic selected lane type
+*                        Directions of use, Geometric co-sharing and Type Specific Attributes
+*                        These Attributes are **lane - global** that is, they are true for the entire length of the lane
+* @field maneuvers: This data element allows only the description of a subset of possible manoeuvres and therefore
+*                    reperesents an incomplete list of possible travel directions. The connecting **lane** data element gives
+*                    the exact information about the manoeuvre relation from ingress to egress lane. Therefore the
+*                    "maneuver" data element is used only additionally if the travel direction of the manoeuvre is
+* @field nodeList: Lane spatial path information as well as various Attribute information along the node path
+*                    Attributes found here are more general and may come and go over the length of the lane.
+* @field connectsTo: a list of other lanes and their signal group IDs each connecting lane and its signal group ID
+*                    is given, therefore this element provides the information formerly in "signalGroups" in prior editions.
+* @field overlays: A list of any lanes which have spatial paths that overlay (run on top of, and not simply cross)
+*                    the path of this lane when used
+* @field regional: optional region specific data.
+*
+* @note: The data elements **ingressApproach** and **egressApproach** are used for grouping lanes whin an
+*       approach (e.g. lanes defined in travel direction towards the intersection, lanes in exiting direction and
+*       cross walks). For a bidirectrional lane (e.g. bike lane) both dataelements are used for the same lane. The
+*       integer value used for identifying the **ingressApproach** and the **egressAproach**, based on the
+*       topology, may be e.g. the same for all lanes within an approach of an intersection.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+GenericLane ::= SEQUENCE {
+  laneID           LaneID,
+  name             DescriptiveName OPTIONAL,
+  ingressApproach  ApproachID OPTIONAL,
+  egressApproach   ApproachID OPTIONAL,
+  laneAttributes   LaneAttributes,
+  maneuvers        AllowedManeuvers OPTIONAL,
+  nodeList         NodeListXY,
+  connectsTo       ConnectsToList OPTIONAL,
+  overlays         OverlayLaneList OPTIONAL,
+  regional  SEQUENCE (SIZE(1..4)) OF
+            RegionalExtension {{Reg-GenericLane}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to specify the index of either a single approach or a single lane at
+* which a service is needed. This is used, for example, with the Signal Request Message (SRM) to indicate the inbound
+* and outbound points by which the requestor (such as a public safety vehicle) can traverse an intersection.
+*
+* @field lane: the representation of the point as lane identifier.
+* @field approach: the representation of the point as approach identifier.
+* @field connection: the representation of the point as connection identifier.
+*
+* @note: Note that the value of zero has a reserved meaning for these two indexing systems. In both cases, this value
+*    is used to indicate the concept of "none" in use. When the value is of zero is used here, it implies the center of the
+*    intersection itself. For example, requesting an outbound point of zero implies the requestor wishes to have the intersection
+*    itself be the destination. Alternatively, an inbound value of zero implies the requestor is within the intersection itself and
+*    wishes to depart for the outbound value provided. This special meaning for the value zero can be used in either the lane
+*    or approach with the same results.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionAccessPoint ::= CHOICE {
+  lane       LaneID,
+  approach   ApproachID,
+  connection LaneConnectionID,
+  ...
+}
+
+/**
+* A complete description of an intersection's roadway geometry and its allowed navigational paths (independent of
+* any additional regulatory restrictions that may apply over time or from user classification).
+*
+* @field name: For debug use only
+* @field id: A globally unique value set, consisting of a regionID and intersection ID assignment
+* @field revision: This profile extends the purpose of the **revision** data element as defined in SAE J2735 as follows.
+*           The revision data element is used to communicate the valid release of the intersection geometry
+*           description. If there are no changes in the deployed intersection description, the same revision counter
+*           is transmitted. Due to a revised deployment of the intersection description (e.g. new lane added, ID's
+*           changed, etc.), the revision is increased by one. After revision equal to 127, the increment restarts by 0.
+*           The intersection geometry and the signal phase and timing information is related each other. Therefore,
+*           the revision of the intersection geometry of the MapData message shall be the same as the revision of
+*           the intersection state of the SPAT (see data element **revision** of **DF_IntersectionState** in [ISO TS 19091] G.8.2.9)
+* @field refPoint: The reference from which subsequent data points are offset until a new point is used.
+* @field laneWidth: Reference width used by all subsequent lanes unless a new width is given
+* @field speedLimits: Reference regulatory speed limits used by all subsequent lanes unless a new speed is given
+* @field laneSet: Data about one or more lanes (all lane data is found here) Data describing how to use and request preemption and
+*           priority services from this intersection (if supported)
+* @field preemptPriorityData: This DF is not used.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionGeometry ::= SEQUENCE {
+  name        DescriptiveName OPTIONAL,
+  id          IntersectionReferenceID,
+  revision    MsgCount,
+  refPoint    Position3D,
+  laneWidth   LaneWidth OPTIONAL,
+  speedLimits SpeedLimitList OPTIONAL,
+  laneSet     LaneList,
+  preemptPriorityData PreemptPriorityList OPTIONAL,
+  regional     SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-IntersectionGeometry}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of IntersectionGeometry entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionGeometryList ::= SEQUENCE (SIZE(1..32)) OF IntersectionGeometry
+
+/**
+* This DF conveys the combination of an optional RoadRegulatorID and of an
+* IntersectionID that is unique within that region. When the RoadRegulatorID is present the IntersectionReferenceID is
+* guaranteed to be globally unique.
+*
+* @field region: a globally unique regional assignment value typical assigned to a regional DOT authority
+*                the value zero shall be used for testing needs
+* @field id: a unique mapping to the intersection in question within the above region of use
+*
+* @note: A fully qualified intersection consists of its regionally unique ID (the IntersectionID) and its region ID (the
+*        RoadRegulatorID). Taken together these form a unique value which is never repeated.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionReferenceID ::= SEQUENCE {
+  region  RoadRegulatorID OPTIONAL,
+  id      IntersectionID
+}
+
+/**
+* This DF is used to convey all the SPAT information for a single intersection. Both current
+* and future data can be sent.
+*
+* @field name: human readable name for intersection to be used only in debug mode
+* @field id: A globally unique value set, consisting of a regionID and intersection ID assignment
+*            provides a unique mapping to the intersection MAP in question which provides complete location
+*            and approach/move/lane data
+* @field revision: The data element **revision** is used to communicate the actual valid release of the intersection
+*                  description. If there are no changes in the deployed intersection description, almost the same revision
+*                  counter is transmitted. Due to a revised deployment of the intersection description (e.g. introduction of
+*                  additional signal state element), the revision is increased by one. After revision equal to 127, the
+*                  increment leads to 0 (due to the element range).
+*                  The intersection state and the intersection geometry is related to each other. Therefore, the revision of
+*                  the intersection state shall be the same as the revision of the intersection geometry (see the data
+*                  element **revision** of **DF_IntersectionGeometry** in [ISO TS 19091] G.8.2.6).
+* @field status: general status of the controller(s)
+* @field moy: Minute of current UTC year, used only with messages to be archived.
+* @field timeStamp: the mSec point in the current UTC minute that this message was constructed.
+* @field enabledLanes: a list of lanes where the RevocableLane bit has been set which are now active and
+*                      therefore part of the current intersection
+* @field states: Each Movement is given in turn and contains its signal phase state,
+*                mapping to the lanes it applies to, and point in time it will end, and it
+*                may contain both active and future states
+* @field maneuverAssistList: Assist data
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionState ::= SEQUENCE {
+  name         DescriptiveName OPTIONAL,
+  id           IntersectionReferenceID,
+  revision     MsgCount,
+  status       IntersectionStatusObject,
+  moy          MinuteOfTheYear OPTIONAL,
+  timeStamp    DSecond OPTIONAL,
+  enabledLanes EnabledLaneList OPTIONAL,
+  states       MovementList,
+  maneuverAssistList  ManeuverAssistList OPTIONAL,
+  regional     SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-IntersectionState}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of IntersectionState entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionStateList ::= SEQUENCE (SIZE(1..32)) OF  IntersectionState
+
+/**
+* This DF holds all of the constant attribute information of any lane object (as well as
+* denoting the basic lane type itself) within a single structure. Constant attribute information are those values which do not
+* change over the path of the lane, such as the direction of allowed travel. Other lane attribute information can change at or
+* between each node.
+* The structure consists of three element parts as follows: LaneDirection specifies the allowed directions of travel, if any.
+* LaneSharing indicates whether this lane type is shared with other types of travel modes or users. The lane type is defined
+* in LaneTypeAttributes, along with additional attributes specific to that type.
+* The fundamental type of lane object is described by the element selected in the LaneTypeAttributes data concept.
+* Additional information specific or unique to a given lane type can be found there as well. A regional extension is provided
+* as well.
+* Note that combinations of regulatory maneuver information such as "both a left turn and straight ahead movement are
+* allowed, but never a u-turn," are expressed by the AllowedManeuvers data concept which typically follows after this
+* element and in the same structure. Note that not all lane objects require this information (for example a median). The
+* various values are set via bit flags to indicate the assertion of a value. Each defined lane type contains the bit flags
+* suitable for its application area.
+* Note that the concept of LaneSharing is used to indicate that there are other users of this lane with equal regulatory rights
+* to occupy the lane (which is a term this standard does not formally define since it varies by world region). A typical case is
+* a light rail vehicle running along the same lane path as motorized traffic. In such a case, motor traffic may be allowed
+* equal access to the lane when a train is not present. Another case would be those intersection lanes (at the time of writing
+* rather unusual) where bicycle traffic is given full and equal right of way to an entire width of motorized vehicle lane. This
+* example would not be a bike lane or bike box in the traditional sense.
+*
+* @field directionalUse: directions of lane use
+* @field sharedWith: co-users of the lane path
+* @field laneType: specific lane type data
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes ::= SEQUENCE {
+  directionalUse  LaneDirection,
+  sharedWith      LaneSharing,
+  laneType        LaneTypeAttributes,
+  regional        RegionalExtension {{Reg-LaneAttributes}} OPTIONAL
+}
+
+/**
+* This DF is used to relate an attribute and a control value at a node point or along a
+* lane segment from an enumerated list of defined choices. It is then followed by a defined data value associated with it and
+* which is defined elsewhere in this standard.
+*
+* @field pathEndPointAngle: adjusts final point/width slant of the lane to align with the stop line
+* @field laneCrownPointCenter: sets the canter of the road bed from centerline point
+* @field laneCrownPointLeft: sets the canter of the road bed from left edge
+* @field laneCrownPointRight: sets the canter of the road bed from right edge
+* @field laneAngle: the angle or direction of another lane this is required when a merge point angle is required
+* @field speedLimits: Reference regulatory speed limits used by all segments
+* @field regional: optional region specific data.
+*
+* @note: This data concept handles a variety of use case needs with a common and consistent message pattern. The
+*     typical use of this data concept (and several similar others) is to inject the selected Attribute into the spatial description of
+*     a lane's center line path (the segment list). In this way, attribute information which is true for a portion of the overall lane
+*     can be described when needed. This attribute information applies from the node point in the stream of segment data until
+*     changed again. Denoting the porous aspects of a lane along its path as it merges with another lane would be an example
+*     of this use case. In this case the start and end node points would be followed by suitable segment attributes. Re-using a
+*     lane path (previously called a computed lane) is another example. In this case the reference lane to be re-used appears
+*     as a segment attribute followed by the lane value. It is then followed by one or more segment attributes which relate the
+*     positional translation factors to be used (offset, rotate, scale) and any further segment attribute changes.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneDataAttribute ::= CHOICE {
+   pathEndPointAngle        DeltaAngle,
+   laneCrownPointCenter     RoadwayCrownAngle,
+   laneCrownPointLeft       RoadwayCrownAngle,
+   laneCrownPointRight      RoadwayCrownAngle,
+   laneAngle                MergeDivergeNodeAngle,
+   speedLimits              SpeedLimitList,
+   regional  SEQUENCE (SIZE(1..4)) OF
+             RegionalExtension {{Reg-LaneDataAttribute}},
+   ...
+}
+
+/**
+* This DF consists of a list of LaneDataAttribute entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneDataAttributeList ::= SEQUENCE (SIZE(1..8)) OF LaneDataAttribute
+
+/**
+* This DF consists of a list of GenericLane entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneList ::= SEQUENCE (SIZE(1..255)) OF GenericLane
+
+/**
+* This DE is used to denote the presence of other user types (travel modes) who have an
+* equal right to access and use the lane. There may also be another lane object describing their use of a lane. This data
+* concept is used to indicate lanes and/or users that travel along the same path, and not those that simply cross over the
+* lane's segments path (such as a pedestrian crosswalk crossing a lane for motor vehicle use). The typical use is to alert
+* the user of the MAP data that additional traffic of another mode may be present in the same spatial lane.
+*
+* Bits used:
+* - 0 - overlappingLaneDescriptionProvided: Assert when another lane object is present to describe the
+*                                           path of the overlapping shared lane this construct is not used for lane objects which simply cross
+* - 1 - multipleLanesTreatedAsOneLane: Assert if the lane object path and width details represents multiple lanes within it
+*                                      that are not further described Various modes and type of traffic that may share this lane:
+* - 2 - otherNonMotorizedTrafficTypes: horse drawn etc.
+* - 3 - individualMotorizedVehicleTraffic:
+* - 4 - busVehicleTraffic:
+* - 5 - taxiVehicleTraffic:
+* - 6 - pedestriansTraffic:
+* - 7 - cyclistVehicleTraffic:
+* - 8 - trackedVehicleTraffic:
+* - 9 - pedestrianTraffic:
+*
+* @note: All zeros would indicate **not shared** and **not overlapping**
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneSharing ::= BIT STRING {
+   overlappingLaneDescriptionProvided  (0),
+   multipleLanesTreatedAsOneLane       (1),
+   otherNonMotorizedTrafficTypes       (2),
+   individualMotorizedVehicleTraffic   (3),
+   busVehicleTraffic                   (4),
+   taxiVehicleTraffic                  (5),
+   pedestriansTraffic                  (6),
+   cyclistVehicleTraffic               (7),
+   trackedVehicleTraffic               (8),
+   pedestrianTraffic                   (9)
+} (SIZE (10))
+
+/**
+* This DF is used to hold attribute information specific to a given lane type. It is typically
+* used in the DE_LaneAttributes data frame as part of an overall description of a lane object. Information unique to the
+* specific type of lane is found here. Information common to lanes is expressed in other entries. The various values are set
+* by bit flags to indicate the assertion of a value. Each defined lane type contains bit flags suitable for its application area.
+*
+* @field vehicle:         motor vehicle lanes
+*
+* @field crosswalk:       pedestrian crosswalks
+*
+* @field bikeLane:        bike lanes
+*
+* @field sidewalk:        pedestrian sidewalk paths
+*
+* @field median:          medians & channelization
+*
+* @field striping:        roadway markings
+*
+* @field trackedVehicle:  trains and trolleys
+*
+* @field parking:         parking and stopping lanes
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneTypeAttributes ::= CHOICE {
+  vehicle        LaneAttributes-Vehicle,
+  crosswalk      LaneAttributes-Crosswalk,
+  bikeLane       LaneAttributes-Bike,
+  sidewalk       LaneAttributes-Sidewalk,
+  median         LaneAttributes-Barrier,
+  striping       LaneAttributes-Striping,
+  trackedVehicle LaneAttributes-TrackedVehicle,
+  parking        LaneAttributes-Parking,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref ConnectionManeuverAssist entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ManeuverAssistList ::= SEQUENCE (SIZE(1..16)) OF ConnectionManeuverAssist
+
+/**
+* This DF contains details about a single movement. It is used by the movement state to
+* convey one of number of movements (typically occurring over a sequence of times) for a SignalGroupID.
+*
+* @field eventState: Consisting of: Phase state (the basic 11 states), Directional, protected, or permissive state
+* @field timing: Timing Data in UTC time stamps for event includes start and min/max end times of phase confidence and estimated next occurrence
+* @field speeds: various speed advisories for use by general and specific types of vehicles supporting green-wave and other flow needs
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementEvent ::= SEQUENCE {
+  eventState   MovementPhaseState,
+  timing       TimeChangeDetails OPTIONAL,
+  speeds       AdvisorySpeedList OPTIONAL,
+  regional     SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-MovementEvent}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref MovementEvent entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementEventList ::= SEQUENCE (SIZE(1..16)) OF MovementEvent
+
+/**
+* This DF consists of a list of @ref MovementState entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementList ::= SEQUENCE (SIZE(1..255)) OF MovementState
+
+/**
+* This DF is used to convey various information about the current or future movement state of
+* a designated collection of one or more lanes of a common type. This is referred to as the GroupID. Note that lane object
+* types supported include both motorized vehicle lanes as well as pedestrian lanes and dedicated rail and transit lanes. Of
+* the reported data elements, the time to change (the time remaining in the current state) is often of the most value. Lanes
+* with a common state (typically adjacent sets of lanes in an approach) in a signalized intersection will have individual lane
+* values such as total vehicle counts, summed. It is used in the SPAT message to convey every active movement in a
+* given intersection so that vehicles, when combined with certain map information, can determine the state of the signal phases.
+*
+* @field movementName: uniquely defines movement by name human readable name for intersection to be used only in debug mode.
+* @field signalGroup: is used to map to lists of lanes (and their descriptions) which this MovementState data applies to.
+* @field state-time-speed: Consisting of sets of movement data with @ref SignalPhaseState, @ref TimeChangeDetail and @ref AdvisorySpeed
+*                          *Note:* one or more of the movement events may be for a future time and that this allows conveying multiple
+*                          predictive phase and movement timing for various uses for the current signal group.
+* @field maneuverAssistList: This information may also be placed in the @ref IntersectionState when common information applies to different lanes in the same way
+* @field regional: optional region specific data.
+*
+* @note: Note that the value given for the time to change will vary in many actuated signalized intersections based on
+*      the sensor data received during the phase. The data transmitted always reflects the then most current timemark value
+*      (which is the point in UTC time when the change will occur). As an example, in a phase which may vary from 15 to 25
+*      seconds of duration based on observed traffic flows, a time to change value of 15 seconds in the future might be
+*      transmitted for many consecutive seconds (and the time mark value extended for as much as 10 seconds depending on
+*      the extension time logic used by the controller before it either times out or gaps out), followed by a final time mark value
+*      reflecting the decreasing values as the time runs out, presuming the value was not again extended to a new time mark
+*      due to other detection events. The time to change element can therefore generally be regarded as a guaranteed minimum
+*      value of the time that will elapse unless a preemption event occurs.
+*
+*      In use, the @ref SignalGroupID element is matched to lanes that are members of that ID. The type of lane (vehicle, crosswalk,
+*      etc.) is known by the lane description as well as its allowed maneuvers and any vehicle class restrictions. Every lane type
+*      is treated the same way (cross walks map to suitable meanings, etc.). Lane objects which are not part of the sequence of
+*      signalized lanes do not appear in any GroupID. The visual details of how a given signal phase is presented to a mobile
+*      user will vary based on lane type and with regional conventions. Not all signal states will be used in all regional
+*      deployments. For example, a pre-green visual indication is not generally found in US deployments. Under such operating
+*      conditions, the unused phase states are simply skipped.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementState ::= SEQUENCE {
+  movementName       DescriptiveName OPTIONAL,
+  signalGroup        SignalGroupID,
+  state-time-speed   MovementEventList,
+  maneuverAssistList ManeuverAssistList OPTIONAL,
+  regional           SEQUENCE (SIZE(1..4)) OF
+                     RegionalExtension {{Reg-MovementState}} OPTIONAL,
+  ...
+}
+
+/**
+* All the node attributes defined in this DF are valid in the direction of
+* node declaration and not in driving direction (i.e. along the sequence of the declared nodes). E.g. node
+* attributes of an **ingress** or an **egress** lane are defined from the conflict area (first node) to the
+* outside of the intersection (last node). Node attributes with **left** and **right** in their name are also
+* defined in the direction of the node declaration. This allows using attributes in a unambigious way also
+* for lanes with biderctional driving. See the following attribuets examples for additianl explanations.
+*
+* @field localNode: Attribute states which pertain to this node point
+* @field disabled: Attribute states which are disabled at this node point
+* @field enabled: Attribute states which are enabled at this node point and which remain enabled until disabled or the lane ends
+* @field data: Attributes which require an additional data values some of these are local to the node point, while others
+*              persist with the provided values until changed and this is indicated in each entry
+* @field dWidth: A value added to the current lane width at this node and from this node onwards, in 1cm steps
+*               lane width between nodes are a linear taper between pts the value of zero shall not be sent here.
+* @field dElevation: A value added to the current Elevation at this node from this node onwards, in 10cm steps
+*                    elevations between nodes are a linear taper between pts the value of zero shall not be sent here
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeAttributeSetXY ::= SEQUENCE {
+  localNode    NodeAttributeXYList OPTIONAL,
+  disabled     SegmentAttributeXYList OPTIONAL,
+  enabled      SegmentAttributeXYList OPTIONAL,
+  data         LaneDataAttributeList OPTIONAL,
+  dWidth       Offset-B10 OPTIONAL,
+  dElevation   Offset-B10 OPTIONAL,
+  regional     SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-NodeAttributeSetXY}} OPTIONAL,
+  ...
+}
+
+/**
+* This DE is an enumerated list of attributes which can pertain to the current node
+* point. The **scope** of these values is limited to the node itself. That is, unlike other types of attributes which can be
+* switched on or off at any given node (and hence pertains to one or more segments), the DE_NodeAttribute is local to the
+* node in which it is found. These attributes are all binary flags in that they do not need to convey any additional data. Other
+* attributes allow sending short data values to reflect a setting which is set and persists in a similar fashion.
+*
+*  - reserved:             do not use
+*  - stopLine:             point where a mid-path stop line exists. See also **do not block** for segments
+*  - roundedCapStyleA:     Used to control final path rounded end shape with edge of curve at final point in a circle
+*  - roundedCapStyleB:     Used to control final path rounded end shape with edge of curve extending 50% of width past final point in a circle
+*  - mergePoint:           merge with 1 or more lanes
+*  - divergePoint:         diverge with 1 or more lanes
+*  - downstreamStopLine:   downstream intersection (a 2nd intersection) stop line
+*  - downstreamStartNode:  downstream intersection (a 2nd intersection) start node
+*  - closedToTraffic:      where a pedestrian may NOT go to be used during construction events
+*  - safeIsland:           a pedestrian safe stopping point also called a traffic island
+*                          This usage described a point feature on a path, other entries can describe a path
+*  - curbPresentAtStepOff: the sidewalk to street curb is NOT angled where it meets the edge of the roadway (user must step up/down)
+*  - hydrantPresent:       Or other services access
+*
+* @note: See usage examples in [ISO TS 19091] G.8.2.8
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeAttributeXY ::= ENUMERATED {
+  reserved,
+  stopLine,
+  roundedCapStyleA,
+  roundedCapStyleB,
+  mergePoint,
+  divergePoint,
+  downstreamStopLine,
+  downstreamStartNode,
+  closedToTraffic,
+  safeIsland,
+  curbPresentAtStepOff,
+  hydrantPresent,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref NodeAttributeXY entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeAttributeXYList ::= SEQUENCE (SIZE(1..8)) OF NodeAttributeXY
+
+/**
+* A 64-bit node type with lat-long values expressed in one tenth of a micro degree.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-LLmD-64b ::= SEQUENCE {
+  lon  Longitude,
+  lat  Latitude
+}
+
+/**
+* A 20-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-20b ::= SEQUENCE {
+  x  Offset-B10,
+  y  Offset-B10
+}
+
+/**
+* A 22-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-22b ::= SEQUENCE {
+  x  Offset-B11,
+  y  Offset-B11
+}
+
+/**
+* A 24-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-24b ::= SEQUENCE {
+  x  Offset-B12,
+  y  Offset-B12
+}
+
+/**
+* A 26-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-26b ::= SEQUENCE {
+  x  Offset-B13,
+  y  Offset-B13
+}
+
+/**
+* A 28-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-28b ::= SEQUENCE {
+  x  Offset-B14,
+  y  Offset-B14
+}
+
+/**
+* A 32-bit node type with offset values from the last point in X and Y.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Node-XY-32b ::= SEQUENCE {
+  x  Offset-B16,
+  y  Offset-B16
+}
+
+/**
+* This DF provides the sequence of signed offset node point values for determining the Xs and Ys
+* (and possibly Width or Zs when present), using the then current Position3D object to build a path for the centerline of
+* the subject lane type. Each X,Y point is referred to as a Node Point. The straight line paths between these points are
+* referred to as Segments.
+* All nodes may have various optional attributes the state of which can vary along the path and which are enabled and
+* disabled by the sequence of objects found in the list of node structures. Refer to the explanatory text in Section 11 for a
+* description of how to correctly encode and decode this type of the data element. As a simple example, a motor vehicle
+* lane may have a section of the overall lane path marked "do not block", indicating that vehicles should not come to a stop
+* and remain in that region. This is encoded in the Node data structures by an element in one node to indicate the start of
+* the "do not block" lane attributes at a given offset, and then by a termination element when this attribute is set false. Other
+* types of elements in the segment choice allow inserting attributes containing data values affecting the segment or the
+* node.
+*
+* @field nodes: a lane made up of two or more XY node points and any attributes defined in those nodes
+* @field computed: a lane path computed by translating the data defined by another lane
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeListXY ::= CHOICE {
+  nodes     NodeSetXY,
+  computed  ComputedLane,
+  ...
+}
+
+/**
+* This DF presents a structure to hold different sized data frames for a single node
+* point in a lane. Nodes are described in terms of X and Y offsets in units of 1 centimeter (when zoom is 1:1). Changes in
+* elevation and in the lane width can be expressed in a similar way with the optional Attributes data entry which appears
+* alongside the NodeOffsetPoint in use.
+*
+* The choice of which node type is driven by the magnitude (size) of the offset data to be encoded. When the distance from
+* the last node point is smaller, the smaller entries can (and should) be chosen
+* Each single selected node is computed as an X and Y offset from the prior node point unless one of the entries reflecting
+* a complete lat-long representation is selected. In this case, subsequent entries become offsets from that point. This ability
+* was added for assistance with the development, storage, and back office exchange of messages where message size is
+* not a concern and should not be sent over the air due to its additional message payload size.
+*
+* The general usage guidance is to construct the content of each lane node point with the smallest possible element to
+* conserve message size. However, using an element which is larger than needed is not a violation of the ASN.1 rules.
+*
+* @field node-XY1:    node is within 5.11m of last node
+* @field node-XY2:    node is within 10.23m of last node
+* @field node-XY3:    node is within 20.47m of last node
+* @field node-XY4:    node is within 40.96m of last node
+* @field node-XY5:    node is within 81.91m of last node
+* @field node-XY6:    node is within 327.67m of last node
+* @field node-LatLon: node is a full 32b Lat/Lon range
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeOffsetPointXY ::= CHOICE {
+  node-XY1         Node-XY-20b,
+  node-XY2         Node-XY-22b,
+  node-XY3         Node-XY-24b,
+  node-XY4         Node-XY-26b,
+  node-XY5         Node-XY-28b,
+  node-XY6         Node-XY-32b,
+  node-LatLon      Node-LLmD-64b,
+  regional         RegionalExtension {{Reg-NodeOffsetPointXY}}
+}
+
+/**
+* This DF presents a structure to hold data for a single node point in a path. Each selected node
+* has an X and Y offset from the prior node point (or a complete lat-long representation in some cases) as well as optional
+* attribute information. The node list for a lane (or other object) is made up of a sequence of these to describe the desired
+* path. The X,Y points are selected to reflect the centerline of the path with sufficient accuracy for the intended applications.
+* Simple lanes can be adequately described with only two node points, while lanes with curvature may require more points.
+* Changes to the lane width and elevation can be expressed in the NodeAttributes entry, as well as various attributes that
+* pertain to either the current node point or to one of more subsequent segments along the list of lane node points. As a
+* broad concept, NodeAttributes are used to describe aspects of the lane that persist for only a portion of the overall lane
+* path (either at a node or over a set of segments).
+* A further description of the use of the NodeOffsetPoint and the Attributes data concepts can be found in the data
+* dictionary entries for each one. Note that each allows regional variants to be supported as well.
+*
+* @field delta:      A choice of which X,Y offset value to use this includes various delta values as well a regional choices.
+* @field attributes: Any optional Attributes which are needed. This includes changes to the current lane width and elevation.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeXY ::= SEQUENCE {
+  delta       NodeOffsetPointXY,
+  attributes  NodeAttributeSetXY OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of Node entries using XY offsets.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+NodeSetXY ::= SEQUENCE (SIZE(2..63)) OF NodeXY
+
+/** This DF is the ODG Addition for Legancy R09 telegrams.
+* 
+* @field reportingPoint: reporting point as of R09 (maps to R09 field M Meldepunktnummer)
+* @field priorityLevel:  priority level as of R09 (maps to R09 field P Prioritaet)
+* @field length:         train length point as of R09 (maps to R09 field A Zuglaenge)
+* @field route:          route as of R09 (maps to R09 field K Kursnummer)
+* @field line:           line as of R09 (maps to R09 field L Liniennummer)
+* @field direction:      direction as of R09 (maps to R09 field H Richtung von Hand)
+* @field tour:           tour as of R09 (maps to R09 field Z Zielnummer)
+* @field version:        version of R09
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+OcitRequestorDescriptionContainer ::= SEQUENCE {
+  reportingPoint      ReportingPoint OPTIONAL,
+  priorityLevel       PriorityLevel OPTIONAL,
+  length              TrainLength OPTIONAL,
+  route               RouteNumber OPTIONAL,
+  line                LineNumber OPTIONAL,
+  direction           TransitDirection OPTIONAL,
+  tour                TourNumber OPTIONAL,
+  version             VersionId OPTIONAL,
+  ...
+}
+
+/**
+* This DF is a sequence of lane IDs which refers to lane objects that overlap or overlay the current lane's spatial path.
+*
+* Contains the unique ID numbers for any lane object which have spatial paths that overlay (run on top of, and not
+* simply cross with) the current lane.
+* Such as a train path that overlays a motor vehicle lane object for a roadway segment.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+OverlayLaneList ::= SEQUENCE (SIZE(1..5)) OF LaneID
+
+/**
+* This DF consists of various parameters of quality used to model the accuracy of the
+* positional determination with respect to each given axis.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PositionalAccuracy ::= SEQUENCE {
+   semiMajor     SemiMajorAxisAccuracy,
+   semiMinor     SemiMinorAxisAccuracy,
+   orientation   SemiMajorAxisOrientation
+}
+
+/**
+* This DF combines multiple related bit fields into a single concept.
+*
+* @field pos:       confidence for both horizontal directions
+* @field elevation: confidence for vertical direction
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PositionConfidenceSet ::= SEQUENCE {
+   pos        PositionConfidence,
+   elevation  ElevationConfidence
+}
+
+/**
+* This DF provides a precise location in the WGS-84 coordinate system, from which short
+* offsets may be used to create additional data using a flat earth projection centered on this location. Position3D is typically
+* used in the description of maps and intersections, as well as signs and traveler data.
+*
+* @field lat: Latitude in 1/10th microdegrees
+* @field long: Longitude in 1/10th microdegrees
+* @field elevation: The elevation information is defined by the regional extension (see module ETSI-ITS-DSRC-AddGrpC). 
+*                   Therefore, the **elevation** data element of **DF_Position3D** is not used.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Position3D ::= SEQUENCE {
+  lat        Latitude,
+  long       Longitude,
+  elevation  Elevation  OPTIONAL,
+  regional   SEQUENCE (SIZE(1..4)) OF
+             RegionalExtension {{Reg-Position3D}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of RegionalSignalControlZone entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PreemptPriorityList ::= SEQUENCE (SIZE(1..32)) OF SignalControlZone
+
+/**
+* This DF is used to convey a regulatory speed about a lane, lanes, or roadway segment.
+*
+* @field type: The type of regulatory speed which follows
+* @field speed: The speed in units of 0.02 m/s
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RegulatorySpeedLimit ::= SEQUENCE {
+  type        SpeedLimitType,
+  speed       Velocity
+}
+
+/**
+* This DF is used to provide identity information about a selected vehicle or users.
+* This data frame is typically used with fleet type vehicles which can (or which must) safely release such information for use
+* with probe measurements or with other interactions (such as a signal request).
+*
+* @field id:               The ID used in the CAM of the requestor. This ID is presumed not to change during the exchange.
+* @field type:             Information regarding all type and class data about the requesting vehicle
+* @field position:         The location of the requesting vehicle
+* @field name:             A human readable name for debugging use
+* @field routeName:        A string for transit operations use
+* @field transitStatus:    current vehicle state (loading, etc.)
+* @field transitOccupancy: current vehicle occupancy
+* @field transitSchedule:  current vehicle schedule adherence
+* @field regional:         optional region specific data.
+* @field ocit:             Extension container for Legacy R09 data (as defined by [OCIT]).
+*
+* @note: Note that the requestor description elements which are used when the request (the req) is made differ from
+*        those used when the status of an active or pending request is reported (the ack). Typically, when reporting the status to
+*        other parties, less information is required and only the temporaryID (contained in the VehicleID) and request number (a
+*        unique ID used in the orginal request) are used.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestorDescription ::= SEQUENCE {
+  id                VehicleID,
+  type              RequestorType OPTIONAL,
+  position          RequestorPositionVector OPTIONAL,
+  name              DescriptiveName OPTIONAL,
+  routeName         DescriptiveName OPTIONAL,
+  transitStatus     TransitVehicleStatus OPTIONAL,
+  transitOccupancy  TransitVehicleOccupancy OPTIONAL,
+  transitSchedule   DeltaTime OPTIONAL,
+  regional          SEQUENCE (SIZE(1..4)) OF RegionalExtension {{Reg-RequestorDescription}} OPTIONAL,
+  ...,
+  ocit OcitRequestorDescriptionContainer -- Extension for OCIT in V2.2.1
+}
+
+/**
+* This DF provides a report of the requestor's position, speed, and heading.
+* Used by a vehicle or other type of user to request services and at other times when the larger FullPositionVector is not required.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestorPositionVector ::= SEQUENCE {
+  position           Position3D,
+  heading            Angle OPTIONAL,
+  speed              TransmissionAndSpeed OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used when a DSRC-equipped device is requesting service from another
+* device. The most common use case is when a vehicle is requesting a signal preemption or priority service call from the
+* signal controller in an intersection. This data frame provides the details of the requestor class taxonomy required to
+* support the request. Depending on the precise use case and the local implementation, these details can vary
+* considerably. As a result, besides the basic role of the vehicle, the other classification systems supported are optional. It
+* should also be observed that often only a subset of the information in the RequestorType data frame is used to report the
+* "results" of such a request to others. As an example, a police vehicle might request service based on being in a police
+* vehicle role (and any further sub-type if required) and on the type of service call to which the vehicle is then responding
+* (perhaps a greater degree of emergency than another type of call), placing these information elements in the
+* RequestorType, which is then part of the Signal Request Message (SRM). This allows the roadway operator to define
+* suitable business rules regarding how to reply. When informing the requestor and other nearby drivers of the outcome,
+* using the Signal Status Message (SSM) message, only the fact that the preemption was granted or denied to some
+* vehicle with a unique request ID is conveyed.
+*
+* @field role:     Basic role of this user at this time.
+* @field subrole:  A local list with role based items.
+* @field request:  A local list with request items
+* @field iso3883:  Additional classification details
+* @field hpmsType: HPMS classification types
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestorType ::= SEQUENCE {
+  role         BasicVehicleRole,
+  subrole      RequestSubRole OPTIONAL,
+  request      RequestImportanceLevel OPTIONAL,
+  iso3883      Iso3833VehicleType OPTIONAL,
+  hpmsType     VehicleType OPTIONAL,
+  regional     RegionalExtension {{Reg-RequestorType}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to assign (or bind) a single RestrictionClassID data
+* element to a list of all user classes to which it applies. A collection of these bindings is conveyed in the
+* RestrictionClassList data frame in the MAP message to travelers. The established index is then used in the lane object of
+* the MAP message, in the ConnectTo data frame, to qualify to whom a signal group ID applies when it is sent by the SPAT
+* message about a movement.
+*
+* @field id: the unique value (within an intersection or local region) that is assigned to this group of users.
+* @field users: The list of user types/classes to which this restriction ID applies.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionClassAssignment ::= SEQUENCE {
+  id       RestrictionClassID,
+  users    RestrictionUserTypeList
+}
+
+/**
+* This DF is used to enumerate a list of user classes which belong to a given
+* assigned index. The resulting collection is treated as a group by the signal controller when it issues movement data
+* (signal phase information) with the GroupID for this group. This data frame is typically static for long periods of time
+* (months) and conveyed to the user by means of the MAP message.
+*
+* @note: The overall restriction class assignment process allows dynamic support within the framework of the common
+*        message set for the various special cases that some signalized intersections must support. While the assigned value
+*        needs to be unique only within the scope of the intersection that uses it, the resulting assignment lists will tend to be static
+*        and stable for regional deployment areas such as a metropolitan area based on their operational practices and needs.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionClassList ::= SEQUENCE (SIZE(1..254)) OF RestrictionClassAssignment
+
+/**
+* This DF is used to provide a means to select one, and only one, user type or class
+* from a number of well-known lists. The selected entry is then used in the overall Restriction Class assignment process to
+* indicate that a given GroupID (a way of expressing a movement in the SPAT/MAP system) applies to (is restricted to) this
+* class of user.
+*
+* @field basicType: a set of the most commonly used types.
+* @field regional:  optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionUserType ::= CHOICE {
+  basicType   RestrictionAppliesTo,
+  regional    SEQUENCE (SIZE(1..4)) OF
+              RegionalExtension {{Reg-RestrictionUserType}},
+  ...
+}
+
+/**
+* This DF consists of a list of @ref RestrictionUserType entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionUserTypeList ::= SEQUENCE (SIZE(1..16)) OF  RestrictionUserType
+
+/**
+* This DF consists of a list of GenericLane entries used to describe a segment of roadway.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadLaneSetList ::= SEQUENCE (SIZE(1..255)) OF GenericLane
+
+/**
+* This DF is used to convey theRoadSegmentID which is unique to a given road segment of interest,
+* and also the RoadRegulatorID assigned to the region in which it is operating (when required).
+*
+* @field region: a globally unique regional assignment value typically assigned to a regional DOT authority the value zero shall be used for testing needs.
+* @field id:     a unique mapping to the road segment in question within the above region of use during its period of assignment and use
+*                note that unlike intersectionID values, this value can be reused by the region.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadSegmentReferenceID ::= SEQUENCE {
+  region  RoadRegulatorID OPTIONAL,
+  id      RoadSegmentID
+}
+
+/**
+* This DF is a complete description of a RoadSegment including its geometry and its
+* allowed navigational paths (independent of any additional regulatory restrictions that may apply over time or from user
+* classification) and any current disruptions such as a work zone or incident event.
+*
+* @field name: some descriptive text.
+* @field id: a globally unique value for the segment.
+* @field revision: .
+* @field refPoint: the reference from which subsequent data points are offset until a new point is used.
+* @field laneWidth: Reference width used by all subsequent lanes unless a new width is given.
+* @field speedLimits: Reference regulatory speed limits used by all subsequent lanes unless a new speed is given.
+* @field roadLaneSet: Data describing disruptions in the RoadSegment such as work zones etc will be added here.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadSegment ::= SEQUENCE {
+  name        DescriptiveName OPTIONAL,
+  id          RoadSegmentReferenceID,
+  revision    MsgCount,
+  refPoint    Position3D,
+  laneWidth   LaneWidth OPTIONAL,
+  speedLimits SpeedLimitList OPTIONAL,
+  roadLaneSet RoadLaneSetList,
+  regional    SEQUENCE (SIZE(1..4)) OF
+              RegionalExtension {{Reg-RoadSegment}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref RoadSegment entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadSegmentList ::= SEQUENCE (SIZE(1..32)) OF RoadSegment
+
+/**
+* This DF is a collection of data values used to convey RTCM information between users. It
+* is not required or used when sending RTCM data from a corrections source to end users (from a base station to devices
+* deployed in the field which are called rovers).
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RTCMheader ::= SEQUENCE {
+   status     GNSSstatus,
+   offsetSet  AntennaOffsetSet
+}
+
+/**
+* This DF consists of a list of @ref RTCMmessage entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RTCMmessageList ::= SEQUENCE (SIZE(1..5)) OF RTCMmessage
+
+/**
+* This DF consists of a list of @ref SegmentAttributeXY entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SegmentAttributeXYList ::= SEQUENCE (SIZE(1..8)) OF SegmentAttributeXY
+
+/**
+* This DF is a dummy placeholder to contain a regional SignalControlZone DF.
+* It is not used, yet here for backwards compatibility.
+*
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalControlZone ::=  SEQUENCE {
+  zone  RegionalExtension {{Reg-SignalControlZone}},
+  ...
+}
+
+/**
+* This DF is used to contain information regarding the entity that requested a given
+* signal behavior. In addition to the VehicleID, the data frame also contains a request reference number used to uniquely
+* refer to the request and some basic type information about the request maker which may be used by other parties.
+*
+* @field id: to uniquely identify the requester and the specific request to all parties.
+* @field request: to uniquely identify the requester and the specific request to all parties.
+* @field sequenceNumber: to uniquely identify the requester and the specific request to all parties.
+* @field role: vehicle role
+* @field typeData: Used when addition data besides the role is needed, at which point the role entry above is not sent.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalRequesterInfo ::= SEQUENCE {
+  id             VehicleID,
+  request        RequestID,
+  sequenceNumber MsgCount,
+  role           BasicVehicleRole OPTIONAL,
+  typeData       RequestorType OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used (as part of a request message) to request either a priority or a preemption service
+* from a signalized intersection. It relates the intersection ID as well as the specific request information. Additional
+* information includes the approach and egress values or lanes to be used.
+*
+* @field id: the unique ID of the target intersection
+* @field requestID: The unique requestID used by the requestor
+* @field requestType: The type of request or cancel for priority or preempt use when a prior request is canceled, only the requestID is needed.
+* @field inBoundLane: desired entry approach or lane.
+* @field outBoundLane: desired exit approach or lane. the value zero is used to indicate intent to stop within the intersection.
+* @field regional: optional region specific data.
+*
+* @note: In typical use either an approach or a lane number would be given, this indicates the requested
+*        path through the intersection to the degree it is known.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalRequest ::= SEQUENCE {
+  id            IntersectionReferenceID,
+  requestID     RequestID,
+  requestType   PriorityRequestType,
+  inBoundLane   IntersectionAccessPoint,
+  outBoundLane  IntersectionAccessPoint OPTIONAL,
+  regional      SEQUENCE (SIZE(1..4)) OF
+                RegionalExtension {{Reg-SignalRequest}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref SignalRequest entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalRequestList ::= SEQUENCE (SIZE(1..32)) OF SignalRequestPackage
+
+/**
+* This DF contains both the service request itself (the preemption and priority
+* details and the inbound-outbound path details for an intersection) and the time period (start and end time) over which this
+* service is sought from one single intersection. One or more of these packages are contained in a list in the Signal
+* Request Message (SREM).
+*
+* @field request:  The specific request to the intersection contains IntersectionID, request type, requested action (approach/lane request).
+* @field minute:   Time period start.
+* @field second:   Time period start.
+* @field duration: The duration value is used to provide a short interval that extends the ETA so that the requesting vehicle can arrive at
+*                  the point of service with uncertainty or with some desired duration of service. This concept can be used to avoid needing
+*                  to frequently update the request. The requester must update the ETA and duration values if the
+*                  period of services extends beyond the duration time. It should be assumed that if the vehicle does not clear the
+*                  intersection when the duration is reached, the request will be cancelled and the intersection will revert to normal operation.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalRequestPackage ::= SEQUENCE {
+  request        SignalRequest,
+  minute         MinuteOfTheYear OPTIONAL,
+  second         DSecond OPTIONAL,
+  duration       DSecond OPTIONAL,
+  regional       SEQUENCE (SIZE(1..4)) OF
+                 RegionalExtension {{Reg-SignalRequestPackage}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is used to provide the status of a single intersection to others, including any active
+* preemption or priority state in effect.
+*
+* @field sequenceNumber: changed whenever the below contents have change
+* @field id:             this provides a unique mapping to the intersection map in question which provides complete location
+*                        and approach/movement/lane data as well as zones for priority/preemption.
+* @field sigStatus:      a list of detailed status containing all priority or preemption state data, both active and pending,
+*                        and who requested it requests which are denied are also listed here for a short period of time.
+* @field regional: optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatus ::= SEQUENCE {
+  sequenceNumber MsgCount,
+  id             IntersectionReferenceID,
+  sigStatus      SignalStatusPackageList,
+  regional       SEQUENCE (SIZE(1..4)) OF
+                 RegionalExtension {{Reg-SignalStatus}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF consists of a list of @ref SignalStatus entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatusList ::= SEQUENCE (SIZE(1..32)) OF SignalStatus
+
+/**
+* This DF consists of a list of @ref SignalStatusPackage entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatusPackageList ::= SEQUENCE (SIZE(1..32)) OF SignalStatusPackage
+
+/**
+* This DF contains all the data needed to describe the preemption or priority state
+* of the signal controller with respect to a given request and to uniquely identify the party who requested that state to occur.
+* It should be noted that this data frame describes both active and anticipated states of the controller. A requested service
+* may not be active when the message is created and issued. A requested service may be rejected. This structure allows
+* the description of pending requests that have been granted (accepted rather than rejected) but are not yet active and
+* being serviced. It also provides for the description of rejected requests so that the initial message is acknowledged
+* (completing a dialog using the broadcast messages).
+*
+* @field requester:  The party that made the initial SREM request.
+* @field inboundOn:  estimated lane / approach of vehicle.
+* @field outboundOn: estimated lane / approach of vehicle.
+* @field minute:     The Estimated Time of Arrival (ETA) when the service is requested. This data echos the data of the request.
+* @field second:     seconds part of ETA.
+* @field duration:   duration part of ETA.
+* @field status:     Status of request, this may include rejection.
+* @field regional:   optional region specific data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalStatusPackage ::= SEQUENCE {
+  requester    SignalRequesterInfo OPTIONAL,
+  inboundOn    IntersectionAccessPoint,
+  outboundOn   IntersectionAccessPoint OPTIONAL,
+  minute       MinuteOfTheYear OPTIONAL,
+  second       DSecond OPTIONAL,
+  duration     DSecond OPTIONAL,
+  status       PrioritizationResponseStatus,
+  regional     SEQUENCE (SIZE(1..4)) OF
+               RegionalExtension {{Reg-SignalStatusPackage}} OPTIONAL,
+  ...
+}
+
+/**
+* This DF is a single data frame combining multiple related bit fields into one concept.
+*
+* @field heading: confidence for heading values
+* @field speed: confidence for speed values
+* @field throttle: confidence for throttle values 
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SpeedandHeadingandThrottleConfidence ::= SEQUENCE {
+   heading   HeadingConfidenceDSRC,
+   speed     SpeedConfidenceDSRC,
+   throttle  ThrottleConfidence
+}
+
+/**
+* This DF consists of a list of SpeedLimit entries.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SpeedLimitList ::= SEQUENCE (SIZE(1..9)) OF RegulatorySpeedLimit
+
+/**
+* This DE relates the type of speed limit to which a given speed refers.
+*
+* - unknown: Speed limit type not available
+* - maxSpeedInSchoolZone: Only sent when the limit is active
+* - maxSpeedInSchoolZoneWhenChildrenArePresent: Sent at any time
+* - maxSpeedInConstructionZone: Used for work zones, incident zones, etc. where a reduced speed is present
+* - vehicleMinSpeed: Regulatory speed limit for general traffic
+* - vehicleMaxSpeed: Regulatory speed limit for general traffic
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SpeedLimitType ::= ENUMERATED {
+   unknown,
+   maxSpeedInSchoolZone,
+   maxSpeedInSchoolZoneWhenChildrenArePresent,
+   maxSpeedInConstructionZone,
+   vehicleMinSpeed,
+   vehicleMaxSpeed,
+   vehicleNightMaxSpeed,
+   truckMinSpeed,
+   truckMaxSpeed,
+   truckNightMaxSpeed,
+   vehiclesWithTrailersMinSpeed,
+   vehiclesWithTrailersMaxSpeed,
+   vehiclesWithTrailersNightMaxSpeed,
+   ...
+}
+
+/**
+* This DF conveys details about the timing of a phase within a movement. The core
+* data concept expressed is the time stamp (time mark) at which the related phase will change to the next state. This is
+* often found in the MinEndTime element, but the other elements may be needed to convey the full concept when adaptive
+* timing is employed.
+*
+* @field startTime: is used to relate when the phase itself started or is expected to start. This in turn allows the
+*                   indication that a set of time change details refers to a future phase, rather than a currently active phase.
+*                   By this method, timing information about "pre" phase events (which are the short transitional phase used to alert OBUs to
+*                   an impending green/go or yellow/caution phase) and the longer yellow-caution phase data is supported in the same form
+*                   as various green/go phases. In theory, the time change details could be sent for a large sequence of phases if the signal
+*                   timing was not adaptive and the operator wished to do so. In practice, it is expected only the "next" future phase will
+*                   commonly be sent. It should be noted that this also supports the sending of time periods regarding various red phases;
+*                   however, this is not expected to be done commonly.
+* @field minEndTime: is used to convey the earliest time possible at which the phase could change, except when
+*                   unpredictable events relating to a preemption or priority call disrupt a currently active timing plan. In a phase where the
+*                   time is fixed (as in a fixed yellow or clearance time), this element shall be used alone. This value can be viewed as the
+*                   earliest possible time at which the phase could change, except when unpredictable events relating to a preemption or
+*                   priority call come into play and disrupt a currently active timing plan.
+* @field maxEndTime: is used to convey the latest time possible which the phase could change,
+*                   except when unpredictable events relating to a preemption or priority
+*                   call come into play and disrupt a currently active timing plan. In a phase where the time is fixed (as in a fixed yellow or
+*                   clearance time), this element shall be used alone.
+* @field likelyTime: is used to convey the most likely time the phase changes. This occurs between MinEndTime and
+*                   MaxEndTime and is only relevant for traffic-actuated control programs. This time might be calculated out of logged
+*                   historical values, detected events (e.g., from inductive loops), or from other sources.
+* @field confidence: is used to convey basic confidence data about the likelyTime.
+* @field nextTime:   is used to express a general (and presumably less precise) value regarding when this phase will
+*                   next occur. This is intended to be used to alert the OBU when the next green/go may occur so that various ECO driving
+*                   applications can better manage the vehicle during the intervening stopped time.
+*
+* @note: Remarks: It should be noted that all times are expressed as absolute values and not as countdown timer values. When
+*          the stated time mark is reached, the state changes to the next state. Several technical reasons led to this choice; among
+*          these was that with a countdown embodiment, there is an inherent need to update the remaining time every time a SPAT
+*          message is issued. This would require re-formulating the message content as as well as cryptographically signing the
+*          message each time. With the use of absolute values (time marks) chosen here, the current count down time when the
+*          message is created is added to the then-current time to create an absolute value and can be used thereafter without
+*          change. The message content need only change when the signal controller makes a timing decision to be published. This
+*          allows a clean separation of the logical functions of message creation from the logical functions of message scheduling
+*          and sending, and fulfills the need to minimize further real time processing when possible. This Standard sets no limits on
+*          where each of these functions is performed in the overall roadside system.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TimeChangeDetails ::= SEQUENCE {
+  startTime   TimeMark               OPTIONAL,
+  minEndTime  TimeMark,
+  maxEndTime  TimeMark               OPTIONAL,
+  likelyTime  TimeMark               OPTIONAL,
+  confidence  TimeIntervalConfidence OPTIONAL,
+  nextTime    TimeMark               OPTIONAL
+}
+
+/**
+* This DE is used to relate a moment in UTC (Coordinated Universal Time)-based time when a
+* signal phase is predicted to change, with a precision of 1/10 of a second. A range of 60 full minutes is supported and it
+* can be presumed that the receiver shares a common sense of time with the sender which is kept aligned to within a
+* fraction of a second or better.
+*
+* If there is a need to send a value greater than the range allowed by the data element (over one hour in the future), the
+* value 36000 shall be sent and shall be interpreted to indicate an indefinite future time value. When the value to be used is
+* undefined or unknown a value of 36001 shall be sent. Note that leap seconds are also supported.
+*
+* The value is tenths of a second in the current or next hour in units of 1/10th second from UTC time
+* - A range of 0-36000 covers one hour
+* - The values 35991..35999 are used when a leap second occurs
+* - The value 36000 is used to indicate time >3600 seconds
+* - 36001 is to be used when value undefined or unknown
+*
+* @note: Note that this is NOT expressed in GPS time or in local time
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TimeMark ::= INTEGER (0..36001)
+
+/**
+* This DF expresses the speed of the vehicle and the state of the transmission.
+* The transmission state of **reverse** can be used as a sign value for the speed element when needed.
+*
+* @field transmisson: state of the transmission
+* @field speed: speed of the vehicle
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TransmissionAndSpeed ::= SEQUENCE {
+  transmisson   TransmissionState,
+  speed         Velocity
+}
+
+/**
+* This DF is used to contain either a (US) TemporaryID or an (EU) StationID in a simple frame.
+* These two different value domains are used to uniquely identify a vehicle or other object in these two regional DSRC
+* value is unavailable but needed by another type of user (such as the roadside infrastructure sending data about an
+* environments. In normal use cases, this value changes over time to prevent tracking of the subject vehicle. When this
+* unequipped vehicle), the value zero shall be used. A typical restriction on the use of this value during a dialog or other
+* exchange is that the value remains constant for the duration of that exchange. Refer to the performance requirements for
+* a given application for details.
+*
+* @field entityID: representation for US stations
+* @field stationID: representation for EU stations
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+VehicleID ::= CHOICE {
+  entityID     TemporaryID,
+  stationID    StationID
+}
+
+/**
+* This DE relates the type of travel to which a given speed refers. This element is
+* typically used as part of an @ref AdvisorySpeed data frame for signal phase and timing data.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+AdvisorySpeedType ::= ENUMERATED {
+  none       (0),
+  greenwave  (1),
+  ecoDrive   (2),
+  transit    (3),
+  ...
+}
+
+/**
+* This DE relates the allowed (possible) maneuvers from a lane, typically a
+* motorized vehicle lane. It should be noted that in practice these values may be further restricted by vehicle class, local
+* regulatory environment and other changing conditions.
+*
+* @note: When used by data frames, the AllowedManeuvers data concept is used in two places: optionally in the
+*    generic lane structure to list all possible maneuvers (as in what that lane can do at its stop line point); and within each
+*    ConnectsTo structure. Each ConnectsTo structure contains a list used to provide a single valid maneuver in the context of
+*    one lane connecting to another in the context of a signal phase that applies to that maneuver. It should be noted that, in
+*    some intersections, multiple outbound lanes can be reached by the same maneuver (for example two independent left
+*    turns might be found in a 5-legged intersection) but that to reach any given lane from the stop line of another lane is
+*    always a single maneuver item (hence the use of a list). Not all intersection descriptions may contain an exhaustive set of
+*    ConnectsTo information (unsignalized intersections for example) and in such cases the AllowedManeuvers in the generic
+*    lane structure can be used. If present in both places, the data expressed in the generic lane shall not conflict with the data
+*    found in the collection of ConnectsTo entries.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+AllowedManeuvers ::= BIT STRING {
+  maneuverStraightAllowed      (0),
+  maneuverLeftAllowed          (1),
+  maneuverRightAllowed         (2),
+  maneuverUTurnAllowed         (3),
+  maneuverLeftTurnOnRedAllowed (4),
+  maneuverRightTurnOnRedAllowed (5),
+  maneuverLaneChangeAllowed    (6),
+  maneuverNoStoppingAllowed    (7),
+  yieldAllwaysRequired         (8),
+  goWithHalt                   (9),
+  caution                      (10),
+  reserved1                    (11)
+} (SIZE(12))
+
+/**
+* This DE is used to describe an angular measurement in units of degrees. This data
+* element is often used as a heading direction when in motion. In this use, the current heading of the sending device is
+* expressed in unsigned units of 0.0125 degrees from North, such that 28799 such degrees represent 359.9875 degrees.
+* North shall be defined as the axis defined by the WGS-84 coordinate system and its reference ellipsoid. Any angle "to the
+* east" is defined as the positive direction. A value of 28800 shall be used when Angle is unavailable.
+*
+* @note: Note that other heading and angle data elements of various sizes and precisions are found in other parts of this standard and in ITS.
+* @unit: 0.0125 degrees
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Angle ::= INTEGER (0..28800)
+
+/**
+* This DE is used to relate the index of an approach, either ingress or egress within the
+* subject lane. In general, an approach index in the context of a timing movement is not of value in the MAP and SPAT
+* process because the lane ID and signal group ID concepts handle this with more precision. This value can also be useful
+* as an aid as it can be used to indicate the gross position of a moving object (vehicle) when its lane level accuracy is
+* unknown. This value can also be used when a deployment represents sets of lanes as groups without further details (as is
+* done in Japan).
+*
+* @note: zero to be used when valid value is unknown
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ApproachID ::= INTEGER (0..15)
+
+/**
+* This DE provides a means to indicate the current role that a DSRC device is playing
+* This is most commonly employed when a vehicle needs to take on another role in order to send certain DSRC message
+* types. As an example, when a public safety vehicle such as a police car wishes to send a signal request message (SRM)
+* to an intersection to request a preemption service, the vehicle takes on the role "police" from the below list in both the
+* SRM message itself and also in the type of security CERT which is sent (the SSP in the CERT it used to identify the
+* requester as being of type "police" and that they are allowed to send this message in this way). The BasicVehicleRole
+* entry is often used and combined with other information about the requester as well, such as details of why the request is
+* being made.
+*
+* - 0 - `basicVehicle`     - Light duty passenger vehicle type
+* - 1 - `publicTransport`  - Used in EU for Transit us
+* - 2 - `specialTransport` - Used in EU (e.g. heavy load)
+* - 3 - `dangerousGoods`   - Used in EU for any HAZMAT
+* - 4 - `roadWork`         - Used in EU for State and Local DOT uses
+* - 5 - `roadRescue`       - Used in EU and in the US to include tow trucks.
+* - 6 - `emergency`        - Used in EU for Police, Fire and Ambulance units
+* - 7 - `safetyCar`        - Used in EU for Escort vehicles
+* - 8 - `none-unknown`     - added to follow current SAE style guidelines
+* - 9 - `truck`            - Heavy trucks with additional BSM rights and obligations
+* - 10 - `motorcycle`      - Motorcycle
+* - 11 - `roadSideSource`  - For infrastructure generated calls such as fire house, rail infrastructure, roadwork site, etc.
+* - 12 - `police`          - Police vehicle
+* - 13 - `fire`            - Firebrigade
+* - 14 - `ambulance`       - (does not include private para-transit etc.)
+* - 15 - `dot`             - all roadwork vehicles
+* - 16 - `transit`         - all transit vehicles
+* - 17 - `slowMoving`      - to also include oversize etc.
+* - 18 - `stopNgo`         - to include trash trucks, school buses and others
+* - 19 - `cyclist`         - bicycles
+* - 20 - `pedestrian`      - also includes those with mobility limitations
+* - 21 - `nonMotorized`    - other, horse drawn, etc.
+* - 22 - `military`        - military vehicles
+*
+* @note: It should be observed that devices can at times change their roles (i.e. a fire operated by a volunteer
+*    fireman can assume a fire role for a period of time when in service, or a pedestrian may assume a cyclist role when using
+*    a bicycle). It should be observed that not all devices (or vehicles) can assume all roles, nor that a given
+*    device in a given role will be provided with a security certificate (CERT) that has suitable SSP credentials to provide the
+*    ability to send a particular message or message content. The ultimate responsibility to determine what role is to be used,
+*    and what CERTs would be provided for that role (which in turn controls the messages and message content that can be
+*    sent within SAE-defined PSIDs) rests with the regional deployment.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+BasicVehicleRole ::= ENUMERATED {
+  basicVehicle     (0),
+  publicTransport  (1),
+  specialTransport (2),
+  dangerousGoods   (3),
+  roadWork         (4),
+  roadRescue       (5),
+  emergency        (6),
+  safetyCar        (7),
+  none-unknown     (8),
+  truck            (9),
+  motorcycle      (10),
+  roadSideSource  (11),
+  police          (12),
+  fire            (13),
+  ambulance       (14),
+  dot             (15),
+  transit         (16),
+  slowMoving      (17),
+  stopNgo         (18),
+  cyclist         (19),
+  pedestrian      (20),
+  nonMotorized    (21),
+  military        (22),
+  ...,
+  tram            (23)   -- Extension in V2.2.1
+}
+
+/**
+* The DSRC style day is a simple value consisting of integer values from zero to 31. The value of zero shall represent an unknown value.
+*
+* @unit: days
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DDay ::= INTEGER (0..31)
+
+/**
+* This DE provides the final angle used in the last point of the lane path. Used to "cant" the stop line of the lane.
+*
+* With an angle range from negative 150 to positive 150 in one degree steps where zero is directly
+* along the axis or the lane center line as defined by the two closest points.
+*
+* @unit: degree
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DeltaAngle ::= INTEGER (-150..150)
+
+/**
+* This DE provides a time definition for an object's schedule adherence (typically a transit
+* vehicle) within a limited range of time. When the reporting object is ahead of schedule, a positive value is used; when
+* behind, a negative value is used. A value of zero indicates schedule adherence. This value is typically sent from a vehicle
+* to the traffic signal controller's RSU to indicate the urgency of a signal request in the context of being within schedule or
+* not. In another use case, the traffic signal controller may advise the transit vehicle to speed up (DeltaTime > 0) or to slow
+* down (DeltaTime < 0) to optimize the transit vehicle distribution driving along a specific route (e.g. a Bus route).
+*
+* Supporting a range of +/- 20 minute in steps of 10 seconds:
+* - the value of `-121` shall be used when more than -20 minutes
+* - the value of `+120` shall be used when more than +20 minutes
+* - the value `-122` shall be used when the value is unavailable
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DeltaTime ::= INTEGER (-122 .. 121)
+
+/**
+* This DE is used in maps and intersections to provide a human readable and
+* recognizable name for the feature that follows. It is typically used when debugging a data flow and not in production use.
+* One key exception to this general rule is to provide a human-readable string for disabled travelers in the case of
+* crosswalks and sidewalk lane objects.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DescriptiveName ::= IA5String (SIZE(1..63))
+
+/**
+* The DSRC hour consists of integer values from zero to 23 representing the hours within a day. The value of 31 shall
+* represent an unknown value. The range 24 to 30 is used in some transit applications to represent schedule adherence.
+*
+* @unit: hours
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DHour ::= INTEGER (0..31)
+
+/**
+* The DSRC style minute is a simple value consisting of integer values from zero to 59 representing the minutes
+* within an hour. The value of 60 shall represent an unknown value.
+*
+* @unit: minutes
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DMinute ::= INTEGER (0..60)
+
+/**
+* The DSRC month consists of integer values from one to 12, representing the month within a year. The value of 0
+* shall represent an unknown value.
+*
+* @unit: months
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DMonth ::= INTEGER (0..12)
+
+/**
+* The DSRC (time zone) offset consists of a signed integer representing an hour and minute value set from -14:00 to
+* +14:00, representing all the world’s local time zones in units of minutes. The value of zero (00:00) may also represent an
+* unknown value. Note some time zones are do not align to hourly boundaries.
+*
+* @unit: minutes from UTC time
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DOffset ::= INTEGER (-840..840)
+
+/**
+* This DE is an integer value expressing the offset in a defined axis from a
+* reference lane number from which a computed lane is offset. The measurement is taken from the reference lane center
+* line to the new center line, independent of any width values. The units are a signed value with an LSB of 1 cm.
+*
+* @unit: cm
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DrivenLineOffsetLg ::= INTEGER (-32767..32767)
+
+/**
+* The DrivenLineOffsetSmall data element is an integer value expressing the offset in a defined axis from a reference
+* lane number from which a computed lane is offset. The measurement is taken from the reference lane center line to the
+* new center line, independent of any width values. The units are a signed value with an LSB of 1 cm.
+*
+* @unit: cm
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DrivenLineOffsetSm ::= INTEGER (-2047..2047)
+
+/**
+* The DSRC second expressed in this DE consists of integer values from zero to 60999, representing the
+* milliseconds within a minute. A leap second is represented by the value range 60000 to 60999. The value of 65535 shall
+* represent an unavailable value in the range of the minute. The values from 61000 to 65534 are reserved.
+*
+* @unit: milliseconds
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DSecond ::= INTEGER (0..65535)
+
+/**
+* The DSRC year consists of integer values from zero to 4095 representing the year according to the Gregorian
+* calendar date system. The value of zero shall represent an unknown value.
+*
+* @unit: years
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+DYear ::= INTEGER (0..4095)
+
+/**
+* This DE represents the geographic position above or below the reference ellipsoid (typically WGS-84).
+* The number has a resolution of 1 decimeter and represents an asymmetric range of positive and negative
+* values. Any elevation higher than +6143.9 meters is represented as +61439.
+*
+* Any elevation lower than -409.5 meters is represented as -4095.
+*
+* If the sending device does not know its elevation, it shall encode the Elevation data element with -4096.
+*
+* @note: When a vehicle is being measured, the elevation is taken from the horizontal spatial center of the vehicle
+*        projected downward, regardless of vehicle tilt, to the point where the vehicle meets the road surface.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Elevation ::= INTEGER (-4096..61439)
+
+/**
+* This DE is used to provide the 95% confidence level for the currently reported value of @ref Elevation,
+* taking into account the current calibration and precision of the sensor(s) used to measure and/or
+* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing
+* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element
+* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should
+* be increased accordingly. The frame of reference and axis of rotation used shall be in accordance with that defined in Section 11.
+*
+* - `unavailable` - 0:   B'0000 Not Equipped or unavailable
+* - `elev-500-00` - 1:   B'0001 (500 m)
+* - `elev-200-00` - 2:   B'0010 (200 m)
+* - `elev-100-00` - 3:   B'0011 (100 m)
+* - `elev-050-00` - 4:   B'0100 (50 m)
+* - `elev-020-00` - 5:   B'0101 (20 m)
+* - `elev-010-00` - 6:   B'0110 (10 m)
+* - `elev-005-00` - 7:   B'0111 (5 m)
+* - `elev-002-00` - 8:   B'1000 (2 m)
+* - `elev-001-00` - 9:   B'1001 (1 m)
+* - `elev-000-50` - 10:  B'1010 (50 cm)
+* - `elev-000-20` - 11:  B'1011 (20 cm)
+* - `elev-000-10` - 12:  B'1100 (10 cm)
+* - `elev-000-05` - 13:  B'1101 (5 cm)
+* - `elev-000-02` - 14:  B'1110 (2 cm)
+* - `elev-000-01` - 15:  B'1111 (1 cm)
+*
+* @note: Encoded as a 4 bit value
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ElevationConfidence ::= ENUMERATED {
+   unavailable (0),
+   elev-500-00 (1),
+   elev-200-00 (2),
+   elev-100-00 (3),
+   elev-050-00 (4),
+   elev-020-00 (5),
+   elev-010-00 (6),
+   elev-005-00 (7),
+   elev-002-00 (8),
+   elev-001-00 (9),
+   elev-000-50 (10),
+   elev-000-20 (11),
+   elev-000-10 (12),
+   elev-000-05 (13),
+   elev-000-02 (14),
+   elev-000-01 (15)
+}
+
+/**
+* This DE provides the type of fuel used by a vehicle.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+FuelType ::= INTEGER (0..15)
+   unknownFuel FuelType  ::= 0
+   gasoline FuelType     ::= 1
+   ethanol FuelType      ::= 2
+   diesel FuelType       ::= 3
+   electric FuelType     ::= 4
+   hybrid FuelType       ::= 5
+   hydrogen FuelType     ::= 6
+   natGasLiquid FuelType ::= 7
+   natGasComp FuelType   ::= 8
+   propane FuelType      ::= 9
+
+/**
+* This DE is used to relate the current state of a GPS/GNSS rover or base system in terms
+* of its general health, lock on satellites in view, and use of any correction information. Various bits can be asserted (made
+* to a value of one) to reflect these values. A GNSS set with unknown health and no tracking or corrections would be
+* represented by setting the unavailable bit to one. A value of zero shall be used when a defined data element is
+* unavailable. The term "GPS" in any data element name in this standard does not imply that it is only to be used for GPS-
+* type GNSS systems.
+*
+* - `unavailable`              - 0: Not Equipped or unavailable
+* - `isHealthy`                - 1:
+* - `isMonitored`              - 2:
+* - `baseStationType`          - 3: Set to zero if a moving base station, or if a rover device (an OBU), Set to one if it is a fixed base station
+* - `aPDOPofUnder5`            - 4: A dilution of precision greater than 5
+* - `inViewOfUnder5`           - 5: Less than 5 satellites in view
+* - `localCorrectionsPresent`  - 6: DGPS type corrections used
+* - `networkCorrectionsPresen` - 7: RTK type corrections used
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+GNSSstatus ::= BIT STRING {
+   unavailable               (0),
+   isHealthy                 (1),
+   isMonitored               (2),
+   baseStationType           (3),
+   aPDOPofUnder5             (4),
+   inViewOfUnder5            (5),
+   localCorrectionsPresent   (6),
+   networkCorrectionsPresent (7)
+ } (SIZE(8))
+
+/**
+* The DE_HeadingConfidence data element is used to provide the 95% confidence level for the currently reported
+* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing
+* value of DE_Heading, taking into account the current calibration and precision of the sensor(s) used to measure and/or
+* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element
+* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should
+* be increased accordingly. The frame of reference and axis of rotation used shall be in accordance with that defined Section 11.
+*
+* - `unavailable`   - 0: B'000 Not Equipped or unavailable
+* - `prec10deg`     - 1: B'010 10 degrees
+* - `prec05deg`     - 2: B'011 5 degrees
+* - `prec01deg`     - 3: B'100 1 degrees
+* - `prec0-1deg`    - 4: B'101 0.1 degrees
+* - `prec0-05deg`   - 5: B'110 0.05 degrees
+* - `prec0-01deg`   - 6: B'110 0.01 degrees
+* - `prec0-0125deg` - 7: B'111 0.0125 degrees, aligned with heading LSB
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+HeadingConfidenceDSRC ::= ENUMERATED {
+   unavailable   (0),
+   prec10deg     (1),
+   prec05deg     (2),
+   prec01deg     (3),
+   prec0-1deg    (4),
+   prec0-05deg   (5),
+   prec0-01deg   (6),
+   prec0-0125deg (7)
+}
+
+/**
+* This DE provides the current heading of the sending device, expressed in unsigned units of
+* 0.0125 degrees from North such that 28799 such degrees represent 359.9875 degrees. North shall be defined as the axis
+* prescribed by the WGS-84 coordinate system and its reference ellipsoid. Headings "to the east" are defined as the
+* positive direction. A value of 28800 shall be used when unavailable. This element indicates the direction of motion of the
+* device. When the sending device is stopped and the trajectory (path) over which it traveled to reach that location is well
+* known, the past heading may be used.
+*
+* Value provides a range of 0 to 359.9875 degrees
+*
+* @unit: Note that other heading data elements of various sizes and precisions are found in other parts of this standard
+*        and in ITS. This element should no longer be used for new work: the @ref Angle entry is preferred.
+*
+* @unit: 0.0125 degrees
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+HeadingDSRC ::= INTEGER (0..28800)
+
+/**
+* This DE is used within a region to uniquely define an intersection within that country or region in a 16-bit
+* field. Assignment rules are established by the regional authority associated with the RoadRegulatorID under which this
+* IntersectionID is assigned. Within the region the policies used to ensure an assigned value’s uniqueness before that value
+* is reused (if ever) is the responsibility of that region. Any such reuse would be expected to occur over a long epoch (many years).
+* The values zero through 255 are allocated for testing purposes
+*
+* @note:  Note that the value assigned to an intersection will be unique within a given regional ID only
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionID ::= INTEGER (0..65535)
+
+/**
+* The Intersection Status Object contains Advanced Traffic Controller (ATC) status information that may be sent to
+* local OBUs as part of the SPAT process.
+*
+* With bits as defined:
+* - `manualControlIsEnabled`                - 0: Timing reported is per programmed values, etc. but person at cabinet can manually request that certain intervals are terminated early (e.g. green).
+* - `stopTimeIsActivated`                   - 1: And all counting/timing has stopped.
+* - `failureFlash`                          - 2: Above to be used for any detected hardware failures, e.g. conflict monitor as well as for police flash
+* - `fixedTimeOperation`                    - 5: Schedule of signals is based on time only (i.e. the state can be calculated)
+* - `trafficDependentOperation`             - 6: Operation is based on different levels of traffic parameters (requests, duration of gaps or more complex parameters)
+* - `standbyOperation`                      - 7: Controller: partially switched off or partially amber flashing
+* - `failureMode`                           - 8: Controller has a problem or failure in operation
+* - `off`                                   - 9: Controller is switched off
+* - `recentMAPmessageUpdate`                - 10: Map revision with content changes
+* - `recentChangeInMAPassignedLanesIDsUsed` - 11: Change in MAP's assigned lanes used (lane changes) Changes in the active lane list description
+* - `noValidMAPisAvailableAtThisTime`       - 12: MAP (and various lanes indexes) not available
+* - `noValidSPATisAvailableAtThisTime`      - 13: SPAT system is not working at this time
+* - Bits 14,15 reserved at this time and shall be zero
+*
+* @note: All zeros indicate normal operating mode with no recent changes. The duration of the term **recent** is defined by the system performance requirement in use.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+IntersectionStatusObject ::= BIT STRING {
+  manualControlIsEnabled                (0),
+  stopTimeIsActivated                   (1),
+  failureFlash                          (2),
+  preemptIsActive                       (3),
+  signalPriorityIsActive                (4),
+  fixedTimeOperation                    (5),
+  trafficDependentOperation             (6),
+  standbyOperation                      (7),
+  failureMode                           (8),
+  off                                   (9),
+  recentMAPmessageUpdate                (10),
+  recentChangeInMAPassignedLanesIDsUsed (11),
+  noValidMAPisAvailableAtThisTime       (12),
+  noValidSPATisAvailableAtThisTime      (13)
+} (SIZE(16))
+
+/**
+* This DE relates specific properties found in a Barrier or Median lane type (a type of lane object used to separate traffic lanes).
+* It should be noted that various common lane attribute properties (such as travel directions and allowed movements or maneuvers) can be found in other entries.
+*
+* With bits as defined:
+* - `median-RevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - Bits 10-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Barrier ::= BIT STRING {
+  median-RevocableLane     (0),
+  median                   (1),
+  whiteLineHashing         (2),
+  stripedLines             (3),
+  doubleStripedLines       (4),
+  trafficCones             (5),
+  constructionBarrier      (6),
+  trafficChannels          (7),
+  lowCurbs                 (8),
+  highCurbs                (9)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in a bicycle lane type. It should be noted that various common lane attribute properties
+* (such as travel directions and allowed movements or maneuvers) can be found in other entries.
+*
+* With bits as defined:
+* - `bikeRevocableLane`       - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - `pedestrianUseAllowed`    - 1: The path allows pedestrian traffic, if not set, this mode is prohibited
+* - `isBikeFlyOverLane`       - 2: path of lane is not at grade
+* - `fixedCycleTime`          - 3: the phases use preset times, i.e. there is not a **push to cross** button
+* - `biDirectionalCycleTimes` - 4: ped walk phases use different SignalGroupID for each direction. The first SignalGroupID in the first Connection
+*                                  represents **inbound** flow (the direction of travel towards the first node point) while second SignalGroupID in the
+*                                  next Connection entry represents the `outbound` flow. And use of RestrictionClassID entries in the Connect follow this same pattern in pairs.
+* - `isolatedByBarrier`           - 5: The lane path is isolated by a fixed barrier
+* - `unsignalizedSegmentsPresent` - 6: The lane path consists of one of more segments which are not part of a signal group ID
+* - Bits 7-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Bike ::= BIT STRING {
+  bikeRevocableLane       (0),
+  pedestrianUseAllowed    (1),
+  isBikeFlyOverLane       (2),
+  fixedCycleTime          (3),
+  biDirectionalCycleTimes (4),
+  isolatedByBarrier       (5),
+  unsignalizedSegmentsPresent  (6)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in a crosswalk lane type. It should be noted that various common lane attribute properties
+* (such as travel directions and allowed movements or maneuvers) can be found in other entries.
+*
+* With bits as defined:
+* - `crosswalkRevocableLane`  - 0:  this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - `bicyleUseAllowed`        - 1: The path allows bicycle traffic, if not set, this mode is prohibited
+* - `isXwalkFlyOverLane`      - 2: path of lane is not at grade
+* - `fixedCycleTime`          - 3: ped walk phases use preset times. i.e. there is not a **push to cross** button
+* - `biDirectionalCycleTimes` - 4:  ped walk phases use different SignalGroupID for each direction. The first SignalGroupID
+*                                   in the first Connection represents **inbound** flow (the direction of travel towards the first
+*                                   node point) while second SignalGroupID in the next Connection entry represents the **outbound**
+*                                   flow. And use of RestrictionClassID entries in the Connect follow this same pattern in pairs.
+* - `hasPushToWalkButton`     - 5: Has a demand input
+* - `audioSupport`            - 6:  audio crossing cues present
+* - `rfSignalRequestPresent`  - 7: Supports RF push to walk technologies
+* - `unsignalizedSegmentsPresent` - 8: The lane path consists of one of more segments which are not part of a signal group ID
+* - Bits 9-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Crosswalk ::= BIT STRING {
+  crosswalkRevocableLane  (0),
+  bicyleUseAllowed        (1),
+  isXwalkFlyOverLane      (2),
+  fixedCycleTime          (3),
+  biDirectionalCycleTimes (4),
+  hasPushToWalkButton     (5),
+  audioSupport            (6),
+  rfSignalRequestPresent  (7),
+  unsignalizedSegmentsPresent  (8)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in a vehicle parking lane type. It should be noted that various common lane attribute
+* properties can be found in other entries.
+*
+* With bits as defined:
+* - `parkingRevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - `doNotParkZone`        - 3: used to denote fire hydrants as well as short disruptions in a parking zone
+* - `noPublicParkingUse`   - 6: private parking, as in front of private property
+* - Bits 7-15 reserved and set to zero*
+*
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Parking ::= BIT STRING {
+  parkingRevocableLane         (0),
+  parallelParkingInUse         (1),
+  headInParkingInUse           (2),
+  doNotParkZone                (3),
+  parkingForBusUse             (4),
+  parkingForTaxiUse            (5),
+  noPublicParkingUse           (6)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in a sidewalk lane type. It should be noted that various common lane attribute properties
+* (such as travel directions and allowed movements or maneuvers) can be found in other entries.
+*
+* With bits as defined:
+* - `sidewalk-RevocableLane`- 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present.
+* - `bicyleUseAllowed`      - 1: The path allows bicycle traffic, if not set, this mode is prohibited
+* - `isSidewalkFlyOverLane` - 2: path of lane is not at grade
+* - `walkBikes`             - 3: bike traffic must dismount and walk
+* - Bits 4-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Sidewalk ::= BIT STRING {
+  sidewalk-RevocableLane  (0),
+  bicyleUseAllowed        (1),
+  isSidewalkFlyOverLane   (2),
+  walkBikes               (3)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in various types of ground striping lane
+* types. This includes various types of painted lane ground striping and iconic information needs to convey information in a
+* complex intersection. Typically, this consists of visual guidance for drivers to assist them to connect across the
+* intersection to the correct lane. Such markings are typically used with restraint and only under conditions when the
+* geometry of the intersection makes them more beneficial than distracting. It should be noted that various common lane
+* attribute properties (such as travel directions and allowed movements or maneuvers) can be found in other entries.
+*
+* With bits as defined:
+* - `stripeToConnectingLanesRevocableLane` - 0: this lane may be activated or not activated based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - `stripeToConnectingLanesAhead` - 5: the stripe type should be presented to the user visually to reflect stripes in the intersection for the type of movement indicated.
+* - Bits 6-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Striping ::= BIT STRING {
+  stripeToConnectingLanesRevocableLane      (0),
+  stripeDrawOnLeft                          (1),
+  stripeDrawOnRight                         (2),
+  stripeToConnectingLanesLeft               (3),
+  stripeToConnectingLanesRight              (4),
+  stripeToConnectingLanesAhead              (5)
+} (SIZE (16))
+
+/**
+* This DE relates specific properties found in a tracked vehicle lane types (trolley
+* and train lanes). The term “rail vehicle” can be considered synonymous. In this case, the term does not relate to vehicle
+* types with tracks or treads. It should be noted that various common lane attribute properties (such as travel directions and
+* allowed movements or maneuvers) can be found in other entries. It should also be noted that often this type of lane object
+* does not clearly relate to an approach in the traditional traffic engineering sense, although the message set allows
+* assigning a value when desired.
+*
+* With bits as defined:
+* - `spec-RevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present.
+* - Bits 5-15 reserved and set to zero
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-TrackedVehicle ::= BIT STRING {
+  spec-RevocableLane         (0),
+  spec-commuterRailRoadTrack (1),
+  spec-lightRailRoadTrack    (2),
+  spec-heavyRailRoadTrack    (3),
+  spec-otherRailType         (4)
+} (SIZE (16))
+
+
+/**
+* This DE relates specific properties found in a vehicle lane type. This data element provides a means to denote that the use of a lane
+* is restricted to certain vehicle types. Various common lane attribute properties (such as travel directions and allowed movements or maneuvers)
+* can be found in other entries.
+*
+* With bits as defined:
+* - `isVehicleRevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present
+* - `isVehicleFlyOverLane`   - 1: path of lane is not at grade
+* - `permissionOnRequest`    - 7: e.g. to inform about a lane for e-cars
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneAttributes-Vehicle ::= BIT STRING {
+  isVehicleRevocableLane       (0),
+  isVehicleFlyOverLane         (1),
+  hovLaneUseOnly               (2),
+  restrictedToBusUse           (3),
+  restrictedToTaxiUse          (4),
+  restrictedFromPublicUse      (5),
+  hasIRbeaconCoverage          (6),
+  permissionOnRequest          (7)
+} (SIZE (8,...))
+
+/**
+* This DE is used to state a connection index for a lane to lane connection. It is used to
+* relate this connection between the lane (defined in the MAP) and any dynamic clearance data sent in the SPAT. It should
+* be noted that the index may be shared with other lanes (for example, two left turn lanes may share the same dynamic
+* clearance data). It should also be noted that a given lane to lane connection may be part of more than one GroupID due
+* to signal phase considerations, but will only have one ConnectionID. The ConnectionID concept is not used (is not
+* present) when dynamic clearance data is not provided in the SPAT.
+*
+* @note: It should be noted that the LaneConnectionID is used as a means to index to a connection description
+*        between two lanes. It is not the same as the laneID, which is the unique index to each lane itself.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneConnectionID ::= INTEGER (0..255)
+
+/**
+* This DE is used to denote the allowed direction of travel over a lane object. By convention, the lane object is always described
+* from the stop line outwards away from the intersection. Therefore, the ingress direction is from the end of the path to the stop
+* line and the egress direction is from the stop line outwards.
+*
+* It should be noted that some lane objects are not used for travel and that some lane objects allow bi-directional travel.
+*
+* With bits as defined:
+* - Allowed directions of travel in the lane object
+* - All lanes are described from the stop line outwards
+*
+* @field ingressPath: travel from rear of path to front is allowed
+*
+* @field egressPath: travel from front of path to rear is allowed
+*
+* @note: No Travel, i.e. the lane object type does not support travel (medians, curbs, etc.) is indicated by not
+*        asserting any bit value Bi-Directional Travel (such as a ped crosswalk) is indicated by asserting both of the bits.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneDirection ::= BIT STRING {
+  ingressPath     (0),
+  egressPath      (1)
+} (SIZE (2))
+
+/**
+* This DE conveys an assigned index that is unique within an intersection. It is used to refer to
+* that lane by other objects in the intersection map data structure. Lanes may be ingress (inbound traffic) or egress
+* (outbound traffic) in nature, as well as barriers and other types of specialty lanes. Each lane (each lane object) is
+* assigned a unique ID. The Lane ID, in conjunction with the intersection ID, forms a regionally unique way to address a
+* specific lane in that region.
+*
+* - the value 0 shall be used when the lane ID is not available or not known
+* - the value 255 is reserved for future use
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneID ::= INTEGER (0..255)
+
+/**
+* Large @ref MapData descriptions are not possible to be broadcast with a single message and have to be
+* fragmented using two or more messages over the air. Therefore, the LayerID allows defining an
+* index for fragmentation of large @ref MapData descriptions. The fragmentation of the messages shall be
+* executed on application layer. The fragmentation occurs on an approach base. This means that almost a
+* complete approach (e.g. lanes, connectsTo, etc.) has to be included within a fragment.
+* The decimal value of the **layerID** is used to define the amount of maximum @ref MapData fragments. The
+* lower value defines the actual fragment.
+*
+* Example:
+* If a MapData consists of three fragments (e.g. three approaches), the fragments are identified as follows:
+* - `31` - first fragment of three (e.g. approach south);
+* - `33` - third fragment of three (e.g. approach north).
+* - `32` - second fragment of three (e.g. approach west);
+*
+* If there are only two fragments, the fragment identification will be 21, 22.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LayerID ::= INTEGER (0..100)
+
+/**
+* This DE is used to uniquely identify the type of information to be found in a layer of a geographic map fragment such as an intersection.
+*
+* @field `mixedContent`: two or more of the below types
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LayerType ::= ENUMERATED {
+  none,
+  mixedContent,
+  generalMapData,
+  intersectionData,
+  curveData,
+  roadwaySectionData,
+  parkingAreaData,
+  sharedLaneData,
+  ...
+}
+
+/**
+* This DE conveys the width of a lane in LSB units of 1 cm. Maximum value for a lane is 327.67 meters in width
+*
+* @units: cm
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+LaneWidth ::= INTEGER (0..32767)
+
+/**
+* This DE is used to provide the R09 line information.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+LineNumber ::= INTEGER (0..4294967295)
+
+/**
+* The angle at which another lane path meets the current lanes at the node point. Typically found in the node
+* attributes and used to describe the angle of the departing or merging lane. Note that oblique and obtuse angles are allowed.
+*
+* The value `-180` shall be used to represent data is not available or unknown
+*
+* @unit: 1.5 degrees from north
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MergeDivergeNodeAngle ::= INTEGER (-180..180)
+
+/**
+* This DE expresses the number of elapsed minutes of the current year in the time system being used (typically UTC time).
+*
+* It is typically used to provide a longer range time stamp indicating when a message was created.
+* Taken together with the DSecond data element, it provides a range of one full year with a resolution of 1 millisecond.
+*
+* The value 527040 shall be used for invalid.
+*
+* @note: It should be noted that at the yearly roll-over point there is no "zero" minute, in the same way that there was
+*        never a "year zero" at the very start of the common era (BC -> AD). By using the number of elapsed whole minutes here
+*        this issue is avoided and the first valid value of every new year is zero, followed by one, etc. Leap years are
+*        accommodated, as are leap seconds in the DSecond data concept.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MinuteOfTheYear ::= INTEGER (0..527040)
+
+/**
+* This DE provides the overall current state of the movement (in many cases a signal state), including its core phase state
+*  and an indication of whether this state is permissive or protected.
+*
+* It is expected that the allowed transitions from one state to another will be defined by regional deployments. Not all
+* regions will use all states; however, no new states are to be defined. In most regions a regulatory body provides precise
+* legal definitions of these state changes. For example, in the US the MUTCD is used, as is indicated in the US regional
+* variant of the above image. In various regions and modes of transportation, the visual expression of these states varies
+* (the precise meaning of various color combinations, shapes, and/or flashing etc.). The below definition is designed to to
+* be independent of these regional conventions.
+*
+* Values:
+* - `unavailable` - 0:         This state is used for unknown or error
+* - `dark` - 1:                The signal head is dark (unlit)
+* - `stop-Then-Proceed` - 2:   Often called **flashing red**
+*                              Driver Action:
+*                              - Stop vehicle at stop line.
+*                              - Do not proceed unless it is safe.
+*                              Note that the right to proceed either right or left when it is safe may be contained in the lane description to
+*                              handle what is called a **right on red**
+* - `stop-And-Remain` - 3:     e.g. called **red light**
+*                              Driver Action:
+*                              - Stop vehicle at stop line.
+*                              - Do not proceed.
+*                              Note that the right to proceed either right or left when it is safe may be contained in the lane description to
+*                              handle what is called a **right on red**
+* - `pre-Movement` - 4:        Not used in the US, red+yellow partly in EU
+*                              Driver Action:
+*                              - Stop vehicle.
+*                              - Prepare to proceed (pending green)
+*                              - (Prepare for transition to green/go)
+* - `permissive-Movement-Allowed` - 5: Often called **permissive green**
+*                              Driver Action:
+*                              - Proceed with caution,
+*                              - must yield to all conflicting traffic
+*                              Conflicting traffic may be present in the intersection conflict area
+* - `protected-Movement-Allowed` - 6: Often called **protected green**
+*                              Driver Action:
+*                              - Proceed, tossing caution to the wind, in indicated (allowed) direction.
+* - `permissive-clearance` - 7: Often called **permissive yellow**.
+*                              The vehicle is not allowed to cross the stop bar if it is possible
+*                              to stop without danger.
+*                              Driver Action:
+*                              - Prepare to stop.
+*                              - Proceed if unable to stop,
+*                              - Clear Intersection.
+*                              Conflicting traffic may be present in the intersection conflict area
+* - `protected-clearance` - 8:  Often called **protected yellow**
+*                              Driver Action:
+*                              - Prepare to stop.
+*                              - Proceed if unable to stop, in indicated direction (to connected lane)
+*                              - Clear Intersection.
+* - `caution-Conflicting-Traffic` - 9: Often called **flashing yellow**
+*                              Often used for extended periods of time
+*                              Driver Action:
+*                              - Proceed with caution,
+*                              Conflicting traffic may be present in the intersection conflict area
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MovementPhaseState ::= ENUMERATED {
+  unavailable (0),
+  dark (1),
+  stop-Then-Proceed (2),
+  stop-And-Remain (3),
+  pre-Movement (4),
+  permissive-Movement-Allowed (5),
+  protected-Movement-Allowed (6),
+  permissive-clearance (7),
+  protected-clearance (8),
+  caution-Conflicting-Traffic (9)
+}
+
+/**
+* This DE is used to provide a sequence number within a stream of messages with the same DSRCmsgID and from the same sender.
+* A sender may initialize this element to any value in the range 0-127 when sending the first message with a given DSRCmsgID,
+* or if the sender has changed identity (e.g. by changing its TemporaryID) since sending the most recent message with that DSRCmsgID.
+*
+* Depending on the application the sequence number may change with every message or may remain fixed during a stream of messages when the content within each
+* message has not changed from the prior message sent. For this element, the value after 127 is zero.
+*
+* The receipt of a non-sequential MsgCount value (from the same sending device and message type) implies that one or
+* more messages from that sending device may have been lost, unless MsgCount has been re-initialized due to an identity
+* change.
+*
+* @note: In the absence of additional requirements defined in a standard using this data element, the follow guidelines shall be used.
+*
+* In usage, some devices change their Temporary ID frequently, to prevent identity tracking, while others do not. A change
+* in Temporary ID data element value (which also changes the message contents in which it appears) implies that the
+* MsgCount may also change value.
+*
+* If a sender is composing a message with new content with a given DSRCmsgID, and the TemporaryID has not changed
+* since it sent the previous message, the sender shall increment the previous value.
+* If a sender is composing a message with new content with a given DSRCmsgID, and the TemporaryID has changed since
+* it sent the previous message, the sender may set the MsgCount element to any valid value in the range (including
+* incrementing the previous value).
+*
+* If a sender is composing a message with the same content as the most recent message with the same DSRCmsgID, and
+* less than 10 seconds have elapsed since it sent the previous message with that DSRCmsgID, the sender will use the
+* same MsgCount as sent in the previous message.
+*
+* If a sender is composing a message with the same content as the most recent message with the same DSRCmsgID, and
+* at least 10 seconds have elapsed since it sent the previous message with that DSRCmsgID, the sender may set the
+* MsgCount element to any valid value in the range; this includes the re-use of the previous value.
+*
+* If a sending device sends more than one stream of messages from message types that utilize the MsgCount element, it
+* shall maintain a separate MsgCount state for each message type so that the MsgCount value in a given message
+* identifies its place in the stream of that message type. The MsgCount element is a function only of the message type in a
+* given sending device, not of the one or more applications in that device which may be sending the same type of message.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+MsgCount ::= INTEGER (0..127)
+
+/**
+* A 9-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to
+* indicate an unknown value.
+* a range of +- 2.55 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B09 ::= INTEGER (-256..255)
+
+/**
+* A 10-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to
+* indicate an unknown value.
+* a range of +- 5.11 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B10 ::= INTEGER (-512..511)
+
+/**
+* An 11-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to
+* indicate an unknown value.
+* a range of +- 10.23 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B11 ::= INTEGER (-1024..1023)
+
+/**
+* A 12-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of
+* reference, non-vehicle centric coordinate frames of reference, offset is positive to the East (X) and to the North (Y)
+* directions. The most negative value shall be used to indicate an unknown value.
+* a range of +- 20.47 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B12 ::= INTEGER (-2048..2047)
+
+/**
+* A 13-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to
+* indicate an unknown value.
+* a range of +- 40.95 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B13 ::= INTEGER (-4096..4095)
+
+/**
+* A 14-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions.
+* a range of +- 81.91 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B14 ::= INTEGER (-8192..8191)
+
+/**
+* A 16-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of
+* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to
+* indicate an unknown value.
+* a range of +- 327.68 meters
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Offset-B16 ::= INTEGER (-32768..32767)
+
+/**
+* This DE is used to provide an indication of whether Pedestrians and/or Bicyclists have been detected in the crossing lane.
+* true if ANY Pedestrians or Bicyclists are detected crossing the target lane or lanes
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PedestrianBicycleDetect ::= BOOLEAN
+
+/**
+* This DE entry is used to provide the 95% confidence level for the currently reported value of
+* entries such as the DE_Position entries, taking into account the current calibration and precision of the sensor(s) used to
+* measure and/or calculate the value. It is used in the horizontal plane. This data element is only to provide the listener with
+* information on the limitations of the sensing system; not to support any type of automatic error correction or to imply a
+* guaranteed maximum error. This data element should not be used for fault detection or diagnosis, but if a vehicle is able
+* to detect a fault, the confidence interval should be increased accordingly. The frame of reference and axis of rotation used
+* shall be accordance with that defined in Section 11 of this standard.
+*
+* - `unavailable` - 0: B'0000 Not Equipped or unavailable
+* - `a500m`       - 1: B'0001 500m or about 5 * 10 ^ -3 decimal degrees
+* - `a200m`       - 2: B'0010 200m or about 2 * 10 ^ -3 decimal degrees
+* - `a100m`       - 3: B'0011 100m or about 1 * 10 ^ -3 decimal degrees
+* - `a50m`        - 4: B'0100 50m or about 5 * 10 ^ -4 decimal degrees
+* - `a20m`        - 5: B'0101 20m or about 2 * 10 ^ -4 decimal degrees
+* - `a10m`        - 6: B'0110 10m or about 1 * 10 ^ -4 decimal degrees
+* - `a5m`         - 7: B'0111 5m or about 5 * 10 ^ -5 decimal degrees
+* - `a2m`         - 8: B'1000 2m or about 2 * 10 ^ -5 decimal degrees
+* - `a1m`         - 9: B'1001 1m or about 1 * 10 ^ -5 decimal degrees
+* - `a50cm`       - 10: B'1010 0.50m or about 5 * 10 ^ -6 decimal degrees
+* - `a20cm`       - 11: B'1011 0.20m or about 2 * 10 ^ -6 decimal degrees
+* - `a10cm`       - 12: B'1100 0.10m or about 1 * 10 ^ -6 decimal degrees
+* - `a5cm`        - 13: B'1101 0.05m or about 5 * 10 ^ -7 decimal degrees
+* - `a2cm`        - 14: B'1110 0.02m or about 2 * 10 ^ -7 decimal degrees
+* - `a1cm`        - 15) B'1111 0.01m or about 1 * 10 ^ -7 decimal degrees
+* - Encoded as a 4 bit value
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PositionConfidence ::= ENUMERATED {
+   unavailable (0),
+   a500m   (1),
+   a200m   (2),
+   a100m   (3),
+   a50m    (4),
+   a20m    (5),
+   a10m    (6),
+   a5m     (7),
+   a2m     (8),
+   a1m     (9),
+   a50cm  (10),
+   a20cm  (11),
+   a10cm  (12),
+   a5cm   (13),
+   a2cm   (14),
+   a1cm   (15)
+ }
+
+/**
+* This DE is used in the @ref PrioritizationResponse data frame to indicate the
+* general status of a prior prioritization request.
+*
+* - `unknown`           - 0: Unknown state
+* - `requested`         - 1: This prioritization request was detected by the traffic controller
+* - `processing`        - 2: Checking request (request is in queue, other requests are prior)
+* - `watchOtherTraffic` - 3: Cannot give full permission, therefore watch for other traffic. Note that other requests may be present
+* - `granted`           - 4: Intervention was successful and now prioritization is active
+* - `rejected`          - 5: The prioritization or preemption request was rejected by the traffic controller
+* - `maxPresence`       - 6: The Request has exceeded maxPresence time. Used when the controller has determined that the requester should then back off and request an alternative.
+* - `reserviceLocked`   - 7: Prior conditions have resulted in a reservice
+*                            locked event: the controller requires the passage of time before another similar request will be accepted
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PrioritizationResponseStatus ::= ENUMERATED {
+  unknown           (0),
+  requested         (1),
+  processing        (2),
+  watchOtherTraffic (3),
+  granted           (4),
+  rejected          (5),
+  maxPresence       (6),
+  reserviceLocked   (7),
+  ...
+}
+
+/**
+* This DE is used to provide the R09 priority.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+PriorityLevel ::= INTEGER (0..255)
+
+/**
+* This DE provides a means to indicate if a request (found in the Signal RequestMessage) represents
+* a new service request, a request update, or a request cancellation for either preemption or priority services.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+PriorityRequestType ::= ENUMERATED {
+  priorityRequestTypeReserved (0),
+  priorityRequest             (1),
+  priorityRequestUpdate       (2),
+  priorityCancellation        (3),
+  ...
+}
+
+/**
+* This DE is used to define regions where unique additional content may be added and
+* used in the message set. The index values defined below represent various regions known at the time of publication. This
+* list is expected to grow over time. The index values assigned here can be augmented by local (uncoordinated)
+* assignments in the allowed range. It should be noted that such a local value is specified in the "REGION" ASN module, so
+* there is no need to edit the DSRC ASN specification of the standard. This process is further described in Section 11.1.
+*
+* - `noRegion` - 0: Use default supplied stubs
+* - `addGrpA`  - 1: USA
+* - `addGrpB`  - 2: Japan
+* - `addGrpC`  - 3: EU
+*
+* @note: new registered regional IDs will be added here
+*        The values 128 and above are for local region use
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RegionId ::= INTEGER (0..255)
+  noRegion     RegionId ::= 0
+  addGrpA      RegionId ::= 1
+  addGrpB      RegionId ::= 2
+  addGrpC      RegionId ::= 3
+
+/**
+* This DE is used to provide the R09 reporting point.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+ReportingPoint ::= INTEGER (0..65535)
+
+/**
+* This DE is used to provide a unique ID between two parties for various dialog exchanges.
+* Combined with the sender's VehicleID (consisting of a TempID or a Station ID), this provides a unique string for some
+* mutually defined period of time. A typical example of use would be a signal preemption or priority request dialog
+* containing multiple requests from one sender (denoted by the unique RequestID with each). When such a request is
+* processed and reflected in the signal status messages, the original sender and the specific request can both be determined.
+*
+* @note: In typical use, this value is simply incremented in a modulo fashion to ensure a unique stream of values for the
+*        device creating it. Any needs for uniqueness across multiple dialogs to one or more parties shall be the responsibility of
+*        the device to manage. There are often normative restrictions on the device changing its TempID during various dialogs
+*        when this data element is used. Further details of these operational concepts can be found in the relevant standards.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestID ::= INTEGER (0..255)
+
+/**
+* This DE is used to state what type of signal request is being made to a signal
+* controller by a DSRC device in a defined role (such as a police vehicle). The levels of the request typically convey a
+* sense of urgency or importance with respect to other demands to allow the controller to use predefined business rules to
+* determine how to respond. These rules will vary in terms of how details of overall importance and urgency are to be
+* ranked, so they are to be implemented locally. As a result of this regional process, the list below should be assigned well-
+* defined meanings by the local deployment. These meaning will typically result in assigning a set of values to list for each
+* vehicle role type that is to be supported.
+*
+* - `requestImportanceLevel1`     1: The least important request
+* - `requestImportanceLevel14`   14: The most important request
+* - `requestImportanceReserved`  15: Reserved for future use
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestImportanceLevel ::= ENUMERATED {
+  requestImportanceLevelUnKnown  (0),
+  requestImportanceLevel1        (1),
+  requestImportanceLevel2        (2),
+  requestImportanceLevel3        (3),
+  requestImportanceLevel4        (4),
+  requestImportanceLevel5        (5),
+  requestImportanceLevel6        (6),
+  requestImportanceLevel7        (7),
+  requestImportanceLevel8        (8),
+  requestImportanceLevel9        (9),
+  requestImportanceLevel10      (10),
+  requestImportanceLevel11      (11),
+  requestImportanceLevel12      (12),
+  requestImportanceLevel13      (13),
+  requestImportanceLevel14      (14),
+  requestImportanceReserved     (15)
+}
+
+/**
+* This DE is used to further define the details of the role which any DSRC device might
+* play when making a request to a signal controller. This value is not always needed. For example, perhaps in a
+* deployment all police vehicles are to be treated equally. The taxonomy of what details are selected to be entered into the
+* list is a regional choice but should be devised to allow the controller to use predefined business rules to respond using the
+* data. As another example, perhaps in a regional deployment a cross-city express type of transit vehicle is given a different
+* service response for the same request than another type of transit vehicle making an otherwise similar request. As a
+* result of this regional process, the list below should be assigned well-defined meanings by the local deployment. These
+* meanings will typically result in assigning a set of values to list for each vehicle role type that is to be supported.
+*
+* - `requestSubRole1`        - 1:  The first type of sub role
+* - `requestSubRole14`       - 14: The last type of sub role
+* - `requestSubRoleReserved` - 15: Reserved for future use
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RequestSubRole ::= ENUMERATED {
+  requestSubRoleUnKnown    (0),
+  requestSubRole1          (1),
+  requestSubRole2          (2),
+  requestSubRole3          (3),
+  requestSubRole4          (4),
+  requestSubRole5          (5),
+  requestSubRole6          (6),
+  requestSubRole7          (7),
+  requestSubRole8          (8),
+  requestSubRole9          (9),
+  requestSubRole10        (10),
+  requestSubRole11        (11),
+  requestSubRole12        (12),
+  requestSubRole13        (13),
+  requestSubRole14        (14),
+  requestSubRoleReserved  (15)
+}
+
+/**
+* The RestrictionAppliesTo data element provides a short list of common vehicle types which may have one or more
+* special movements at an intersection. In general, these movements are not visible to other traffic with signal heads, but
+* the SPAT data reflects the state of the movement. Various restricted movements at an intersection can be expressed
+* using this element to indicate where the movement applies.
+*
+* - `none` :              applies to nothing
+* - `equippedTransit`:    buses etc.
+* - `equippedTaxis`:
+* - `equippedOther`:      other vehicle types with necessary signal phase state reception equipment
+* - `emissionCompliant`:  regional variants with more definitive items also exist
+* - `equippedBicycle`:
+* - `weightCompliant`:
+* - `heightCompliant`:    Items dealing with traveler needs serviced by the infrastructure. These end users (which are not vehicles) are presumed to be suitably equipped
+* - `pedestrians`:
+* - `slowMovingPersons`:
+* - `wheelchairUsers`:
+* - `visualDisabilities`:
+* - `audioDisabilities`:  hearing
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionAppliesTo ::= ENUMERATED {
+  none,
+  equippedTransit,
+  equippedTaxis,
+  equippedOther,
+  emissionCompliant,
+  equippedBicycle,
+  weightCompliant,
+  heightCompliant,
+  pedestrians,
+  slowMovingPersons,
+  wheelchairUsers,
+  visualDisabilities,
+  audioDisabilities,
+  otherUnknownDisabilities,
+  ...
+}
+
+/**
+* This DE defines an intersection-unique value to convey data about classes of users.
+* The mapping used varies with each intersection and is defined in the MAP message if needed. The defined mappings
+* found there are used to determine when a given class is meant. The typical use of this element is to map additional
+* movement restrictions or rights (in both the MAP and SPAT messages) to special classes of users (trucks, high sided
+* vehicles, special vehicles etc.). There is the general presumption that in the absence of this data, any allowed movement
+* extends to all users.
+*
+* An index value to identify data about classes of users the value used varies with each intersection's
+* needs and is defined in the map to the assigned classes of supported users.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RestrictionClassID ::= INTEGER (0..255)
+
+/**
+* This DE is a 16-bit globally unique identifier assigned to an entity responsible for assigning
+* Intersection IDs in the region over which it has such authority. The value zero shall be used for testing, and should only be
+* used in the absence of a suitable assignment. A single entity which assigns intersection IDs may be assigned several
+* RoadRegulatorIDs. These assignments are presumed to be permanent.
+*
+* The value zero shall be used for testing only
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadRegulatorID ::= INTEGER (0..65535)
+
+/**
+* This DE is used to uniquely define a section of roadway within a country or region in a 16-bit field.
+* Assignment rules for this value are established elsewhere and may use regional assignment schemas that vary. Within
+* the region the policies used to ensure an assigned value’s uniqueness before that value is reused is the responsibility of
+* that region. Such reuse is expected to occur, but over somewhat lengthy epoch (months).
+*
+* The values zero to 255 shall be used for testing only
+* Note that the value assigned to an RoadSegment will be
+* unique within a given regional ID only during its use
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadSegmentID ::= INTEGER (0..65535)
+
+/**
+* The RoadwayCrownAngle data element relates the gross tangential angle of the roadway surface with respect to
+* the local horizontal axis and is measured at the indicated part of the lane. This measurement is typically made at the
+* crown (centerline) or at an edge of the lane path. Its typical use is to relate data used in speed warning and traction
+* calculations for the lane segment or roadway segment in which the measurement is taken.
+*
+* - The value -128 shall be used for unknown
+* - The value zero shall be used for angles which are between -0.15 and +0.15
+*
+* @unit: 0.3 degrees of angle over a range of -38.1 to + 38.1 degrees
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RoadwayCrownAngle ::= INTEGER (-128..127)
+
+/**
+* This DE is used to provide the R09 route information.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+RouteNumber ::= INTEGER (0..4294967295)
+
+/**
+* This DE contains the stream of octets of the actual RTCM message that is being sent.
+* The message’s contents are defined in RTCM Standard 10403.1 and in RTCM Standard 10402.1 and its successors.
+* Note that most RTCM messages are considerably smaller than the size limit defined here, but that some messages may
+* need to be broken into smaller messages (as per the rules defined in the RTCM work) in order to be transmitted over DSRC.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RTCMmessage ::= OCTET STRING (SIZE(1..1023))
+
+/**
+* This DE provides the specific revision of the RTCM standard which is being used. This is
+* helpful to know precisely the mapping of the message types to their definitions, as well as some minor transport layer
+* ordering details when received in the mobile unit. All RTCM SC-104 messages follow a common message numbering
+* method (wherein all defined messages are given unique values) which can be decoded from the initial octets of the
+* message. This operation is typically performed by the GNSS rover that consumes the messages, so it is transparent at
+* the DSRC message set level.
+*
+* Values:
+* - `rtcmRev2`:  Std 10402.x et al
+* - `rtcmRev3`:  Std 10403.x et al
+*
+* @note:: In order to fully support the use of networked transport of RTCM corrections (so-called Ntrip systems), the
+*         enumerated list of protocol types provides for all the common types outlined in RTCM Standard 10410.0, Appendix B. It is
+*         anticipated that revisions 3.x and 2.3 will predominate in practice as they do today. It should also be noted that RTCM
+*         standards use the term `byte` for an 8-bit value, while in this standard the term `octet` is used.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+RTCM-Revision ::= ENUMERATED {
+  unknown  (0),
+  rtcmRev2 (1),
+  rtcmRev3 (2),
+  reserved (3),
+  ...
+}
+
+/**
+* A 12-bit signed scaling factor supporting scales from zero (which is not used) to >200%. In this data element, the
+* value zero is taken to represent a value of one (scale 1:1). Values above and below this add or remove exactly 0.05%
+* from the initial value of 100%. Hence, a value of 2047 adds 102.35% to 100%, resulting in a scale of 202.35% exactly (the
+* largest valid scale value). Negative values which would result in an effective final value below zero are not supported. The
+* smallest valid value allowed is -1999 and the remaining negative values are reserved for future definition.
+*
+* @unit: in steps of 0.05 percent
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Scale-B12 ::= INTEGER (-2048..2047)
+
+/**
+* This DE is an index used to map between the internal state machine of one or more signal controllers (or
+* other types of traffic flow devices) and a common numbering system that can represent all possible combinations of active
+* states (movements and phases in US traffic terminology). All possible movement variations are assigned a unique value
+* within the intersection. Conceptually, the ID represents a means to provide a list of lanes in a set which would otherwise
+* need to be enumerated in the message. The values zero and 255 are reserved, so there may up to 254 different signal
+* group IDs within one single intersection. The value 255 represents a protected-Movement-Allowed or permissive-
+* Movement-Allowed condition that exists at all times. This value is applied to lanes, with or without traffic control devices,
+* that operate as free-flow lanes. Typically referred to as Channelized Right/Left Turn Lanes (in right/left-hand drive
+* countries).
+*
+* Values:
+* - the value `0` shall be used when the ID is not available or not known
+* - the value `255` is reserved to indicate a permanent green movement state
+* - therefore a simple 8 phase signal controller device might use 1..9 as its groupIDs
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SignalGroupID ::= INTEGER (0..255)
+
+/**
+* This DE is an enumerated list of attributes about the current lane segment which
+* may be enabled or disabled to indicate the presence or absence of the selected attribute on the segment. A segment is
+* one or more of the straight lines formed between each set of node points. It is common for a segment attribute to persist
+* for more than one set of node points if there is any curvature in the lane itself. The described attributes are all binary flags
+* in that they do not need to convey any additional data. Other attributes allow sending short data values to reflect a setting
+* which is set and persists in a similar fashion.
+*
+* Various values which can be Enabled and Disabled for a lane segment
+* - reserved:
+* - doNotBlock: segment where a vehicle may not come to a stop
+* - whiteLine:  segment where lane crossing not allowed such as the final few meters of a lane 
+* - mergingLaneLeft: indicates porous lanes
+* - mergingLaneRight: indicates porous lanes
+* - curbOnLeft: indicates presence of curbs
+* - curbOnRight: indicates presence of curbs
+* - loadingzoneOnLeft:  loading or drop off zones
+* - loadingzoneOnRight: loading or drop off zones
+* - turnOutPointOnLeft: opening to adjacent street/alley/road
+* - turnOutPointOnRight: opening to adjacent street/alley/road
+* - adjacentParkingOnLeft: side of road parking
+* - adjacentParkingOnRight: side of road parking
+* - adjacentBikeLaneOnLeft: presence of marked bike lanes
+* - adjacentBikeLaneOnRight: presence of marked bike lanes
+* - sharedBikeLane: right of way is shared with bikes who may occupy entire lane width
+* - bikeBoxInFront:
+* - transitStopOnLeft: any form of bus/transit loading, with pull in-out access to lane on left
+* - transitStopOnRight: any form of bus/transit loading, with pull in-out access to lane on right
+* - transitStopInLane: any form of bus/transit loading, in mid path of the lane
+* - sharedWithTrackedVehicle: lane is shared with train or trolley, not used for crossing tracks 
+* - safeIsland: begin/end a safety island in path
+* - lowCurbsPresent: for ADA support
+* - rumbleStripPresent: for ADA support
+* - audibleSignalingPresent: for ADA support
+* - adaptiveTimingPresent: for ADA support
+* - rfSignalRequestPresent: Supports RF push to walk technologies
+* - partialCurbIntrusion: path is blocked by a median or curb but at least 1 meter remains open for use
+*                         and at-grade passage Lane geometry details
+* - taperToLeft: Used to control final path shape (see standard for defined shapes)
+* - taperToRight: Used to control final path shape (see standard for defined shapes)
+* - taperToCenterLine: Used to control final path shape (see standard for defined shapes)
+* - parallelParking: Parking at an angle with the street
+* - headInParking:   Parking at an angle with the street
+* - freeParking:     No restriction on use of parking
+* - timeRestrictionsOnParking: Parking is not permitted at all times
+*                              typically used when the **parking** lane becomes a driving lane at times
+* - costToPark: Used where parking has a cost
+* - midBlockCurbPresent: a protruding curb near lane edge
+* - unEvenPavementPresent: a disjoint height at lane edge
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SegmentAttributeXY ::= ENUMERATED {
+  reserved                  ,
+  doNotBlock                ,
+  whiteLine                 ,
+  mergingLaneLeft           ,
+  mergingLaneRight          ,
+  curbOnLeft                ,
+  curbOnRight               ,
+  loadingzoneOnLeft         ,
+  loadingzoneOnRight        ,
+  turnOutPointOnLeft        ,
+  turnOutPointOnRight       ,
+  adjacentParkingOnLeft     ,
+  adjacentParkingOnRight    ,
+  adjacentBikeLaneOnLeft    ,
+  adjacentBikeLaneOnRight   ,
+  sharedBikeLane            ,
+  bikeBoxInFront            ,
+  transitStopOnLeft         ,
+  transitStopOnRight        ,
+  transitStopInLane         ,
+  sharedWithTrackedVehicle  ,
+  safeIsland                ,
+  lowCurbsPresent           ,
+  rumbleStripPresent        ,
+  audibleSignalingPresent   ,
+  adaptiveTimingPresent     ,
+  rfSignalRequestPresent    ,
+  partialCurbIntrusion      ,
+  taperToLeft               ,
+  taperToRight              ,
+  taperToCenterLine         ,
+  parallelParking           ,
+  headInParking             ,
+  freeParking               ,
+  timeRestrictionsOnParking ,
+  costToPark                ,
+  midBlockCurbPresent       ,
+  unEvenPavementPresent     ,
+  ...
+}
+
+/**
+* This DE is used to express the radius (length) of the semi-major axis of an
+* ellipsoid representing the accuracy which can be expected from a GNSS system in 5cm steps,
+* typically at a one sigma level of confidence.
+*
+* Value is semi-major axis accuracy at one standard dev.
+* - Range 0-12.7 meter, LSB = .05m
+* - 254 = any value equal or greater than 12.70 meter
+* - 255 = unavailable semi-major axis value
+*
+* @unit: 0.05m
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SemiMajorAxisAccuracy ::= INTEGER (0..255)
+
+/**
+* This DE is used to orientate the angle of the semi-major axis of an
+* ellipsoid representing the accuracy which can be expected from a GNSS system with respect to the coordinate system.
+*
+* Value is orientation of semi-major axis
+* - relative to true north (0-359.9945078786 degrees)
+* - LSB units of 360/65535 deg = 0.0054932479
+* - a value of 0 shall be 0 degrees
+* - a value of 1 shall be 0.0054932479 degrees
+* - a value of 65534 shall be 359.9945078786 deg
+* - a value of 65535 shall be used for orientation unavailable
+*
+* @unit: 360/65535 degree
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SemiMajorAxisOrientation ::= INTEGER (0..65535)
+
+/**
+* This DE is used to express the radius of the semi-minor axis of an ellipsoid
+* representing the accuracy which can be expected from a GNSS system in 5cm steps, typically at a one sigma level of
+* confidence.
+*
+* Value is semi-minor axis accuracy at one standard dev
+* - range 0-12.7 meter, LSB = .05m
+* - 254 = any value equal or greater than 12.70 meter
+* - 255 = unavailable semi-minor axis value
+*
+* @unit: 0.05m
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SemiMinorAxisAccuracy ::= INTEGER (0..255)
+
+/**
+* This data element represents the recommended velocity of an object, typically a vehicle speed along a roadway,
+* expressed in unsigned units of 0.1 meters per second.
+*
+* - LSB units are 0.1 m/s
+* - the value 499 shall be used for values at or greater than 49.9 m/s
+* - the value 500 shall be used to indicate that speed is unavailable
+*
+* @unit: 0.1 m/s
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SpeedAdvice ::= INTEGER (0..500)
+
+/**
+* This DE is used to provide the 95% confidence level for the currently reported
+* value of @ref Speed, taking into account the current calibration and precision of the sensor(s) used to measure and/or
+* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing
+* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element
+* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should
+* be increased accordingly.
+*
+* - 0 - `unavailable` : Not Equipped or unavailable
+* - 1 - `prec100ms`   : 100  meters / sec
+* - 2 - `prec10ms`    : 10   meters / sec
+* - 3 - `prec5ms`     : 5    meters / sec
+* - 4 - `prec1ms`     : 1    meters / sec
+* - 5 - `prec0-1ms`   : 0.1  meters / sec
+* - 6 - `prec0-05ms`  : 0.05 meters / sec
+* - 7 - `prec0-01ms`  : 0.01 meters / sec
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+SpeedConfidenceDSRC ::= ENUMERATED {
+   unavailable (0),
+   prec100ms   (1),
+   prec10ms    (2),
+   prec5ms     (3),
+   prec1ms     (4),
+   prec0-1ms   (5),
+   prec0-05ms  (6),
+   prec0-01ms  (7)
+ }
+
+/**
+* This is the 4 octet random device identifier, called the TemporaryID. When used for a mobile OBU device, this value
+* will change periodically to ensure the overall anonymity of the vehicle, unlike a typical wireless or wired 802 device ID.
+* Because this value is used as a means to identify the local vehicles that are interacting during an encounter, it is used in
+* the message set. Other devices, such as infrastructure (RSUs), may have a fixed value for the temporary ID value. See
+* also @ref StationId which is used in other deployment regions.
+*
+* @note: The circumstances and times at which various DSRC devices (notably OBUs) create and change their current
+*        Temporary ID is a complex application level topic. It should be noted that the Temporary ID is not the same as a device
+*        MAC value, although when used as a means to uniquely identify a device, both have many common properties. It should
+*        further be noted that the MAC value for a mobile OBU device (unlike a typical wireless or wired 802 device) will
+*        periodically change to a new random value to ensure the overall anonymity of the vehicle.
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TemporaryID ::= OCTET STRING (SIZE(4))
+
+/**
+* This DE is used to provide the 95% confidence level for the currently reported
+* value of DE @ref Throttle, taking into account the current calibration and precision of the sensor(s) used to measure and/or
+* calculate the value. This data element is only to provide information on the limitations of the sensing system, not to
+* support any type of automatic error correction or to imply a guaranteed maximum error. This data element should not be
+* used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should be increased
+* accordingly. If a fault that triggers the MIL is of a nature to render throttle performance unreliable, then ThrottleConfidence
+* should be represented as "notEquipped."
+*
+* - 0 - `unavailable`:    B'00 Not Equipped or unavailable
+* - 1 - `prec10percent`:  B'01 10 percent Confidence level
+* - 2 - `prec1percent`:   B'10 1 percent Confidence level
+* - 3 - `prec0-5percent`: B'11 0.5 percent Confidence level
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ThrottleConfidence ::= ENUMERATED {
+   unavailable     (0),
+   prec10percent   (1),
+   prec1percent    (2),
+   prec0-5percent  (3)
+ }
+
+/**
+* This DE is used to provide the 95% confidence level for the currently reported value
+* of time, taking into account the current calibration and precision of the sensor(s) used to measure and/or calculate the
+* value. This data element is only to provide information on the limitations of the sensing system, not to support any type of
+* automatic error correction or to imply a guaranteed maximum error. This data element should not be used for fault
+* detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should be increased accordingly.
+*
+* - 0 - `unavailable`  : Not Equipped or unavailable
+* - 1 - `time-100-000` : Better than 100 Seconds
+* - 2 - `time-050-000` : Better than 50 Seconds
+* - 3 - `time-020-000` : Better than 20 Seconds
+* - 4 - `time-010-000` : Better than 10 Seconds
+* - 5 - `time-002-000` : Better than 2 Seconds
+* - 6 - `time-001-000` : Better than 1 Second
+* - 7 - `time-000-500` : Better than 0.5 Seconds
+* - 8 - `time-000-200` : Better than 0.2 Seconds
+* - 9 - `time-000-100` : Better than 0.1 Seconds
+* - 10 - `time-000-050` : Better than 0.05 Seconds
+* - 11 - `time-000-020` : Better than 0.02 Seconds
+* - 12 - `time-000-010` : Better than 0.01 Seconds
+* - 13 - `time-000-005` : Better than 0.005 Seconds
+* - 14 - `time-000-002` : Better than 0.001 Seconds
+* - 15 - `time-000-001` : Better than 0.001 Seconds
+* - 16 - `time-000-000-5` : Better than 0.000,5 Seconds
+* - 17 - `time-000-000-2` : Better than 0.000,2 Seconds
+* - 18 - `time-000-000-1` : Better than 0.000,1 Seconds
+* - 19 - `time-000-000-05` : Better than 0.000,05 Seconds
+* - 20 - `time-000-000-02` : Better than 0.000,02 Seconds
+* - 21 - `time-000-000-01` : Better than 0.000,01 Seconds
+* - 22 - `time-000-000-005` : Better than 0.000,005 Seconds
+* - 23 - `time-000-000-002` : Better than 0.000,002 Seconds
+* - 24 - `time-000-000-001` : Better than 0.000,001 Seconds
+* - 25 - `time-000-000-000-5` : Better than 0.000,000,5 Seconds
+* - 26 - `time-000-000-000-2` : Better than 0.000,000,2 Seconds
+* - 27 - `time-000-000-000-1` : Better than 0.000,000,1 Seconds
+* - 28 - `time-000-000-000-05` : Better than 0.000,000,05 Seconds
+* - 29 - `time-000-000-000-02` : Better than 0.000,000,02 Seconds
+* - 30 - `time-000-000-000-01` : Better than 0.000,000,01 Seconds
+* - 31 - `time-000-000-000-005` : Better than 0.000,000,005 Seconds
+* - 32 - `time-000-000-000-002` : Better than 0.000,000,002 Seconds
+* - 33 - `time-000-000-000-001` : Better than 0.000,000,001 Seconds
+* - 34 - `time-000-000-000-000-5` : Better than 0.000,000,000,5 Seconds
+* - 35 - `time-000-000-000-000-2` : Better than 0.000,000,000,2 Seconds
+* - 36 - `time-000-000-000-000-1` : Better than 0.000,000,000,1 Seconds
+* - 37 - `time-000-000-000-000-05` : Better than 0.000,000,000,05 Seconds
+* - 38 - `time-000-000-000-000-02` : Better than 0.000,000,000,02 Seconds
+* - 39 - `time-000-000-000-000-01` : Better than 0.000,000,000,01 Seconds
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TimeConfidence ::= ENUMERATED {
+   unavailable              (0),
+   time-100-000             (1),
+   time-050-000             (2),
+   time-020-000             (3),
+   time-010-000             (4),
+   time-002-000             (5),
+   time-001-000             (6),
+   time-000-500             (7),
+   time-000-200             (8),
+   time-000-100             (9),
+   time-000-050            (10),
+   time-000-020            (11),
+   time-000-010            (12),
+   time-000-005            (13),
+   time-000-002            (14),
+   time-000-001            (15),
+   time-000-000-5          (16),
+   time-000-000-2          (17),
+   time-000-000-1          (18),
+   time-000-000-05         (19),
+   time-000-000-02         (20),
+   time-000-000-01         (21),
+   time-000-000-005        (22),
+   time-000-000-002        (23),
+   time-000-000-001        (24),
+   time-000-000-000-5      (25),
+   time-000-000-000-2      (26),
+   time-000-000-000-1      (27),
+   time-000-000-000-05     (28),
+   time-000-000-000-02     (29),
+   time-000-000-000-01     (30),
+   time-000-000-000-005    (31),
+   time-000-000-000-002    (32),
+   time-000-000-000-001    (33),
+   time-000-000-000-000-5  (34),
+   time-000-000-000-000-2  (35),
+   time-000-000-000-000-1  (36),
+   time-000-000-000-000-05 (37),
+   time-000-000-000-000-02 (38),
+   time-000-000-000-000-01 (39)
+}
+
+/**
+* This is the statistical confidence for the predicted time of signal group state change. For evaluation, the formula
+* 10^(x/a)-b with a=82.5 and b=1.3 was used. The values are encoded as probability classes with proposed values listed in
+* the below table in the ASN.1 specification.
+*
+* Value: Probability
+* - 0 - 21%
+* - 1 - 36%
+* - 2 - 47%
+* - 3 - 56%
+* - 4 - 62%
+* - 5 - 68%
+* - 6 - 73%
+* - 7 - 77%
+* - 8 - 81%
+* - 9 - 85%
+* - 10 - 88%
+* - 11 - 91%
+* - 12 - 94%
+* - 13 - 96%
+* - 14 - 98%
+* - 15 - 100%
+*
+* @unit: percent
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TimeIntervalConfidence ::= INTEGER (0..15)
+
+/**
+* This DE is used to provide the R09 tour information.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+TourNumber ::= INTEGER (0..4294967295)
+
+/**
+* This DE is used to provide the R09 train length.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+TrainLength ::= INTEGER (0..7)
+
+/**
+* This DE is used to provide the R09 direction information.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+TransitDirection ::= INTEGER (0..255)
+
+/**
+*  This DE is used to relate basic level of current ridership.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TransitVehicleOccupancy ::= ENUMERATED {
+  occupancyUnknown    (0),
+  occupancyEmpty      (1),
+  occupancyVeryLow    (2),
+  occupancyLow        (3),
+  occupancyMed        (4),
+  occupancyHigh       (5),
+  occupancyNearlyFull (6),
+  occupancyFull       (7)
+}
+
+/**
+* This DE is used to relate basic information about the transit run in progress. This is
+* typically used in a priority request to a signalized system and becomes part of the input processing for how that system
+* will respond to the request.
+*
+* - 0 - `loading`:     parking and unable to move at this time
+* - 1 - `anADAuse`:    an ADA access is in progress (wheelchairs, kneeling, etc.)
+* - 2 - `aBikeLoad`:   loading of a bicycle is in progress
+* - 3 - `doorOpen`:    a vehicle door is open for passenger access
+* - 4 - `charging`:    a vehicle is connected to charging point
+* - 5 - `atStopLine`:  a vehicle is at the stop line for the lane it is in
+*
+* @note: Most of these values are used to detect that the transit vehicle in not in a state where movement can occur
+* (and that therefore any priority signal should be ignored until the vehicle is again ready to depart).
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TransitVehicleStatus ::= BIT STRING {
+  loading     (0),
+  anADAuse    (1),
+  aBikeLoad   (2),
+  doorOpen    (3),
+  charging    (4),
+  atStopLine  (5)
+} (SIZE(8))
+
+/**
+* This DE is used to provide the current state of the vehicle transmission.
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+TransmissionState ::= ENUMERATED {
+  neutral      (0),
+  park         (1),
+  forwardGears (2),
+  reverseGears (3),
+  reserved1    (4),
+  reserved2    (5),
+  reserved3    (6),
+  unavailable  (7)
+}
+
+/**
+* The height of the vehicle, measured from the ground to the highest surface, excluding any antenna(s), and
+* expressed in units of 5 cm. In cases of vehicles with adjustable ride heights, camper shells, and other devices which may
+* cause the overall height to vary, the largest possible height will be used.
+*
+* Value is the height of the vehicle, LSB units of 5 cm, range to 6.35 meters
+*
+* @unit: 5cm
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+VehicleHeight ::= INTEGER (0..127)
+
+/**
+* This DE is a type list (i.e., a classification list) of the vehicle in terms of overall size. The
+* data element entries follow the definitions defined in the US DOT Highway Performance Monitoring System (HPMS).
+* Many infrastructure roadway operators collect and classify data according to this list for regulatory reporting needs.
+* Within the ITS industry and within the DSRC message set standards work, there are many similar lists of types for
+* overlapping needs and uses.
+*
+* - 0 - `none`:       Not Equipped, Not known or unavailable
+* - 1 - `unknown`:    Does not fit any other category
+* - 2 - `special`:    Special use
+* - 3 - `moto`:       Motorcycle
+* - 4 - `car`:        Passenger car
+* - 5 - `carOther`:   Four tire single units
+* - 6 - `bus`:        Buses
+* - 7 - `axleCnt2`:   Two axle, six tire single units
+* - 8 - `axleCnt3`:   Three axle, single units
+* - 9 - `axleCnt4`:   Four or more axle, single unit
+* - 10 - `axleCnt4Trailer`:        Four or less axle, single trailer
+* - 11 - `axleCnt5Trailer`:        Five or less axle, single trailer
+* - 12 - `axleCnt6Trailer`:        Six or more axle, single trailer
+* - 13 - `axleCnt5MultiTrailer`:   Five or less axle, multi-trailer
+* - 14 - `axleCnt6MultiTrailer`:   Six axle, multi-trailer
+* - 15 - `axleCnt7MultiTrailer`:   Seven or more axle, multi-trailer
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+VehicleType ::= ENUMERATED {
+  none                 (0),
+  unknown              (1),
+  special              (2),
+  moto                 (3),
+  car                  (4),
+  carOther             (5),
+  bus                  (6),
+  axleCnt2             (7),
+  axleCnt3             (8),
+  axleCnt4             (9),
+  axleCnt4Trailer      (10),
+  axleCnt5Trailer      (11),
+  axleCnt6Trailer      (12),
+  axleCnt5MultiTrailer (13),
+  axleCnt6MultiTrailer (14),
+  axleCnt7MultiTrailer (15),
+  ...
+}
+
+/**
+* This DE represents the velocity of an object, typically a vehicle speed or the recommended speed of
+* travel along a roadway, expressed in unsigned units of 0.02 meters per second. When used with motor vehicles it may be
+* combined with the transmission state to form a data frame for use. A value of 8191 shall be used when the speed is
+* unavailable. Note that Velocity as used here is intended to be a scalar value and not a vector.
+*
+* The value 8191 indicates that velocity is unavailable
+*
+* @unit: 0.02 m/s
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+Velocity ::= INTEGER (0..8191)
+
+/**
+* This DE is used to provide the R09 version information.
+*
+* @category: Infrastructure information
+* @revision: V2.2.1
+*/
+VersionId ::= INTEGER (0..4294967295)
+
+/**
+* This DE is used to indicate to the vehicle that it must stop at the stop line and not move past.
+*
+* If "true", the vehicles on this specific connecting maneuver have to stop on the stop-line and not to enter the collision area
+*
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+WaitOnStopline ::= BOOLEAN
+
+/**
+* This DE is used to provide an estimated distance from the stop bar, along the lane
+* centerline back in the lane to which it pertains. It is used in various ways to relate this distance value. When used with
+* clearance zones, it represents the point at which the driver can successfully execute the connection maneuver. It is used
+* in the Clearance Maneuver Assist data frame to relate dynamic data about the lane. It is also used to relate the distance
+* from the stop bar to the rear edge of any queue. It is further used within the context of a vehicle's traveling speed to
+* advise on preferred dynamic approach speeds.
+*
+* 0 = unknown,
+* The value 10000 to be used for Distances >=10000 m (e.g. from known point to another point along a
+* known path, often against traffic flow direction when used for measuring queues)
+*
+* @unit: meter
+* @category: Infrastructure information
+* @revision: V1.3.1
+*/
+ZoneLength ::= INTEGER (0..10000)
+
+/** 
+* ## References:
+* 1. [ISO TS 19091]: "Intelligent transport systems - Cooperative ITS - Using V2I and I2V communications for applications related to signalized intersections".
+* 2. [SAE J2735]: "SURFACE VEHICLE STANDARD - V2X Communications Message Set Dictionary"
+* 3. [OCIT]: "OCIT Developer Group. https://ocit.org"
+*/
+
+END

--- a/standards/its/src/ts103301/asn1/IVIM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/IVIM-PDU-Descriptions.asn
@@ -1,0 +1,43 @@
+--! @options: no-fields-header
+
+IVIM-PDU-Descriptions {
+    itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) ivim (2) major-version-2 (2) minor-version-1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+IviStructure
+FROM IVI {
+  iso (1) standard (0) ivi (19321) major-version-3 (3) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* In vehicle information Message Message
+* This DF includes DEs for the IVIM protocolVersion, the IVI message type identifier `messageID`,
+* the station identifier `stationID` of the originating ITS-S and the IVI data from ISO TS 19321.
+*
+* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                It shall be set to 2.
+*                The DE `messageID` shall be ivim(6).
+* @field ivi:    contains the IVI data as defined in ISO TS 19321.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+IVIM ::= SEQUENCE {
+    header  ItsPduHeader,
+    ivi     IviStructure
+}
+
+END

--- a/standards/its/src/ts103301/asn1/MAPEM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/MAPEM-PDU-Descriptions.asn
@@ -1,0 +1,49 @@
+--! @options: no-fields-header
+
+MAPEM-PDU-Descriptions {
+    itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) mapem (1) version2 (2)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+/**
+* Includes from ETSI-ITS-DSRC
+*/
+MapData
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+/**
+* Include ETSI TS 102 894-2 (ETSI-ITS-CDD)
+*/
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* Map (lane topology) extended Message
+* This DF includes DEs for the MAPEM: protocolVersion, the MAPEM message type identifier `messageID`, 
+* the station identifier `stationID` of the originating ITS-S and the Map data from ETSI-ITS-DSRC.
+* 
+* @field header:  The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                 It shall be set to 2.
+*                 The DE `messageID` shall be mapem(5).
+* @field map:     contains the MAP data as defined in ETSI-ITS-DSRC.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+MAPEM ::= SEQUENCE {
+    header  ItsPduHeader,
+    map	    MapData
+}
+
+END

--- a/standards/its/src/ts103301/asn1/RTCMEM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/RTCMEM-PDU-Descriptions.asn
@@ -1,0 +1,49 @@
+--! @options: no-fields-header
+
+RTCMEM-PDU-Descriptions {
+    itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) rtcmem (5) version1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+/**
+* Includes from ETSI-ITS-DSRC
+*/
+RTCMcorrections
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+/**
+* Include ETSI TS 102 894-2 (ETSI-ITS-CDD)
+*/
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* RTCM corrections extended extended Message
+* This DF includes DEs for the RTCMEM: protocolVersion, the RTCMEM message type identifier `messageID`,
+* the station identifier `stationID` of the originating ITS-S and the RTCM corrections as of ETSI-ITS-DSRC.
+*
+* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                It shall be set to 1.
+*                The DE `messageID` shall be rtcmem(13).
+* @field rtcmc:  contains the RTCM corrections data as defined in ETSI-ITS-DSRC.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+RTCMEM ::= SEQUENCE {
+    header  ItsPduHeader,
+    rtcmc   RTCMcorrections
+}
+
+END

--- a/standards/its/src/ts103301/asn1/SPATEM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/SPATEM-PDU-Descriptions.asn
@@ -1,0 +1,51 @@
+--! @options: no-fields-header
+
+SPATEM-PDU-Descriptions {
+    itu-t (0) identified-organization (4) etsi (0) itsDomain (5)  wg1 (1) ts103301 (103301) spatem (0) major-version-2 (2) minor-version-1 (1)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+/**
+* Includes from ETSI-ITS-DSRC
+*/
+SPAT
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+/**
+* Include ETSI TS 102 894-2 (ETSI-ITS-CDD)
+*/
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* Signal phase and timing extended Message
+*
+* Signal phase and timing extended Message Root
+* This DF includes DEs for the SPATEM: protocolVersion, the SPATEM message type identifier `messageID`,
+* the station identifier `stationID` of the originating ITS-S and the SPaT data from ETSI-ITS-DSRC module.
+*
+* @field header:  The DE `protocolVersion` used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                 It shall be set to 2.
+*                 The DE `messageID` shall be spatem(4).
+* @field spat:    contains the SPaT data as defined in ETSI-ITS-DSRC.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+SPATEM ::= SEQUENCE {
+    header  ItsPduHeader,
+    spat    SPAT
+}
+
+END

--- a/standards/its/src/ts103301/asn1/SREM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/SREM-PDU-Descriptions.asn
@@ -1,0 +1,49 @@
+--! @options: no-fields-header
+
+SREM-PDU-Descriptions {
+	itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) srem (3) version2 (2)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+/**
+* Includes from ETSI-ITS-DSRC
+*/
+SignalRequestMessage
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+/**
+* Include ETSI TS 102 894-2 (ETSI-ITS-CDD)
+*/
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* Signal request extended Message Message
+* This DF includes DEs for the SREM: protocolVersion, the SREM message type identifier `messageID`,
+* the station identifier `stationID` of the originating ITS-S and the signal request data from ETSI-ITS-DSRC.
+*
+* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                It shall be set to 2.
+*                The DE `messageID` shall be srem(9).
+* @field srm:    contains the Signal request data as defined in ETSI-ITS-DSRC.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+SREM ::= SEQUENCE {
+    header  ItsPduHeader,
+    srm     SignalRequestMessage
+}
+
+END

--- a/standards/its/src/ts103301/asn1/SSEM-PDU-Descriptions.asn
+++ b/standards/its/src/ts103301/asn1/SSEM-PDU-Descriptions.asn
@@ -1,0 +1,50 @@
+--! @options: no-fields-header
+
+SSEM-PDU-Descriptions {
+    itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) ssem (4) version2 (2)
+}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+
+/**
+* Includes from ETSI-ITS-DSRC
+*/
+SignalStatusMessage
+FROM ETSI-ITS-DSRC {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts103301 (103301) dsrc (6) major-version-2 (2) minor-version-1 (1)
+}
+WITH SUCCESSORS
+
+/**
+* Include ETSI TS 102 894-2 (ETSI-ITS-CDD)
+*/
+ItsPduHeader
+FROM ETSI-ITS-CDD {
+  itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-4 (4) minor-version-1 (1)
+}
+WITH SUCCESSORS;
+
+/**
+* Signal status extended Message
+* 
+* This DF includes DEs for the SSEM: protocolVersion, the SSEM message type identifier `messageID` and
+* the station identifier `stationID` of the originating ITS-S and the signal status data from ETSI-ITS-DSRC.
+*
+* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. 
+*                It shall be set to 2.
+*                The DE `messageID` shall be ssem(10).
+* @field ssm:    contains the Signal status data as defined in ETSI-ITS-DSRC.
+* 
+* @category: Basic Information
+* @revision: V1.3.1
+*/
+SSEM ::= SEQUENCE {
+    header  ItsPduHeader,
+    ssm     SignalStatusMessage
+}
+
+END

--- a/standards/its/src/ts103301/mod.rs
+++ b/standards/its/src/ts103301/mod.rs
@@ -1,0 +1,3 @@
+use crate::ts102894_2::etsi_its_cdd;
+
+include!("ts103301.rs");

--- a/standards/its/src/ts103301/ts103301.rs
+++ b/standards/its/src/ts103301/ts103301.rs
@@ -1,0 +1,8253 @@
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod etsi_its_dsrc {
+    extern crate alloc;
+    use super::etsi_its_cdd::{Iso3833VehicleType, Latitude, Longitude, StationID};
+    use super::etsi_its_dsrc_region::{
+        RegAdvisorySpeed, RegComputedLane, RegConnectionManeuverAssist, RegGenericLane,
+        RegIntersectionGeometry, RegIntersectionState, RegLaneAttributes, RegLaneDataAttribute,
+        RegMapData, RegMovementEvent, RegMovementState, RegNodeAttributeSetXY,
+        RegNodeOffsetPointXY, RegPosition3D, RegRTCMcorrections, RegRequestorDescription,
+        RegRequestorType, RegRestrictionUserType, RegRoadSegment, RegSPAT, RegSignalControlZone,
+        RegSignalRequest, RegSignalRequestMessage, RegSignalRequestPackage, RegSignalStatus,
+        RegSignalStatusMessage, RegSignalStatusPackage,
+    };
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousAdvisorySpeedRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousAdvisorySpeedRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousAdvisorySpeedRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegAdvisorySpeed_Type, D::Error> {
+            RegAdvisorySpeed_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct AdvisorySpeedRegional(pub SequenceOf<AnonymousAdvisorySpeedRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey a recommended traveling approach speed to an intersection"]
+    #[doc = "* from the message issuer to various travelers and vehicle types. Besides support for various eco-driving applications, this"]
+    #[doc = "* allows transmitting recommended speeds for specialty vehicles such as transit buses."]
+    #[doc = "*"]
+    #[doc = "* @field type: the type of advisory which this is."]
+    #[doc = "* @field speed: See @ref SpeedAdvice for converting and translating speed expressed in mph into units of m/s."]
+    #[doc = "*               This element is optional ONLY when superceded by the presence of a regional speed element found in Reg-AdvisorySpeed entry"]
+    #[doc = "* @field confidence: A confidence value for the above speed"]
+    #[doc = "* @field distance: The distance indicates the region for which the advised speed is recommended, it is specified upstream from the stop bar"]
+    #[doc = "*                  along the connected egressing lane. Unit = 1 meter "]
+    #[doc = "* @field class: the vehicle types to which it applies when absent, the AdvisorySpeed applies to all motor vehicle types"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AdvisorySpeed {
+        #[rasn(identifier = "type")]
+        pub r_type: AdvisorySpeedType,
+        pub speed: Option<SpeedAdvice>,
+        pub confidence: Option<SpeedConfidenceDSRC>,
+        pub distance: Option<ZoneLength>,
+        pub class: Option<RestrictionClassID>,
+        pub regional: Option<AdvisorySpeedRegional>,
+    }
+    impl AdvisorySpeed {
+        pub fn new(
+            r_type: AdvisorySpeedType,
+            speed: Option<SpeedAdvice>,
+            confidence: Option<SpeedConfidenceDSRC>,
+            distance: Option<ZoneLength>,
+            class: Option<RestrictionClassID>,
+            regional: Option<AdvisorySpeedRegional>,
+        ) -> Self {
+            Self {
+                r_type,
+                speed,
+                confidence,
+                distance,
+                class,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref AdvisorySpeed entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct AdvisorySpeedList(pub SequenceOf<AdvisorySpeed>);
+    #[doc = "*"]
+    #[doc = "* This DE relates the type of travel to which a given speed refers. This element is"]
+    #[doc = "* typically used as part of an @ref AdvisorySpeed data frame for signal phase and timing data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum AdvisorySpeedType {
+        none = 0,
+        greenwave = 1,
+        ecoDrive = 2,
+        transit = 3,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE relates the allowed (possible) maneuvers from a lane, typically a"]
+    #[doc = "* motorized vehicle lane. It should be noted that in practice these values may be further restricted by vehicle class, local"]
+    #[doc = "* regulatory environment and other changing conditions."]
+    #[doc = "*"]
+    #[doc = "* @note: When used by data frames, the AllowedManeuvers data concept is used in two places: optionally in the"]
+    #[doc = "*    generic lane structure to list all possible maneuvers (as in what that lane can do at its stop line point); and within each"]
+    #[doc = "*    ConnectsTo structure. Each ConnectsTo structure contains a list used to provide a single valid maneuver in the context of"]
+    #[doc = "*    one lane connecting to another in the context of a signal phase that applies to that maneuver. It should be noted that, in"]
+    #[doc = "*    some intersections, multiple outbound lanes can be reached by the same maneuver (for example two independent left"]
+    #[doc = "*    turns might be found in a 5-legged intersection) but that to reach any given lane from the stop line of another lane is"]
+    #[doc = "*    always a single maneuver item (hence the use of a list). Not all intersection descriptions may contain an exhaustive set of"]
+    #[doc = "*    ConnectsTo information (unsignalized intersections for example) and in such cases the AllowedManeuvers in the generic"]
+    #[doc = "*    lane structure can be used. If present in both places, the data expressed in the generic lane shall not conflict with the data"]
+    #[doc = "*    found in the collection of ConnectsTo entries."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AllowedManeuvers(pub FixedBitString<12usize>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to describe an angular measurement in units of degrees. This data"]
+    #[doc = "* element is often used as a heading direction when in motion. In this use, the current heading of the sending device is"]
+    #[doc = "* expressed in unsigned units of 0.0125 degrees from North, such that 28799 such degrees represent 359.9875 degrees."]
+    #[doc = "* North shall be defined as the axis defined by the WGS-84 coordinate system and its reference ellipsoid. Any angle \"to the"]
+    #[doc = "* east\" is defined as the positive direction. A value of 28800 shall be used when Angle is unavailable."]
+    #[doc = "*"]
+    #[doc = "* @note: Note that other heading and angle data elements of various sizes and precisions are found in other parts of this standard and in ITS."]
+    #[doc = "* @unit: 0.0125 degrees"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=28800"))]
+    pub struct Angle(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DF is a collection of three offset values in an orthogonal coordinate system"]
+    #[doc = "* which describe how far the electrical phase center of an antenna is in each axis from a nearby known anchor point in units of 1 cm."]
+    #[doc = "*"]
+    #[doc = "* When the antenna being described is on a vehicle, the signed offset shall be in the coordinate system defined in section 11.4."]
+    #[doc = "*"]
+    #[doc = "* @field antOffsetX: a range of +- 20.47 meters."]
+    #[doc = "* @field antOffsetY: a range of +- 2.55 meters."]
+    #[doc = "* @field antOffsetZ: a range of +- 5.11 meters."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct AntennaOffsetSet {
+        #[rasn(identifier = "antOffsetX")]
+        pub ant_offset_x: OffsetB12,
+        #[rasn(identifier = "antOffsetY")]
+        pub ant_offset_y: OffsetB09,
+        #[rasn(identifier = "antOffsetZ")]
+        pub ant_offset_z: OffsetB10,
+    }
+    impl AntennaOffsetSet {
+        pub fn new(
+            ant_offset_x: OffsetB12,
+            ant_offset_y: OffsetB09,
+            ant_offset_z: OffsetB10,
+        ) -> Self {
+            Self {
+                ant_offset_x,
+                ant_offset_y,
+                ant_offset_z,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to relate the index of an approach, either ingress or egress within the"]
+    #[doc = "* subject lane. In general, an approach index in the context of a timing movement is not of value in the MAP and SPAT"]
+    #[doc = "* process because the lane ID and signal group ID concepts handle this with more precision. This value can also be useful"]
+    #[doc = "* as an aid as it can be used to indicate the gross position of a moving object (vehicle) when its lane level accuracy is"]
+    #[doc = "* unknown. This value can also be used when a deployment represents sets of lanes as groups without further details (as is"]
+    #[doc = "* done in Japan)."]
+    #[doc = "*"]
+    #[doc = "* @note: zero to be used when valid value is unknown"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct ApproachID(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE provides a means to indicate the current role that a DSRC device is playing"]
+    #[doc = "* This is most commonly employed when a vehicle needs to take on another role in order to send certain DSRC message"]
+    #[doc = "* types. As an example, when a public safety vehicle such as a police car wishes to send a signal request message (SRM)"]
+    #[doc = "* to an intersection to request a preemption service, the vehicle takes on the role \"police\" from the below list in both the"]
+    #[doc = "* SRM message itself and also in the type of security CERT which is sent (the SSP in the CERT it used to identify the"]
+    #[doc = "* requester as being of type \"police\" and that they are allowed to send this message in this way). The BasicVehicleRole"]
+    #[doc = "* entry is often used and combined with other information about the requester as well, such as details of why the request is"]
+    #[doc = "* being made."]
+    #[doc = "*"]
+    #[doc = "* - 0 - `basicVehicle`     - Light duty passenger vehicle type"]
+    #[doc = "* - 1 - `publicTransport`  - Used in EU for Transit us"]
+    #[doc = "* - 2 - `specialTransport` - Used in EU (e.g. heavy load)"]
+    #[doc = "* - 3 - `dangerousGoods`   - Used in EU for any HAZMAT"]
+    #[doc = "* - 4 - `roadWork`         - Used in EU for State and Local DOT uses"]
+    #[doc = "* - 5 - `roadRescue`       - Used in EU and in the US to include tow trucks."]
+    #[doc = "* - 6 - `emergency`        - Used in EU for Police, Fire and Ambulance units"]
+    #[doc = "* - 7 - `safetyCar`        - Used in EU for Escort vehicles"]
+    #[doc = "* - 8 - `none-unknown`     - added to follow current SAE style guidelines"]
+    #[doc = "* - 9 - `truck`            - Heavy trucks with additional BSM rights and obligations"]
+    #[doc = "* - 10 - `motorcycle`      - Motorcycle"]
+    #[doc = "* - 11 - `roadSideSource`  - For infrastructure generated calls such as fire house, rail infrastructure, roadwork site, etc."]
+    #[doc = "* - 12 - `police`          - Police vehicle"]
+    #[doc = "* - 13 - `fire`            - Firebrigade"]
+    #[doc = "* - 14 - `ambulance`       - (does not include private para-transit etc.)"]
+    #[doc = "* - 15 - `dot`             - all roadwork vehicles"]
+    #[doc = "* - 16 - `transit`         - all transit vehicles"]
+    #[doc = "* - 17 - `slowMoving`      - to also include oversize etc."]
+    #[doc = "* - 18 - `stopNgo`         - to include trash trucks, school buses and others"]
+    #[doc = "* - 19 - `cyclist`         - bicycles"]
+    #[doc = "* - 20 - `pedestrian`      - also includes those with mobility limitations"]
+    #[doc = "* - 21 - `nonMotorized`    - other, horse drawn, etc."]
+    #[doc = "* - 22 - `military`        - military vehicles"]
+    #[doc = "*"]
+    #[doc = "* @note: It should be observed that devices can at times change their roles (i.e. a fire operated by a volunteer"]
+    #[doc = "*    fireman can assume a fire role for a period of time when in service, or a pedestrian may assume a cyclist role when using"]
+    #[doc = "*    a bicycle). It should be observed that not all devices (or vehicles) can assume all roles, nor that a given"]
+    #[doc = "*    device in a given role will be provided with a security certificate (CERT) that has suitable SSP credentials to provide the"]
+    #[doc = "*    ability to send a particular message or message content. The ultimate responsibility to determine what role is to be used,"]
+    #[doc = "*    and what CERTs would be provided for that role (which in turn controls the messages and message content that can be"]
+    #[doc = "*    sent within SAE-defined PSIDs) rests with the regional deployment."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum BasicVehicleRole {
+        basicVehicle = 0,
+        publicTransport = 1,
+        specialTransport = 2,
+        dangerousGoods = 3,
+        roadWork = 4,
+        roadRescue = 5,
+        emergency = 6,
+        safetyCar = 7,
+        #[rasn(identifier = "none-unknown")]
+        none_unknown = 8,
+        truck = 9,
+        motorcycle = 10,
+        roadSideSource = 11,
+        police = 12,
+        fire = 13,
+        ambulance = 14,
+        dot = 15,
+        transit = 16,
+        slowMoving = 17,
+        stopNgo = 18,
+        cyclist = 19,
+        pedestrian = 20,
+        nonMotorized = 21,
+        military = 22,
+        #[rasn(extension_addition)]
+        tram = 23,
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum ComputedLaneOffsetXaxis {
+        small(DrivenLineOffsetSm),
+        large(DrivenLineOffsetLg),
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum ComputedLaneOffsetYaxis {
+        small(DrivenLineOffsetSm),
+        large(DrivenLineOffsetLg),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousComputedLaneRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousComputedLaneRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousComputedLaneRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegComputedLane_Type, D::Error> {
+            RegComputedLane_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct ComputedLaneRegional(pub SequenceOf<AnonymousComputedLaneRegional>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to contain information needed to compute one lane from another"]
+    #[doc = "* (hence the name). This concept is used purely as a means of saving size in the message payload. The new lane is"]
+    #[doc = "* expressed as an X,Y offset from the first point of the source lane. It can be optionally rotated and scaled. Any attribute"]
+    #[doc = "* information found within the node of the source lane list cannot be changed and must be reused."]
+    #[doc = "*"]
+    #[doc = "* @field referenceLaneId: the lane ID upon which this computed lane will be based Lane Offset in X and Y direction"]
+    #[doc = "* @field offsetXaxis: A path X offset value for translations of the path's points when creating translated lanes."]
+    #[doc = "* @field offsetYaxis: The values found in the reference lane are all offset based on the X and Y values from"]
+    #[doc = "*                     the coordinates of the reference lane's initial path point."]
+    #[doc = "* @field rotateXY: A path rotation value for the entire lane"]
+    #[doc = "*                  Observe that this rotates the existing orientation"]
+    #[doc = "*                  of the referenced lane, it does not replace it."]
+    #[doc = "*                  Rotation occurs about the initial path point."]
+    #[doc = "* @field scaleXaxis: value for translations or zooming of the path's points. The values found in the reference lane"]
+    #[doc = "* @field scaleYaxis: are all expanded or contracted based on the X and Y and width values from the coordinates of  the reference lane's initial path point."]
+    #[doc = "*                    The Z axis remains untouched."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @note: The specified transformation shall be applied to the reference lane without any intermediary loss of precision"]
+    #[doc = "*        (truncation). The order of the transformations shall be: the East-West and North-South offsets, the scaling factors, and"]
+    #[doc = "*        finally the rotation."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ComputedLane {
+        #[rasn(identifier = "referenceLaneId")]
+        pub reference_lane_id: LaneID,
+        #[rasn(identifier = "offsetXaxis")]
+        pub offset_xaxis: ComputedLaneOffsetXaxis,
+        #[rasn(identifier = "offsetYaxis")]
+        pub offset_yaxis: ComputedLaneOffsetYaxis,
+        #[rasn(identifier = "rotateXY")]
+        pub rotate_xy: Option<Angle>,
+        #[rasn(identifier = "scaleXaxis")]
+        pub scale_xaxis: Option<ScaleB12>,
+        #[rasn(identifier = "scaleYaxis")]
+        pub scale_yaxis: Option<ScaleB12>,
+        pub regional: Option<ComputedLaneRegional>,
+    }
+    impl ComputedLane {
+        pub fn new(
+            reference_lane_id: LaneID,
+            offset_xaxis: ComputedLaneOffsetXaxis,
+            offset_yaxis: ComputedLaneOffsetYaxis,
+            rotate_xy: Option<Angle>,
+            scale_xaxis: Option<ScaleB12>,
+            scale_yaxis: Option<ScaleB12>,
+            regional: Option<ComputedLaneRegional>,
+        ) -> Self {
+            Self {
+                reference_lane_id,
+                offset_xaxis,
+                offset_yaxis,
+                rotate_xy,
+                scale_xaxis,
+                scale_yaxis,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The data concept ties a single lane to a single maneuver needed to reach it from another lane."]
+    #[doc = "* It is typically used to connect the allowed maneuver from the end of a lane to the outbound lane so that these can be"]
+    #[doc = "* mapped to the SPAT message to which both lanes apply."]
+    #[doc = "*"]
+    #[doc = "* @field lane: Index of the connecting lane."]
+    #[doc = "*"]
+    #[doc = "* @field maneuver: This data element allows only the description of a subset of possible manoeuvres and therefore"]
+    #[doc = "*    represents an incomplete list of possible travel directions. The connecting **lane** data element gives the"]
+    #[doc = "*    exact information about the manoeuvre relation from ingress to egress lane. Therefore the \"maneuver\""]
+    #[doc = "*    data element may be used only additionally if the travel direction of the manoeuvre is unanmbigoulsy"]
+    #[doc = "*    represented (e.g. left, right, straight, etc.)."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ConnectingLane {
+        pub lane: LaneID,
+        pub maneuver: Option<AllowedManeuvers>,
+    }
+    impl ConnectingLane {
+        pub fn new(lane: LaneID, maneuver: Option<AllowedManeuvers>) -> Self {
+            Self { lane, maneuver }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to combine/connect multiple physical lanes (i.e. within intersections or road"]
+    #[doc = "* segments). For signalized movements, the **connectsTo** data frame defines e.g. the relation between"]
+    #[doc = "* ingress and egress lanes within an intersection. It describes the allowed manoeuvres and includes the"]
+    #[doc = "* link (**signalGroup** identifier) between the @ref MapData and the @ref SPAT message. The data frame is also used"]
+    #[doc = "* to describe the relation of lanes within a non signalized intersection (e.g. ingress lanes which are"]
+    #[doc = "* bypassing the conflict area and ending in an egress lane without signalization). Within a road segment,"]
+    #[doc = "* it is used to combine two or multiple physical lanes into a single lane object."]
+    #[doc = "*"]
+    #[doc = "* @field connectingLane: "]
+    #[doc = "* @field remoteIntersection: When the data element **remoteIntersection** is used, it indicates"]
+    #[doc = "*                            that the connecting lane belongs to another intersection. "]
+    #[doc = "*                            (see clause [ISO TS 19091] G.9.1 for further explainations)."]
+    #[doc = "* @field signalGroup: "]
+    #[doc = "* @field userClass: "]
+    #[doc = "* @field connectionID: "]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Connection {
+        #[rasn(identifier = "connectingLane")]
+        pub connecting_lane: ConnectingLane,
+        #[rasn(identifier = "remoteIntersection")]
+        pub remote_intersection: Option<IntersectionReferenceID>,
+        #[rasn(identifier = "signalGroup")]
+        pub signal_group: Option<SignalGroupID>,
+        #[rasn(identifier = "userClass")]
+        pub user_class: Option<RestrictionClassID>,
+        #[rasn(identifier = "connectionID")]
+        pub connection_id: Option<LaneConnectionID>,
+    }
+    impl Connection {
+        pub fn new(
+            connecting_lane: ConnectingLane,
+            remote_intersection: Option<IntersectionReferenceID>,
+            signal_group: Option<SignalGroupID>,
+            user_class: Option<RestrictionClassID>,
+            connection_id: Option<LaneConnectionID>,
+        ) -> Self {
+            Self {
+                connecting_lane,
+                remote_intersection,
+                signal_group,
+                user_class,
+                connection_id,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousConnectionManeuverAssistRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousConnectionManeuverAssistRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousConnectionManeuverAssistRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegConnectionManeuverAssist_Type, D::Error> {
+            RegConnectionManeuverAssist_Type::decode(
+                decoder,
+                Some(&self.reg_ext_value),
+                &self.region_id,
+            )
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct ConnectionManeuverAssistRegional(
+        pub SequenceOf<AnonymousConnectionManeuverAssistRegional>,
+    );
+    #[doc = "*"]
+    #[doc = "* This DF contains information about the the dynamic flow of traffic for the lane(s)"]
+    #[doc = "* and maneuvers in question (as determined by the @ref LaneConnectionID). Note that this information can be sent regarding"]
+    #[doc = "* any lane-to-lane movement; it need not be limited to the lanes with active (non-red) phases when sent."]
+    #[doc = "*"]
+    #[doc = "* @field connectionID: the common connectionID used by all lanes to which this data applies"]
+    #[doc = "*                     (this value traces to ConnectsTo entries in lanes)"]
+    #[doc = "*"]
+    #[doc = "* @field queueLength: The distance from the stop line to the back edge of the last vehicle in the queue,"]
+    #[doc = "*                     as measured along the lane center line. (Unit = 1 meter, 0 = no queue)"]
+    #[doc = "*"]
+    #[doc = "* @field availableStorageLength: Distance (e.g. beginning from the downstream stop-line up to a given distance) with a high"]
+    #[doc = "*                     probability for successfully executing the connecting maneuver between the two lanes"]
+    #[doc = "*                     during the current cycle."]
+    #[doc = "*                     Used for enhancing the awareness of vehicles to anticipate if they can pass the stop line"]
+    #[doc = "*                     of the lane. Used for optimizing the green wave, due to knowledge of vehicles waiting in front"]
+    #[doc = "*                     of a red light (downstream)."]
+    #[doc = "*                     The element nextTime in @ref TimeChangeDetails in the containing data frame contains the next"]
+    #[doc = "*                     timemark at which an active phase is expected, a form of storage flush interval."]
+    #[doc = "*                     (Unit = 1 meter, 0 = no space remains)"]
+    #[doc = "*"]
+    #[doc = "* @field waitOnStop:  If true, the vehicles on this specific connecting"]
+    #[doc = "*                     maneuver have to stop on the stop-line and not to enter the collision area"]
+    #[doc = "*"]
+    #[doc = "* @field pedBicycleDetect: true if ANY ped or bicycles are detected crossing the above lanes. Set to false ONLY if there is a"]
+    #[doc = "*                     high certainty that there are none present, otherwise element is not sent."]
+    #[doc = "*"]
+    #[doc = "* @field regional:    This data element includes additional data content @ref ConnectionManeuverAssist-addGrpC defined in"]
+    #[doc = "*                     this profile (see [ISO TS 19091] G.5.1.1). The content is included using the regional extension framework as defined in"]
+    #[doc = "*                     @ref ConnectionManeuverAssist-addGrpC is used for position feedback to moving ITS stations for executing"]
+    #[doc = "*                     safe manoeuvres and is included for this purpose in the data element \"intersectionState\""]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ConnectionManeuverAssist {
+        #[rasn(identifier = "connectionID")]
+        pub connection_id: LaneConnectionID,
+        #[rasn(identifier = "queueLength")]
+        pub queue_length: Option<ZoneLength>,
+        #[rasn(identifier = "availableStorageLength")]
+        pub available_storage_length: Option<ZoneLength>,
+        #[rasn(identifier = "waitOnStop")]
+        pub wait_on_stop: Option<WaitOnStopline>,
+        #[rasn(identifier = "pedBicycleDetect")]
+        pub ped_bicycle_detect: Option<PedestrianBicycleDetect>,
+        pub regional: Option<ConnectionManeuverAssistRegional>,
+    }
+    impl ConnectionManeuverAssist {
+        pub fn new(
+            connection_id: LaneConnectionID,
+            queue_length: Option<ZoneLength>,
+            available_storage_length: Option<ZoneLength>,
+            wait_on_stop: Option<WaitOnStopline>,
+            ped_bicycle_detect: Option<PedestrianBicycleDetect>,
+            regional: Option<ConnectionManeuverAssistRegional>,
+        ) -> Self {
+            Self {
+                connection_id,
+                queue_length,
+                available_storage_length,
+                wait_on_stop,
+                ped_bicycle_detect,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used in the generic lane descriptions to provide a sequence of other defined"]
+    #[doc = "* lanes to which each lane connects beyond its stop point. See the Connection data frame entry for details. Note that this"]
+    #[doc = "* data frame is not used in some lane object types."]
+    #[doc = "*"]
+    #[doc = "* @note: The assignment of lanes in the Connection structure shall start with the leftmost lane from the vehicle"]
+    #[doc = "*   perspective (the u-turn lane in some cases) followed by subsequent lanes in a clockwise assignment order. Therefore, the"]
+    #[doc = "*   rightmost lane to which this lane connects would always be listed last. Note that this order is observed regardless of which"]
+    #[doc = "*   side of the road vehicles use. If this structure is used in the lane description, then all valid lanes to which the subject lane"]
+    #[doc = "*   connects shall be listed."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct ConnectsToList(pub SequenceOf<Connection>);
+    #[doc = "*"]
+    #[doc = "* The DSRC style date is a compound value consisting of finite-length sequences of integers (not characters) of the"]
+    #[doc = "* form: \"yyyy, mm, dd, hh, mm, ss (sss+)\" - as defined below."]
+    #[doc = "*"]
+    #[doc = "* @note: Note that some elements of this structure may not be sent when not needed. At least one element shall be present."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DDateTime {
+        pub year: Option<DYear>,
+        pub month: Option<DMonth>,
+        pub day: Option<DDay>,
+        pub hour: Option<DHour>,
+        pub minute: Option<DMinute>,
+        pub second: Option<DSecond>,
+        pub offset: Option<DOffset>,
+    }
+    impl DDateTime {
+        pub fn new(
+            year: Option<DYear>,
+            month: Option<DMonth>,
+            day: Option<DDay>,
+            hour: Option<DHour>,
+            minute: Option<DMinute>,
+            second: Option<DSecond>,
+            offset: Option<DOffset>,
+        ) -> Self {
+            Self {
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                offset,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The DSRC style day is a simple value consisting of integer values from zero to 31. The value of zero shall represent an unknown value."]
+    #[doc = "*"]
+    #[doc = "* @unit: days"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=31"))]
+    pub struct DDay(pub u8);
+    #[doc = "*"]
+    #[doc = "* The DSRC hour consists of integer values from zero to 23 representing the hours within a day. The value of 31 shall"]
+    #[doc = "* represent an unknown value. The range 24 to 30 is used in some transit applications to represent schedule adherence."]
+    #[doc = "*"]
+    #[doc = "* @unit: hours"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=31"))]
+    pub struct DHour(pub u8);
+    #[doc = "*"]
+    #[doc = "* The DSRC style minute is a simple value consisting of integer values from zero to 59 representing the minutes"]
+    #[doc = "* within an hour. The value of 60 shall represent an unknown value."]
+    #[doc = "*"]
+    #[doc = "* @unit: minutes"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=60"))]
+    pub struct DMinute(pub u8);
+    #[doc = "*"]
+    #[doc = "* The DSRC month consists of integer values from one to 12, representing the month within a year. The value of 0"]
+    #[doc = "* shall represent an unknown value."]
+    #[doc = "*"]
+    #[doc = "* @unit: months"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=12"))]
+    pub struct DMonth(pub u8);
+    #[doc = "*"]
+    #[doc = "* The DSRC (time zone) offset consists of a signed integer representing an hour and minute value set from -14:00 to"]
+    #[doc = "* +14:00, representing all the world’s local time zones in units of minutes. The value of zero (00:00) may also represent an"]
+    #[doc = "* unknown value. Note some time zones are do not align to hourly boundaries."]
+    #[doc = "*"]
+    #[doc = "* @unit: minutes from UTC time"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-840..=840"))]
+    pub struct DOffset(pub i16);
+    #[doc = "*"]
+    #[doc = "* The DSRC second expressed in this DE consists of integer values from zero to 60999, representing the"]
+    #[doc = "* milliseconds within a minute. A leap second is represented by the value range 60000 to 60999. The value of 65535 shall"]
+    #[doc = "* represent an unavailable value in the range of the minute. The values from 61000 to 65534 are reserved."]
+    #[doc = "*"]
+    #[doc = "* @unit: milliseconds"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct DSecond(pub u16);
+    #[doc = "*"]
+    #[doc = "* The DSRC year consists of integer values from zero to 4095 representing the year according to the Gregorian"]
+    #[doc = "* calendar date system. The value of zero shall represent an unknown value."]
+    #[doc = "*"]
+    #[doc = "* @unit: years"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4095"))]
+    pub struct DYear(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide basic (static) information on how a map fragment was processed or determined."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DataParameters {
+        #[rasn(size("1..=255"), identifier = "processMethod")]
+        pub process_method: Option<Ia5String>,
+        #[rasn(size("1..=255"), identifier = "processAgency")]
+        pub process_agency: Option<Ia5String>,
+        #[rasn(size("1..=255"), identifier = "lastCheckedDate")]
+        pub last_checked_date: Option<Ia5String>,
+        #[rasn(size("1..=255"), identifier = "geoidUsed")]
+        pub geoid_used: Option<Ia5String>,
+    }
+    impl DataParameters {
+        pub fn new(
+            process_method: Option<Ia5String>,
+            process_agency: Option<Ia5String>,
+            last_checked_date: Option<Ia5String>,
+            geoid_used: Option<Ia5String>,
+        ) -> Self {
+            Self {
+                process_method,
+                process_agency,
+                last_checked_date,
+                geoid_used,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE provides the final angle used in the last point of the lane path. Used to \"cant\" the stop line of the lane."]
+    #[doc = "*"]
+    #[doc = "* With an angle range from negative 150 to positive 150 in one degree steps where zero is directly"]
+    #[doc = "* along the axis or the lane center line as defined by the two closest points."]
+    #[doc = "*"]
+    #[doc = "* @unit: degree"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-150..=150"))]
+    pub struct DeltaAngle(pub i16);
+    #[doc = "*"]
+    #[doc = "* This DE provides a time definition for an object's schedule adherence (typically a transit"]
+    #[doc = "* vehicle) within a limited range of time. When the reporting object is ahead of schedule, a positive value is used; when"]
+    #[doc = "* behind, a negative value is used. A value of zero indicates schedule adherence. This value is typically sent from a vehicle"]
+    #[doc = "* to the traffic signal controller's RSU to indicate the urgency of a signal request in the context of being within schedule or"]
+    #[doc = "* not. In another use case, the traffic signal controller may advise the transit vehicle to speed up (DeltaTime > 0) or to slow"]
+    #[doc = "* down (DeltaTime < 0) to optimize the transit vehicle distribution driving along a specific route (e.g. a Bus route)."]
+    #[doc = "*"]
+    #[doc = "* Supporting a range of +/- 20 minute in steps of 10 seconds:"]
+    #[doc = "* - the value of `-121` shall be used when more than -20 minutes"]
+    #[doc = "* - the value of `+120` shall be used when more than +20 minutes"]
+    #[doc = "* - the value `-122` shall be used when the value is unavailable"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-122..=121"))]
+    pub struct DeltaTime(pub i8);
+    #[doc = "*"]
+    #[doc = "* This DE is used in maps and intersections to provide a human readable and"]
+    #[doc = "* recognizable name for the feature that follows. It is typically used when debugging a data flow and not in production use."]
+    #[doc = "* One key exception to this general rule is to provide a human-readable string for disabled travelers in the case of"]
+    #[doc = "* crosswalks and sidewalk lane objects."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=63"))]
+    pub struct DescriptiveName(pub Ia5String);
+    #[doc = "*"]
+    #[doc = "* This DE is an integer value expressing the offset in a defined axis from a"]
+    #[doc = "* reference lane number from which a computed lane is offset. The measurement is taken from the reference lane center"]
+    #[doc = "* line to the new center line, independent of any width values. The units are a signed value with an LSB of 1 cm."]
+    #[doc = "*"]
+    #[doc = "* @unit: cm"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-32767..=32767"))]
+    pub struct DrivenLineOffsetLg(pub i16);
+    #[doc = "*"]
+    #[doc = "* The DrivenLineOffsetSmall data element is an integer value expressing the offset in a defined axis from a reference"]
+    #[doc = "* lane number from which a computed lane is offset. The measurement is taken from the reference lane center line to the"]
+    #[doc = "* new center line, independent of any width values. The units are a signed value with an LSB of 1 cm."]
+    #[doc = "*"]
+    #[doc = "* @unit: cm"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-2047..=2047"))]
+    pub struct DrivenLineOffsetSm(pub i16);
+    #[doc = "*"]
+    #[doc = "* This DE represents the geographic position above or below the reference ellipsoid (typically WGS-84)."]
+    #[doc = "* The number has a resolution of 1 decimeter and represents an asymmetric range of positive and negative"]
+    #[doc = "* values. Any elevation higher than +6143.9 meters is represented as +61439."]
+    #[doc = "*"]
+    #[doc = "* Any elevation lower than -409.5 meters is represented as -4095."]
+    #[doc = "*"]
+    #[doc = "* If the sending device does not know its elevation, it shall encode the Elevation data element with -4096."]
+    #[doc = "*"]
+    #[doc = "* @note: When a vehicle is being measured, the elevation is taken from the horizontal spatial center of the vehicle"]
+    #[doc = "*        projected downward, regardless of vehicle tilt, to the point where the vehicle meets the road surface."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-4096..=61439"))]
+    pub struct Elevation(pub i32);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the 95% confidence level for the currently reported value of @ref Elevation,"]
+    #[doc = "* taking into account the current calibration and precision of the sensor(s) used to measure and/or"]
+    #[doc = "* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing"]
+    #[doc = "* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element"]
+    #[doc = "* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should"]
+    #[doc = "* be increased accordingly. The frame of reference and axis of rotation used shall be in accordance with that defined in Section 11."]
+    #[doc = "*"]
+    #[doc = "* - `unavailable` - 0:   B'0000 Not Equipped or unavailable"]
+    #[doc = "* - `elev-500-00` - 1:   B'0001 (500 m)"]
+    #[doc = "* - `elev-200-00` - 2:   B'0010 (200 m)"]
+    #[doc = "* - `elev-100-00` - 3:   B'0011 (100 m)"]
+    #[doc = "* - `elev-050-00` - 4:   B'0100 (50 m)"]
+    #[doc = "* - `elev-020-00` - 5:   B'0101 (20 m)"]
+    #[doc = "* - `elev-010-00` - 6:   B'0110 (10 m)"]
+    #[doc = "* - `elev-005-00` - 7:   B'0111 (5 m)"]
+    #[doc = "* - `elev-002-00` - 8:   B'1000 (2 m)"]
+    #[doc = "* - `elev-001-00` - 9:   B'1001 (1 m)"]
+    #[doc = "* - `elev-000-50` - 10:  B'1010 (50 cm)"]
+    #[doc = "* - `elev-000-20` - 11:  B'1011 (20 cm)"]
+    #[doc = "* - `elev-000-10` - 12:  B'1100 (10 cm)"]
+    #[doc = "* - `elev-000-05` - 13:  B'1101 (5 cm)"]
+    #[doc = "* - `elev-000-02` - 14:  B'1110 (2 cm)"]
+    #[doc = "* - `elev-000-01` - 15:  B'1111 (1 cm)"]
+    #[doc = "*"]
+    #[doc = "* @note: Encoded as a 4 bit value"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum ElevationConfidence {
+        unavailable = 0,
+        #[rasn(identifier = "elev-500-00")]
+        elev_500_00 = 1,
+        #[rasn(identifier = "elev-200-00")]
+        elev_200_00 = 2,
+        #[rasn(identifier = "elev-100-00")]
+        elev_100_00 = 3,
+        #[rasn(identifier = "elev-050-00")]
+        elev_050_00 = 4,
+        #[rasn(identifier = "elev-020-00")]
+        elev_020_00 = 5,
+        #[rasn(identifier = "elev-010-00")]
+        elev_010_00 = 6,
+        #[rasn(identifier = "elev-005-00")]
+        elev_005_00 = 7,
+        #[rasn(identifier = "elev-002-00")]
+        elev_002_00 = 8,
+        #[rasn(identifier = "elev-001-00")]
+        elev_001_00 = 9,
+        #[rasn(identifier = "elev-000-50")]
+        elev_000_50 = 10,
+        #[rasn(identifier = "elev-000-20")]
+        elev_000_20 = 11,
+        #[rasn(identifier = "elev-000-10")]
+        elev_000_10 = 12,
+        #[rasn(identifier = "elev-000-05")]
+        elev_000_05 = 13,
+        #[rasn(identifier = "elev-000-02")]
+        elev_000_02 = 14,
+        #[rasn(identifier = "elev-000-01")]
+        elev_000_01 = 15,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is a sequence of lane IDs for lane objects that are activated in the current map"]
+    #[doc = "* configuration. These lanes, unlike most lanes, have their RevocableLane bit set to one (asserted). Such lanes are not"]
+    #[doc = "* considered to be part of the current map unless they are in the Enabled Lane List. This concept is used to describe all the"]
+    #[doc = "* possible regulatory states for a given physical lane. For example, it is not uncommon to enable or disable the ability to"]
+    #[doc = "* make a right hand turn on red during different periods of a day. Another similar example would be a lane which is used for"]
+    #[doc = "* driving during one period and where parking is allowed at another. Traditionally, this information is conveyed to the vehicle"]
+    #[doc = "* driver by local signage. By using the Enabled Lane List data frame in conjunction with the RevocableLane bit and"]
+    #[doc = "* constructing a separate lane object in the intersection map for each different configuration, a single unified map can be"]
+    #[doc = "* developed and used."]
+    #[doc = "*"]
+    #[doc = "* Contents are the unique ID numbers for each lane object which is **active** as part of the dynamic map contents."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct EnabledLaneList(pub SequenceOf<LaneID>);
+    #[doc = "*"]
+    #[doc = "* This DE provides the type of fuel used by a vehicle."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct FuelType(pub u8);
+    #[doc = "*"]
+    #[doc = "* A complete report of the vehicle's position, speed, and heading at an instant in time. Used in the probe vehicle"]
+    #[doc = "* message (and elsewhere) as the initial position information. Often followed by other data frames that may provide offset"]
+    #[doc = "* path data."]
+    #[doc = "*"]
+    #[doc = "* @field utcTime:   time with mSec precision"]
+    #[doc = "* @field long:      Longitude in 1/10th microdegree"]
+    #[doc = "* @field lat:       Latitude in 1/10th microdegree"]
+    #[doc = "* @field elevation: Elevation in units of 0.1 m"]
+    #[doc = "* @field heading:   Heading value "]
+    #[doc = "* @field speed:     Speed value"]
+    #[doc = "* @field posAccuracy:      position accuracy"]
+    #[doc = "* @field timeConfidence:   time confidence"]
+    #[doc = "* @field posConfidence:    position confidence"]
+    #[doc = "* @field speedConfidence:  speed confidence "]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct FullPositionVector {
+        #[rasn(identifier = "utcTime")]
+        pub utc_time: Option<DDateTime>,
+        pub long: Longitude,
+        pub lat: Latitude,
+        pub elevation: Option<Elevation>,
+        pub heading: Option<HeadingDSRC>,
+        pub speed: Option<TransmissionAndSpeed>,
+        #[rasn(identifier = "posAccuracy")]
+        pub pos_accuracy: Option<PositionalAccuracy>,
+        #[rasn(identifier = "timeConfidence")]
+        pub time_confidence: Option<TimeConfidence>,
+        #[rasn(identifier = "posConfidence")]
+        pub pos_confidence: Option<PositionConfidenceSet>,
+        #[rasn(identifier = "speedConfidence")]
+        pub speed_confidence: Option<SpeedandHeadingandThrottleConfidence>,
+    }
+    impl FullPositionVector {
+        pub fn new(
+            utc_time: Option<DDateTime>,
+            long: Longitude,
+            lat: Latitude,
+            elevation: Option<Elevation>,
+            heading: Option<HeadingDSRC>,
+            speed: Option<TransmissionAndSpeed>,
+            pos_accuracy: Option<PositionalAccuracy>,
+            time_confidence: Option<TimeConfidence>,
+            pos_confidence: Option<PositionConfidenceSet>,
+            speed_confidence: Option<SpeedandHeadingandThrottleConfidence>,
+        ) -> Self {
+            Self {
+                utc_time,
+                long,
+                lat,
+                elevation,
+                heading,
+                speed,
+                pos_accuracy,
+                time_confidence,
+                pos_confidence,
+                speed_confidence,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to relate the current state of a GPS/GNSS rover or base system in terms"]
+    #[doc = "* of its general health, lock on satellites in view, and use of any correction information. Various bits can be asserted (made"]
+    #[doc = "* to a value of one) to reflect these values. A GNSS set with unknown health and no tracking or corrections would be"]
+    #[doc = "* represented by setting the unavailable bit to one. A value of zero shall be used when a defined data element is"]
+    #[doc = "* unavailable. The term \"GPS\" in any data element name in this standard does not imply that it is only to be used for GPS-"]
+    #[doc = "* type GNSS systems."]
+    #[doc = "*"]
+    #[doc = "* - `unavailable`              - 0: Not Equipped or unavailable"]
+    #[doc = "* - `isHealthy`                - 1:"]
+    #[doc = "* - `isMonitored`              - 2:"]
+    #[doc = "* - `baseStationType`          - 3: Set to zero if a moving base station, or if a rover device (an OBU), Set to one if it is a fixed base station"]
+    #[doc = "* - `aPDOPofUnder5`            - 4: A dilution of precision greater than 5"]
+    #[doc = "* - `inViewOfUnder5`           - 5: Less than 5 satellites in view"]
+    #[doc = "* - `localCorrectionsPresent`  - 6: DGPS type corrections used"]
+    #[doc = "* - `networkCorrectionsPresen` - 7: RTK type corrections used"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct GNSSstatus(pub FixedBitString<8usize>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousGenericLaneRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousGenericLaneRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousGenericLaneRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegGenericLane_Type, D::Error> {
+            RegGenericLane_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct GenericLaneRegional(pub SequenceOf<AnonymousGenericLaneRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used for all types of lanes, e.g. motorized vehicle lanes, crosswalks, medians. The"]
+    #[doc = "* GenericLane describes the basic attribute information of the lane. The LaneID value for each lane is unique within an"]
+    #[doc = "* intersection. One use for the LaneID is in the SPAT message, where a given signal or movement phase is mapped to a"]
+    #[doc = "* set of applicable lanes using their respective LaneIDs. The NodeList2 data frame includes a sequence of offset points (or"]
+    #[doc = "* node points) representing the center line path of the lane. As described in this standard, node points are sets of variable"]
+    #[doc = "* sized delta orthogonal offsets from the prior point in the node path. (The initial point is offset from the LLH anchor point"]
+    #[doc = "* used in the intersection.) Each node point may convey optional attribute data as well. The use of attributes is described"]
+    #[doc = "* further in the Node definition, and in a later clause, but an example use would be to indicate a node point where the lane"]
+    #[doc = "* width changes."]
+    #[doc = "*"]
+    #[doc = "* It should be noted that a \"lane\" is an abstract concept that can describe objects other than motorized vehicle lanes, and"]
+    #[doc = "* that the generic lane structure (using features drawn from Japanese usage) also allows combining multiple physical lanes"]
+    #[doc = "* into a single lane object. In addition, such lanes can describe connectivity points with other lanes beyond a single"]
+    #[doc = "* intersection, extending such a lane description over multiple nearby physical intersections and side streets which"]
+    #[doc = "* themselves may not be equipped or assigned an index number in the regional intersection numbering system. (See the"]
+    #[doc = "* ConnectsTo entry for details) This has value when describing a broader service area in terms of the roadway network,"]
+    #[doc = "* probably with less precision and detail."]
+    #[doc = "*"]
+    #[doc = "* @field laneID:  The unique ID number assigned to this lane object"]
+    #[doc = "* @field name:    often for debug use only but at times used to name ped crossings"]
+    #[doc = "* @field ingressApproach:  inbound Approach ID to which this lane belongs"]
+    #[doc = "* @field egressApproach: outbound Approach ID to which this lane belongs"]
+    #[doc = "* @field laneAttributes: All Attribute information about the basic selected lane type"]
+    #[doc = "*                        Directions of use, Geometric co-sharing and Type Specific Attributes"]
+    #[doc = "*                        These Attributes are **lane - global** that is, they are true for the entire length of the lane"]
+    #[doc = "* @field maneuvers: This data element allows only the description of a subset of possible manoeuvres and therefore"]
+    #[doc = "*                    reperesents an incomplete list of possible travel directions. The connecting **lane** data element gives"]
+    #[doc = "*                    the exact information about the manoeuvre relation from ingress to egress lane. Therefore the"]
+    #[doc = "*                    \"maneuver\" data element is used only additionally if the travel direction of the manoeuvre is"]
+    #[doc = "* @field nodeList: Lane spatial path information as well as various Attribute information along the node path"]
+    #[doc = "*                    Attributes found here are more general and may come and go over the length of the lane."]
+    #[doc = "* @field connectsTo: a list of other lanes and their signal group IDs each connecting lane and its signal group ID"]
+    #[doc = "*                    is given, therefore this element provides the information formerly in \"signalGroups\" in prior editions."]
+    #[doc = "* @field overlays: A list of any lanes which have spatial paths that overlay (run on top of, and not simply cross)"]
+    #[doc = "*                    the path of this lane when used"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @note: The data elements **ingressApproach** and **egressApproach** are used for grouping lanes whin an"]
+    #[doc = "*       approach (e.g. lanes defined in travel direction towards the intersection, lanes in exiting direction and"]
+    #[doc = "*       cross walks). For a bidirectrional lane (e.g. bike lane) both dataelements are used for the same lane. The"]
+    #[doc = "*       integer value used for identifying the **ingressApproach** and the **egressAproach**, based on the"]
+    #[doc = "*       topology, may be e.g. the same for all lanes within an approach of an intersection."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct GenericLane {
+        #[rasn(identifier = "laneID")]
+        pub lane_id: LaneID,
+        pub name: Option<DescriptiveName>,
+        #[rasn(identifier = "ingressApproach")]
+        pub ingress_approach: Option<ApproachID>,
+        #[rasn(identifier = "egressApproach")]
+        pub egress_approach: Option<ApproachID>,
+        #[rasn(identifier = "laneAttributes")]
+        pub lane_attributes: LaneAttributes,
+        pub maneuvers: Option<AllowedManeuvers>,
+        #[rasn(identifier = "nodeList")]
+        pub node_list: NodeListXY,
+        #[rasn(identifier = "connectsTo")]
+        pub connects_to: Option<ConnectsToList>,
+        pub overlays: Option<OverlayLaneList>,
+        pub regional: Option<GenericLaneRegional>,
+    }
+    impl GenericLane {
+        pub fn new(
+            lane_id: LaneID,
+            name: Option<DescriptiveName>,
+            ingress_approach: Option<ApproachID>,
+            egress_approach: Option<ApproachID>,
+            lane_attributes: LaneAttributes,
+            maneuvers: Option<AllowedManeuvers>,
+            node_list: NodeListXY,
+            connects_to: Option<ConnectsToList>,
+            overlays: Option<OverlayLaneList>,
+            regional: Option<GenericLaneRegional>,
+        ) -> Self {
+            Self {
+                lane_id,
+                name,
+                ingress_approach,
+                egress_approach,
+                lane_attributes,
+                maneuvers,
+                node_list,
+                connects_to,
+                overlays,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The DE_HeadingConfidence data element is used to provide the 95% confidence level for the currently reported"]
+    #[doc = "* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing"]
+    #[doc = "* value of DE_Heading, taking into account the current calibration and precision of the sensor(s) used to measure and/or"]
+    #[doc = "* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element"]
+    #[doc = "* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should"]
+    #[doc = "* be increased accordingly. The frame of reference and axis of rotation used shall be in accordance with that defined Section 11."]
+    #[doc = "*"]
+    #[doc = "* - `unavailable`   - 0: B'000 Not Equipped or unavailable"]
+    #[doc = "* - `prec10deg`     - 1: B'010 10 degrees"]
+    #[doc = "* - `prec05deg`     - 2: B'011 5 degrees"]
+    #[doc = "* - `prec01deg`     - 3: B'100 1 degrees"]
+    #[doc = "* - `prec0-1deg`    - 4: B'101 0.1 degrees"]
+    #[doc = "* - `prec0-05deg`   - 5: B'110 0.05 degrees"]
+    #[doc = "* - `prec0-01deg`   - 6: B'110 0.01 degrees"]
+    #[doc = "* - `prec0-0125deg` - 7: B'111 0.0125 degrees, aligned with heading LSB"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum HeadingConfidenceDSRC {
+        unavailable = 0,
+        prec10deg = 1,
+        prec05deg = 2,
+        prec01deg = 3,
+        #[rasn(identifier = "prec0-1deg")]
+        prec0_1deg = 4,
+        #[rasn(identifier = "prec0-05deg")]
+        prec0_05deg = 5,
+        #[rasn(identifier = "prec0-01deg")]
+        prec0_01deg = 6,
+        #[rasn(identifier = "prec0-0125deg")]
+        prec0_0125deg = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE provides the current heading of the sending device, expressed in unsigned units of"]
+    #[doc = "* 0.0125 degrees from North such that 28799 such degrees represent 359.9875 degrees. North shall be defined as the axis"]
+    #[doc = "* prescribed by the WGS-84 coordinate system and its reference ellipsoid. Headings \"to the east\" are defined as the"]
+    #[doc = "* positive direction. A value of 28800 shall be used when unavailable. This element indicates the direction of motion of the"]
+    #[doc = "* device. When the sending device is stopped and the trajectory (path) over which it traveled to reach that location is well"]
+    #[doc = "* known, the past heading may be used."]
+    #[doc = "*"]
+    #[doc = "* Value provides a range of 0 to 359.9875 degrees"]
+    #[doc = "*"]
+    #[doc = "* @unit: Note that other heading data elements of various sizes and precisions are found in other parts of this standard"]
+    #[doc = "*        and in ITS. This element should no longer be used for new work: the @ref Angle entry is preferred."]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.0125 degrees"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=28800"))]
+    pub struct HeadingDSRC(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DF is used to specify the index of either a single approach or a single lane at"]
+    #[doc = "* which a service is needed. This is used, for example, with the Signal Request Message (SRM) to indicate the inbound"]
+    #[doc = "* and outbound points by which the requestor (such as a public safety vehicle) can traverse an intersection."]
+    #[doc = "*"]
+    #[doc = "* @field lane: the representation of the point as lane identifier."]
+    #[doc = "* @field approach: the representation of the point as approach identifier."]
+    #[doc = "* @field connection: the representation of the point as connection identifier."]
+    #[doc = "*"]
+    #[doc = "* @note: Note that the value of zero has a reserved meaning for these two indexing systems. In both cases, this value"]
+    #[doc = "*    is used to indicate the concept of \"none\" in use. When the value is of zero is used here, it implies the center of the"]
+    #[doc = "*    intersection itself. For example, requesting an outbound point of zero implies the requestor wishes to have the intersection"]
+    #[doc = "*    itself be the destination. Alternatively, an inbound value of zero implies the requestor is within the intersection itself and"]
+    #[doc = "*    wishes to depart for the outbound value provided. This special meaning for the value zero can be used in either the lane"]
+    #[doc = "*    or approach with the same results."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum IntersectionAccessPoint {
+        lane(LaneID),
+        approach(ApproachID),
+        connection(LaneConnectionID),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousIntersectionGeometryRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousIntersectionGeometryRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousIntersectionGeometryRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegIntersectionGeometry_Type, D::Error> {
+            RegIntersectionGeometry_Type::decode(
+                decoder,
+                Some(&self.reg_ext_value),
+                &self.region_id,
+            )
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct IntersectionGeometryRegional(pub SequenceOf<AnonymousIntersectionGeometryRegional>);
+    #[doc = "*"]
+    #[doc = "* A complete description of an intersection's roadway geometry and its allowed navigational paths (independent of"]
+    #[doc = "* any additional regulatory restrictions that may apply over time or from user classification)."]
+    #[doc = "*"]
+    #[doc = "* @field name: For debug use only"]
+    #[doc = "* @field id: A globally unique value set, consisting of a regionID and intersection ID assignment"]
+    #[doc = "* @field revision: This profile extends the purpose of the **revision** data element as defined in SAE J2735 as follows."]
+    #[doc = "*           The revision data element is used to communicate the valid release of the intersection geometry"]
+    #[doc = "*           description. If there are no changes in the deployed intersection description, the same revision counter"]
+    #[doc = "*           is transmitted. Due to a revised deployment of the intersection description (e.g. new lane added, ID's"]
+    #[doc = "*           changed, etc.), the revision is increased by one. After revision equal to 127, the increment restarts by 0."]
+    #[doc = "*           The intersection geometry and the signal phase and timing information is related each other. Therefore,"]
+    #[doc = "*           the revision of the intersection geometry of the MapData message shall be the same as the revision of"]
+    #[doc = "*           the intersection state of the SPAT (see data element **revision** of **DF_IntersectionState** in [ISO TS 19091] G.8.2.9)"]
+    #[doc = "* @field refPoint: The reference from which subsequent data points are offset until a new point is used."]
+    #[doc = "* @field laneWidth: Reference width used by all subsequent lanes unless a new width is given"]
+    #[doc = "* @field speedLimits: Reference regulatory speed limits used by all subsequent lanes unless a new speed is given"]
+    #[doc = "* @field laneSet: Data about one or more lanes (all lane data is found here) Data describing how to use and request preemption and"]
+    #[doc = "*           priority services from this intersection (if supported)"]
+    #[doc = "* @field preemptPriorityData: This DF is not used."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct IntersectionGeometry {
+        pub name: Option<DescriptiveName>,
+        pub id: IntersectionReferenceID,
+        pub revision: MsgCount,
+        #[rasn(identifier = "refPoint")]
+        pub ref_point: Position3D,
+        #[rasn(identifier = "laneWidth")]
+        pub lane_width: Option<LaneWidth>,
+        #[rasn(identifier = "speedLimits")]
+        pub speed_limits: Option<SpeedLimitList>,
+        #[rasn(identifier = "laneSet")]
+        pub lane_set: LaneList,
+        #[rasn(identifier = "preemptPriorityData")]
+        pub preempt_priority_data: Option<PreemptPriorityList>,
+        pub regional: Option<IntersectionGeometryRegional>,
+    }
+    impl IntersectionGeometry {
+        pub fn new(
+            name: Option<DescriptiveName>,
+            id: IntersectionReferenceID,
+            revision: MsgCount,
+            ref_point: Position3D,
+            lane_width: Option<LaneWidth>,
+            speed_limits: Option<SpeedLimitList>,
+            lane_set: LaneList,
+            preempt_priority_data: Option<PreemptPriorityList>,
+            regional: Option<IntersectionGeometryRegional>,
+        ) -> Self {
+            Self {
+                name,
+                id,
+                revision,
+                ref_point,
+                lane_width,
+                speed_limits,
+                lane_set,
+                preempt_priority_data,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of IntersectionGeometry entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct IntersectionGeometryList(pub SequenceOf<IntersectionGeometry>);
+    #[doc = "*"]
+    #[doc = "* This DE is used within a region to uniquely define an intersection within that country or region in a 16-bit"]
+    #[doc = "* field. Assignment rules are established by the regional authority associated with the RoadRegulatorID under which this"]
+    #[doc = "* IntersectionID is assigned. Within the region the policies used to ensure an assigned value’s uniqueness before that value"]
+    #[doc = "* is reused (if ever) is the responsibility of that region. Any such reuse would be expected to occur over a long epoch (many years)."]
+    #[doc = "* The values zero through 255 are allocated for testing purposes"]
+    #[doc = "*"]
+    #[doc = "* @note:  Note that the value assigned to an intersection will be unique within a given regional ID only"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct IntersectionID(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DF conveys the combination of an optional RoadRegulatorID and of an"]
+    #[doc = "* IntersectionID that is unique within that region. When the RoadRegulatorID is present the IntersectionReferenceID is"]
+    #[doc = "* guaranteed to be globally unique."]
+    #[doc = "*"]
+    #[doc = "* @field region: a globally unique regional assignment value typical assigned to a regional DOT authority"]
+    #[doc = "*                the value zero shall be used for testing needs"]
+    #[doc = "* @field id: a unique mapping to the intersection in question within the above region of use"]
+    #[doc = "*"]
+    #[doc = "* @note: A fully qualified intersection consists of its regionally unique ID (the IntersectionID) and its region ID (the"]
+    #[doc = "*        RoadRegulatorID). Taken together these form a unique value which is never repeated."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct IntersectionReferenceID {
+        pub region: Option<RoadRegulatorID>,
+        pub id: IntersectionID,
+    }
+    impl IntersectionReferenceID {
+        pub fn new(region: Option<RoadRegulatorID>, id: IntersectionID) -> Self {
+            Self { region, id }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousIntersectionStateRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousIntersectionStateRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousIntersectionStateRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegIntersectionState_Type, D::Error> {
+            RegIntersectionState_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct IntersectionStateRegional(pub SequenceOf<AnonymousIntersectionStateRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey all the SPAT information for a single intersection. Both current"]
+    #[doc = "* and future data can be sent."]
+    #[doc = "*"]
+    #[doc = "* @field name: human readable name for intersection to be used only in debug mode"]
+    #[doc = "* @field id: A globally unique value set, consisting of a regionID and intersection ID assignment"]
+    #[doc = "*            provides a unique mapping to the intersection MAP in question which provides complete location"]
+    #[doc = "*            and approach/move/lane data"]
+    #[doc = "* @field revision: The data element **revision** is used to communicate the actual valid release of the intersection"]
+    #[doc = "*                  description. If there are no changes in the deployed intersection description, almost the same revision"]
+    #[doc = "*                  counter is transmitted. Due to a revised deployment of the intersection description (e.g. introduction of"]
+    #[doc = "*                  additional signal state element), the revision is increased by one. After revision equal to 127, the"]
+    #[doc = "*                  increment leads to 0 (due to the element range)."]
+    #[doc = "*                  The intersection state and the intersection geometry is related to each other. Therefore, the revision of"]
+    #[doc = "*                  the intersection state shall be the same as the revision of the intersection geometry (see the data"]
+    #[doc = "*                  element **revision** of **DF_IntersectionGeometry** in [ISO TS 19091] G.8.2.6)."]
+    #[doc = "* @field status: general status of the controller(s)"]
+    #[doc = "* @field moy: Minute of current UTC year, used only with messages to be archived."]
+    #[doc = "* @field timeStamp: the mSec point in the current UTC minute that this message was constructed."]
+    #[doc = "* @field enabledLanes: a list of lanes where the RevocableLane bit has been set which are now active and"]
+    #[doc = "*                      therefore part of the current intersection"]
+    #[doc = "* @field states: Each Movement is given in turn and contains its signal phase state,"]
+    #[doc = "*                mapping to the lanes it applies to, and point in time it will end, and it"]
+    #[doc = "*                may contain both active and future states"]
+    #[doc = "* @field maneuverAssistList: Assist data"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct IntersectionState {
+        pub name: Option<DescriptiveName>,
+        pub id: IntersectionReferenceID,
+        pub revision: MsgCount,
+        pub status: IntersectionStatusObject,
+        pub moy: Option<MinuteOfTheYear>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<DSecond>,
+        #[rasn(identifier = "enabledLanes")]
+        pub enabled_lanes: Option<EnabledLaneList>,
+        pub states: MovementList,
+        #[rasn(identifier = "maneuverAssistList")]
+        pub maneuver_assist_list: Option<ManeuverAssistList>,
+        pub regional: Option<IntersectionStateRegional>,
+    }
+    impl IntersectionState {
+        pub fn new(
+            name: Option<DescriptiveName>,
+            id: IntersectionReferenceID,
+            revision: MsgCount,
+            status: IntersectionStatusObject,
+            moy: Option<MinuteOfTheYear>,
+            time_stamp: Option<DSecond>,
+            enabled_lanes: Option<EnabledLaneList>,
+            states: MovementList,
+            maneuver_assist_list: Option<ManeuverAssistList>,
+            regional: Option<IntersectionStateRegional>,
+        ) -> Self {
+            Self {
+                name,
+                id,
+                revision,
+                status,
+                moy,
+                time_stamp,
+                enabled_lanes,
+                states,
+                maneuver_assist_list,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of IntersectionState entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct IntersectionStateList(pub SequenceOf<IntersectionState>);
+    #[doc = "*"]
+    #[doc = "* The Intersection Status Object contains Advanced Traffic Controller (ATC) status information that may be sent to"]
+    #[doc = "* local OBUs as part of the SPAT process."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `manualControlIsEnabled`                - 0: Timing reported is per programmed values, etc. but person at cabinet can manually request that certain intervals are terminated early (e.g. green)."]
+    #[doc = "* - `stopTimeIsActivated`                   - 1: And all counting/timing has stopped."]
+    #[doc = "* - `failureFlash`                          - 2: Above to be used for any detected hardware failures, e.g. conflict monitor as well as for police flash"]
+    #[doc = "* - `fixedTimeOperation`                    - 5: Schedule of signals is based on time only (i.e. the state can be calculated)"]
+    #[doc = "* - `trafficDependentOperation`             - 6: Operation is based on different levels of traffic parameters (requests, duration of gaps or more complex parameters)"]
+    #[doc = "* - `standbyOperation`                      - 7: Controller: partially switched off or partially amber flashing"]
+    #[doc = "* - `failureMode`                           - 8: Controller has a problem or failure in operation"]
+    #[doc = "* - `off`                                   - 9: Controller is switched off"]
+    #[doc = "* - `recentMAPmessageUpdate`                - 10: Map revision with content changes"]
+    #[doc = "* - `recentChangeInMAPassignedLanesIDsUsed` - 11: Change in MAP's assigned lanes used (lane changes) Changes in the active lane list description"]
+    #[doc = "* - `noValidMAPisAvailableAtThisTime`       - 12: MAP (and various lanes indexes) not available"]
+    #[doc = "* - `noValidSPATisAvailableAtThisTime`      - 13: SPAT system is not working at this time"]
+    #[doc = "* - Bits 14,15 reserved at this time and shall be zero"]
+    #[doc = "*"]
+    #[doc = "* @note: All zeros indicate normal operating mode with no recent changes. The duration of the term **recent** is defined by the system performance requirement in use."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IntersectionStatusObject(pub FixedBitString<16usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LaneAttributesRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl LaneAttributesRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl LaneAttributesRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegLaneAttributes_Type, D::Error> {
+            RegLaneAttributes_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF holds all of the constant attribute information of any lane object (as well as"]
+    #[doc = "* denoting the basic lane type itself) within a single structure. Constant attribute information are those values which do not"]
+    #[doc = "* change over the path of the lane, such as the direction of allowed travel. Other lane attribute information can change at or"]
+    #[doc = "* between each node."]
+    #[doc = "* The structure consists of three element parts as follows: LaneDirection specifies the allowed directions of travel, if any."]
+    #[doc = "* LaneSharing indicates whether this lane type is shared with other types of travel modes or users. The lane type is defined"]
+    #[doc = "* in LaneTypeAttributes, along with additional attributes specific to that type."]
+    #[doc = "* The fundamental type of lane object is described by the element selected in the LaneTypeAttributes data concept."]
+    #[doc = "* Additional information specific or unique to a given lane type can be found there as well. A regional extension is provided"]
+    #[doc = "* as well."]
+    #[doc = "* Note that combinations of regulatory maneuver information such as \"both a left turn and straight ahead movement are"]
+    #[doc = "* allowed, but never a u-turn,\" are expressed by the AllowedManeuvers data concept which typically follows after this"]
+    #[doc = "* element and in the same structure. Note that not all lane objects require this information (for example a median). The"]
+    #[doc = "* various values are set via bit flags to indicate the assertion of a value. Each defined lane type contains the bit flags"]
+    #[doc = "* suitable for its application area."]
+    #[doc = "* Note that the concept of LaneSharing is used to indicate that there are other users of this lane with equal regulatory rights"]
+    #[doc = "* to occupy the lane (which is a term this standard does not formally define since it varies by world region). A typical case is"]
+    #[doc = "* a light rail vehicle running along the same lane path as motorized traffic. In such a case, motor traffic may be allowed"]
+    #[doc = "* equal access to the lane when a train is not present. Another case would be those intersection lanes (at the time of writing"]
+    #[doc = "* rather unusual) where bicycle traffic is given full and equal right of way to an entire width of motorized vehicle lane. This"]
+    #[doc = "* example would not be a bike lane or bike box in the traditional sense."]
+    #[doc = "*"]
+    #[doc = "* @field directionalUse: directions of lane use"]
+    #[doc = "* @field sharedWith: co-users of the lane path"]
+    #[doc = "* @field laneType: specific lane type data"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct LaneAttributes {
+        #[rasn(identifier = "directionalUse")]
+        pub directional_use: LaneDirection,
+        #[rasn(identifier = "sharedWith")]
+        pub shared_with: LaneSharing,
+        #[rasn(identifier = "laneType")]
+        pub lane_type: LaneTypeAttributes,
+        pub regional: Option<LaneAttributesRegional>,
+    }
+    impl LaneAttributes {
+        pub fn new(
+            directional_use: LaneDirection,
+            shared_with: LaneSharing,
+            lane_type: LaneTypeAttributes,
+            regional: Option<LaneAttributesRegional>,
+        ) -> Self {
+            Self {
+                directional_use,
+                shared_with,
+                lane_type,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a Barrier or Median lane type (a type of lane object used to separate traffic lanes)."]
+    #[doc = "* It should be noted that various common lane attribute properties (such as travel directions and allowed movements or maneuvers) can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `median-RevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - Bits 10-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Barrier")]
+    pub struct LaneAttributesBarrier(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a bicycle lane type. It should be noted that various common lane attribute properties"]
+    #[doc = "* (such as travel directions and allowed movements or maneuvers) can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `bikeRevocableLane`       - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - `pedestrianUseAllowed`    - 1: The path allows pedestrian traffic, if not set, this mode is prohibited"]
+    #[doc = "* - `isBikeFlyOverLane`       - 2: path of lane is not at grade"]
+    #[doc = "* - `fixedCycleTime`          - 3: the phases use preset times, i.e. there is not a **push to cross** button"]
+    #[doc = "* - `biDirectionalCycleTimes` - 4: ped walk phases use different SignalGroupID for each direction. The first SignalGroupID in the first Connection"]
+    #[doc = "*                                  represents **inbound** flow (the direction of travel towards the first node point) while second SignalGroupID in the"]
+    #[doc = "*                                  next Connection entry represents the `outbound` flow. And use of RestrictionClassID entries in the Connect follow this same pattern in pairs."]
+    #[doc = "* - `isolatedByBarrier`           - 5: The lane path is isolated by a fixed barrier"]
+    #[doc = "* - `unsignalizedSegmentsPresent` - 6: The lane path consists of one of more segments which are not part of a signal group ID"]
+    #[doc = "* - Bits 7-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Bike")]
+    pub struct LaneAttributesBike(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a crosswalk lane type. It should be noted that various common lane attribute properties"]
+    #[doc = "* (such as travel directions and allowed movements or maneuvers) can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `crosswalkRevocableLane`  - 0:  this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - `bicyleUseAllowed`        - 1: The path allows bicycle traffic, if not set, this mode is prohibited"]
+    #[doc = "* - `isXwalkFlyOverLane`      - 2: path of lane is not at grade"]
+    #[doc = "* - `fixedCycleTime`          - 3: ped walk phases use preset times. i.e. there is not a **push to cross** button"]
+    #[doc = "* - `biDirectionalCycleTimes` - 4:  ped walk phases use different SignalGroupID for each direction. The first SignalGroupID"]
+    #[doc = "*                                   in the first Connection represents **inbound** flow (the direction of travel towards the first"]
+    #[doc = "*                                   node point) while second SignalGroupID in the next Connection entry represents the **outbound**"]
+    #[doc = "*                                   flow. And use of RestrictionClassID entries in the Connect follow this same pattern in pairs."]
+    #[doc = "* - `hasPushToWalkButton`     - 5: Has a demand input"]
+    #[doc = "* - `audioSupport`            - 6:  audio crossing cues present"]
+    #[doc = "* - `rfSignalRequestPresent`  - 7: Supports RF push to walk technologies"]
+    #[doc = "* - `unsignalizedSegmentsPresent` - 8: The lane path consists of one of more segments which are not part of a signal group ID"]
+    #[doc = "* - Bits 9-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Crosswalk")]
+    pub struct LaneAttributesCrosswalk(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a vehicle parking lane type. It should be noted that various common lane attribute"]
+    #[doc = "* properties can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `parkingRevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - `doNotParkZone`        - 3: used to denote fire hydrants as well as short disruptions in a parking zone"]
+    #[doc = "* - `noPublicParkingUse`   - 6: private parking, as in front of private property"]
+    #[doc = "* - Bits 7-15 reserved and set to zero*"]
+    #[doc = "*"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Parking")]
+    pub struct LaneAttributesParking(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a sidewalk lane type. It should be noted that various common lane attribute properties"]
+    #[doc = "* (such as travel directions and allowed movements or maneuvers) can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `sidewalk-RevocableLane`- 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present."]
+    #[doc = "* - `bicyleUseAllowed`      - 1: The path allows bicycle traffic, if not set, this mode is prohibited"]
+    #[doc = "* - `isSidewalkFlyOverLane` - 2: path of lane is not at grade"]
+    #[doc = "* - `walkBikes`             - 3: bike traffic must dismount and walk"]
+    #[doc = "* - Bits 4-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Sidewalk")]
+    pub struct LaneAttributesSidewalk(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in various types of ground striping lane"]
+    #[doc = "* types. This includes various types of painted lane ground striping and iconic information needs to convey information in a"]
+    #[doc = "* complex intersection. Typically, this consists of visual guidance for drivers to assist them to connect across the"]
+    #[doc = "* intersection to the correct lane. Such markings are typically used with restraint and only under conditions when the"]
+    #[doc = "* geometry of the intersection makes them more beneficial than distracting. It should be noted that various common lane"]
+    #[doc = "* attribute properties (such as travel directions and allowed movements or maneuvers) can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `stripeToConnectingLanesRevocableLane` - 0: this lane may be activated or not activated based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - `stripeToConnectingLanesAhead` - 5: the stripe type should be presented to the user visually to reflect stripes in the intersection for the type of movement indicated."]
+    #[doc = "* - Bits 6-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Striping")]
+    pub struct LaneAttributesStriping(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a tracked vehicle lane types (trolley"]
+    #[doc = "* and train lanes). The term “rail vehicle” can be considered synonymous. In this case, the term does not relate to vehicle"]
+    #[doc = "* types with tracks or treads. It should be noted that various common lane attribute properties (such as travel directions and"]
+    #[doc = "* allowed movements or maneuvers) can be found in other entries. It should also be noted that often this type of lane object"]
+    #[doc = "* does not clearly relate to an approach in the traditional traffic engineering sense, although the message set allows"]
+    #[doc = "* assigning a value when desired."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `spec-RevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present."]
+    #[doc = "* - Bits 5-15 reserved and set to zero"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-TrackedVehicle")]
+    pub struct LaneAttributesTrackedVehicle(pub FixedBitString<16usize>);
+    #[doc = "*"]
+    #[doc = "* This DE relates specific properties found in a vehicle lane type. This data element provides a means to denote that the use of a lane"]
+    #[doc = "* is restricted to certain vehicle types. Various common lane attribute properties (such as travel directions and allowed movements or maneuvers)"]
+    #[doc = "* can be found in other entries."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - `isVehicleRevocableLane` - 0: this lane may be activated or not based on the current SPAT message contents if not asserted, the lane is ALWAYS present"]
+    #[doc = "* - `isVehicleFlyOverLane`   - 1: path of lane is not at grade"]
+    #[doc = "* - `permissionOnRequest`    - 7: e.g. to inform about a lane for e-cars"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "LaneAttributes-Vehicle", size("8", extensible))]
+    pub struct LaneAttributesVehicle(pub BitString);
+    #[doc = "*"]
+    #[doc = "* This DE is used to state a connection index for a lane to lane connection. It is used to"]
+    #[doc = "* relate this connection between the lane (defined in the MAP) and any dynamic clearance data sent in the SPAT. It should"]
+    #[doc = "* be noted that the index may be shared with other lanes (for example, two left turn lanes may share the same dynamic"]
+    #[doc = "* clearance data). It should also be noted that a given lane to lane connection may be part of more than one GroupID due"]
+    #[doc = "* to signal phase considerations, but will only have one ConnectionID. The ConnectionID concept is not used (is not"]
+    #[doc = "* present) when dynamic clearance data is not provided in the SPAT."]
+    #[doc = "*"]
+    #[doc = "* @note: It should be noted that the LaneConnectionID is used as a means to index to a connection description"]
+    #[doc = "*        between two lanes. It is not the same as the laneID, which is the unique index to each lane itself."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct LaneConnectionID(pub u8);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousLaneDataAttributeRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousLaneDataAttributeRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousLaneDataAttributeRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegLaneDataAttribute_Type, D::Error> {
+            RegLaneDataAttribute_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct LaneDataAttributeRegional(pub SequenceOf<AnonymousLaneDataAttributeRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to relate an attribute and a control value at a node point or along a"]
+    #[doc = "* lane segment from an enumerated list of defined choices. It is then followed by a defined data value associated with it and"]
+    #[doc = "* which is defined elsewhere in this standard."]
+    #[doc = "*"]
+    #[doc = "* @field pathEndPointAngle: adjusts final point/width slant of the lane to align with the stop line"]
+    #[doc = "* @field laneCrownPointCenter: sets the canter of the road bed from centerline point"]
+    #[doc = "* @field laneCrownPointLeft: sets the canter of the road bed from left edge"]
+    #[doc = "* @field laneCrownPointRight: sets the canter of the road bed from right edge"]
+    #[doc = "* @field laneAngle: the angle or direction of another lane this is required when a merge point angle is required"]
+    #[doc = "* @field speedLimits: Reference regulatory speed limits used by all segments"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @note: This data concept handles a variety of use case needs with a common and consistent message pattern. The"]
+    #[doc = "*     typical use of this data concept (and several similar others) is to inject the selected Attribute into the spatial description of"]
+    #[doc = "*     a lane's center line path (the segment list). In this way, attribute information which is true for a portion of the overall lane"]
+    #[doc = "*     can be described when needed. This attribute information applies from the node point in the stream of segment data until"]
+    #[doc = "*     changed again. Denoting the porous aspects of a lane along its path as it merges with another lane would be an example"]
+    #[doc = "*     of this use case. In this case the start and end node points would be followed by suitable segment attributes. Re-using a"]
+    #[doc = "*     lane path (previously called a computed lane) is another example. In this case the reference lane to be re-used appears"]
+    #[doc = "*     as a segment attribute followed by the lane value. It is then followed by one or more segment attributes which relate the"]
+    #[doc = "*     positional translation factors to be used (offset, rotate, scale) and any further segment attribute changes."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum LaneDataAttribute {
+        pathEndPointAngle(DeltaAngle),
+        laneCrownPointCenter(RoadwayCrownAngle),
+        laneCrownPointLeft(RoadwayCrownAngle),
+        laneCrownPointRight(RoadwayCrownAngle),
+        laneAngle(MergeDivergeNodeAngle),
+        speedLimits(SpeedLimitList),
+        regional(LaneDataAttributeRegional),
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of LaneDataAttribute entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8"))]
+    pub struct LaneDataAttributeList(pub SequenceOf<LaneDataAttribute>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to denote the allowed direction of travel over a lane object. By convention, the lane object is always described"]
+    #[doc = "* from the stop line outwards away from the intersection. Therefore, the ingress direction is from the end of the path to the stop"]
+    #[doc = "* line and the egress direction is from the stop line outwards."]
+    #[doc = "*"]
+    #[doc = "* It should be noted that some lane objects are not used for travel and that some lane objects allow bi-directional travel."]
+    #[doc = "*"]
+    #[doc = "* With bits as defined:"]
+    #[doc = "* - Allowed directions of travel in the lane object"]
+    #[doc = "* - All lanes are described from the stop line outwards"]
+    #[doc = "*"]
+    #[doc = "* @field ingressPath: travel from rear of path to front is allowed"]
+    #[doc = "*"]
+    #[doc = "* @field egressPath: travel from front of path to rear is allowed"]
+    #[doc = "*"]
+    #[doc = "* @note: No Travel, i.e. the lane object type does not support travel (medians, curbs, etc.) is indicated by not"]
+    #[doc = "*        asserting any bit value Bi-Directional Travel (such as a ped crosswalk) is indicated by asserting both of the bits."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct LaneDirection(pub FixedBitString<2usize>);
+    #[doc = "*"]
+    #[doc = "* This DE conveys an assigned index that is unique within an intersection. It is used to refer to"]
+    #[doc = "* that lane by other objects in the intersection map data structure. Lanes may be ingress (inbound traffic) or egress"]
+    #[doc = "* (outbound traffic) in nature, as well as barriers and other types of specialty lanes. Each lane (each lane object) is"]
+    #[doc = "* assigned a unique ID. The Lane ID, in conjunction with the intersection ID, forms a regionally unique way to address a"]
+    #[doc = "* specific lane in that region."]
+    #[doc = "*"]
+    #[doc = "* - the value 0 shall be used when the lane ID is not available or not known"]
+    #[doc = "* - the value 255 is reserved for future use"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct LaneID(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of GenericLane entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=255"))]
+    pub struct LaneList(pub SequenceOf<GenericLane>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to denote the presence of other user types (travel modes) who have an"]
+    #[doc = "* equal right to access and use the lane. There may also be another lane object describing their use of a lane. This data"]
+    #[doc = "* concept is used to indicate lanes and/or users that travel along the same path, and not those that simply cross over the"]
+    #[doc = "* lane's segments path (such as a pedestrian crosswalk crossing a lane for motor vehicle use). The typical use is to alert"]
+    #[doc = "* the user of the MAP data that additional traffic of another mode may be present in the same spatial lane."]
+    #[doc = "*"]
+    #[doc = "* Bits used:"]
+    #[doc = "* - 0 - overlappingLaneDescriptionProvided: Assert when another lane object is present to describe the"]
+    #[doc = "*                                           path of the overlapping shared lane this construct is not used for lane objects which simply cross"]
+    #[doc = "* - 1 - multipleLanesTreatedAsOneLane: Assert if the lane object path and width details represents multiple lanes within it"]
+    #[doc = "*                                      that are not further described Various modes and type of traffic that may share this lane:"]
+    #[doc = "* - 2 - otherNonMotorizedTrafficTypes: horse drawn etc."]
+    #[doc = "* - 3 - individualMotorizedVehicleTraffic:"]
+    #[doc = "* - 4 - busVehicleTraffic:"]
+    #[doc = "* - 5 - taxiVehicleTraffic:"]
+    #[doc = "* - 6 - pedestriansTraffic:"]
+    #[doc = "* - 7 - cyclistVehicleTraffic:"]
+    #[doc = "* - 8 - trackedVehicleTraffic:"]
+    #[doc = "* - 9 - pedestrianTraffic:"]
+    #[doc = "*"]
+    #[doc = "* @note: All zeros would indicate **not shared** and **not overlapping**"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct LaneSharing(pub FixedBitString<10usize>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to hold attribute information specific to a given lane type. It is typically"]
+    #[doc = "* used in the DE_LaneAttributes data frame as part of an overall description of a lane object. Information unique to the"]
+    #[doc = "* specific type of lane is found here. Information common to lanes is expressed in other entries. The various values are set"]
+    #[doc = "* by bit flags to indicate the assertion of a value. Each defined lane type contains bit flags suitable for its application area."]
+    #[doc = "*"]
+    #[doc = "* @field vehicle:         motor vehicle lanes"]
+    #[doc = "*"]
+    #[doc = "* @field crosswalk:       pedestrian crosswalks"]
+    #[doc = "*"]
+    #[doc = "* @field bikeLane:        bike lanes"]
+    #[doc = "*"]
+    #[doc = "* @field sidewalk:        pedestrian sidewalk paths"]
+    #[doc = "*"]
+    #[doc = "* @field median:          medians & channelization"]
+    #[doc = "*"]
+    #[doc = "* @field striping:        roadway markings"]
+    #[doc = "*"]
+    #[doc = "* @field trackedVehicle:  trains and trolleys"]
+    #[doc = "*"]
+    #[doc = "* @field parking:         parking and stopping lanes"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum LaneTypeAttributes {
+        vehicle(LaneAttributesVehicle),
+        crosswalk(LaneAttributesCrosswalk),
+        bikeLane(LaneAttributesBike),
+        sidewalk(LaneAttributesSidewalk),
+        median(LaneAttributesBarrier),
+        striping(LaneAttributesStriping),
+        trackedVehicle(LaneAttributesTrackedVehicle),
+        parking(LaneAttributesParking),
+    }
+    #[doc = "*"]
+    #[doc = "* This DE conveys the width of a lane in LSB units of 1 cm. Maximum value for a lane is 327.67 meters in width"]
+    #[doc = "*"]
+    #[doc = "* @units: cm"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct LaneWidth(pub u16);
+    #[doc = "*"]
+    #[doc = "* Large @ref MapData descriptions are not possible to be broadcast with a single message and have to be"]
+    #[doc = "* fragmented using two or more messages over the air. Therefore, the LayerID allows defining an"]
+    #[doc = "* index for fragmentation of large @ref MapData descriptions. The fragmentation of the messages shall be"]
+    #[doc = "* executed on application layer. The fragmentation occurs on an approach base. This means that almost a"]
+    #[doc = "* complete approach (e.g. lanes, connectsTo, etc.) has to be included within a fragment."]
+    #[doc = "* The decimal value of the **layerID** is used to define the amount of maximum @ref MapData fragments. The"]
+    #[doc = "* lower value defines the actual fragment."]
+    #[doc = "*"]
+    #[doc = "* Example:"]
+    #[doc = "* If a MapData consists of three fragments (e.g. three approaches), the fragments are identified as follows:"]
+    #[doc = "* - `31` - first fragment of three (e.g. approach south);"]
+    #[doc = "* - `33` - third fragment of three (e.g. approach north)."]
+    #[doc = "* - `32` - second fragment of three (e.g. approach west);"]
+    #[doc = "*"]
+    #[doc = "* If there are only two fragments, the fragment identification will be 21, 22."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=100"))]
+    pub struct LayerID(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to uniquely identify the type of information to be found in a layer of a geographic map fragment such as an intersection."]
+    #[doc = "*"]
+    #[doc = "* @field `mixedContent`: two or more of the below types"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum LayerType {
+        none = 0,
+        mixedContent = 1,
+        generalMapData = 2,
+        intersectionData = 3,
+        curveData = 4,
+        roadwaySectionData = 5,
+        parkingAreaData = 6,
+        sharedLaneData = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 line information."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct LineNumber(pub u32);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref ConnectionManeuverAssist entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct ManeuverAssistList(pub SequenceOf<ConnectionManeuverAssist>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousMapDataRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousMapDataRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousMapDataRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegMapData_Type, D::Error> {
+            RegMapData_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct MapDataRegional(pub SequenceOf<AnonymousMapDataRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey many types of geographic road information. At the current time its primary"]
+    #[doc = "* use is to convey one or more intersection lane geometry maps within a single message. The map message content"]
+    #[doc = "* includes such items as complex intersection descriptions, road segment descriptions, high speed curve outlines (used in"]
+    #[doc = "* curve safety messages), and segments of roadway (used in some safety applications). A given single MapData message"]
+    #[doc = "* may convey descriptions of one or more geographic areas or intersections. The contents of this message involve defining"]
+    #[doc = "* the details of indexing systems that are in turn used by other messages to relate additional information (for example, the"]
+    #[doc = "* signal phase and timing via the SPAT message) to events at specific geographic locations on the roadway."]
+    #[doc = "*"]
+    #[doc = "* @field timeStamp: time reference"]
+    #[doc = "* @field msgIssueRevision: The MapData revision is defined by the data element **revision** for each intersection"]
+    #[doc = "*                          geometry (see [ISO TS 19091] G.8.2.4.1). Therefore, an additional revision indication of the overall"]
+    #[doc = "*                          MapData message is not used in this profile. It shall be set to \"0\" for this profile."]
+    #[doc = "* @field layerType: There is no need to additionally identify the topological content by an additional identifier. The ASN.1"]
+    #[doc = "*                   definition of the data frames **intersections** and **roadSegments** are clearly defined and need no"]
+    #[doc = "*                   additional identifier. Therefore, this optional data element shall not be used in this profile."]
+    #[doc = "* @field layerID: This profile extends the purpose of the **layerID** data element as defined in SAE J2735 as follows: For"]
+    #[doc = "*                 large intersections, the length of a MapData description may exceed the maximum data length of the"]
+    #[doc = "*                 communication message. Therefore, a fragmentation of the MapData message (at application layer) in"]
+    #[doc = "*                 two or more MapData fragments may be executed. If no MapData fragmentation is needed, the **layerID**"]
+    #[doc = "*                 shall not be used. For more details, see the definition of the data element @ref LayerID."]
+    #[doc = "* @field intersections: All Intersection definitions."]
+    #[doc = "* @field roadSegments: All roadway descriptions."]
+    #[doc = "* @field dataParameters: Any meta data regarding the map contents."]
+    #[doc = "* @field restrictionList: Any restriction ID tables which have established for these map entries"]
+    #[doc = "* @field regional: This profile extends the MapData message with the regional data element @ref MapData-addGrpC"]
+    #[doc = "*"]
+    #[doc = "* @category: Road topology information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MapData {
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<MinuteOfTheYear>,
+        #[rasn(identifier = "msgIssueRevision")]
+        pub msg_issue_revision: MsgCount,
+        #[rasn(identifier = "layerType")]
+        pub layer_type: Option<LayerType>,
+        #[rasn(identifier = "layerID")]
+        pub layer_id: Option<LayerID>,
+        pub intersections: Option<IntersectionGeometryList>,
+        #[rasn(identifier = "roadSegments")]
+        pub road_segments: Option<RoadSegmentList>,
+        #[rasn(identifier = "dataParameters")]
+        pub data_parameters: Option<DataParameters>,
+        #[rasn(identifier = "restrictionList")]
+        pub restriction_list: Option<RestrictionClassList>,
+        pub regional: Option<MapDataRegional>,
+    }
+    impl MapData {
+        pub fn new(
+            time_stamp: Option<MinuteOfTheYear>,
+            msg_issue_revision: MsgCount,
+            layer_type: Option<LayerType>,
+            layer_id: Option<LayerID>,
+            intersections: Option<IntersectionGeometryList>,
+            road_segments: Option<RoadSegmentList>,
+            data_parameters: Option<DataParameters>,
+            restriction_list: Option<RestrictionClassList>,
+            regional: Option<MapDataRegional>,
+        ) -> Self {
+            Self {
+                time_stamp,
+                msg_issue_revision,
+                layer_type,
+                layer_id,
+                intersections,
+                road_segments,
+                data_parameters,
+                restriction_list,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The angle at which another lane path meets the current lanes at the node point. Typically found in the node"]
+    #[doc = "* attributes and used to describe the angle of the departing or merging lane. Note that oblique and obtuse angles are allowed."]
+    #[doc = "*"]
+    #[doc = "* The value `-180` shall be used to represent data is not available or unknown"]
+    #[doc = "*"]
+    #[doc = "* @unit: 1.5 degrees from north"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-180..=180"))]
+    pub struct MergeDivergeNodeAngle(pub i16);
+    #[doc = "*"]
+    #[doc = "* This DE expresses the number of elapsed minutes of the current year in the time system being used (typically UTC time)."]
+    #[doc = "*"]
+    #[doc = "* It is typically used to provide a longer range time stamp indicating when a message was created."]
+    #[doc = "* Taken together with the DSecond data element, it provides a range of one full year with a resolution of 1 millisecond."]
+    #[doc = "*"]
+    #[doc = "* The value 527040 shall be used for invalid."]
+    #[doc = "*"]
+    #[doc = "* @note: It should be noted that at the yearly roll-over point there is no \"zero\" minute, in the same way that there was"]
+    #[doc = "*        never a \"year zero\" at the very start of the common era (BC -> AD). By using the number of elapsed whole minutes here"]
+    #[doc = "*        this issue is avoided and the first valid value of every new year is zero, followed by one, etc. Leap years are"]
+    #[doc = "*        accommodated, as are leap seconds in the DSecond data concept."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=527040"))]
+    pub struct MinuteOfTheYear(pub u32);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousMovementEventRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousMovementEventRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousMovementEventRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegMovementEvent_Type, D::Error> {
+            RegMovementEvent_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct MovementEventRegional(pub SequenceOf<AnonymousMovementEventRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF contains details about a single movement. It is used by the movement state to"]
+    #[doc = "* convey one of number of movements (typically occurring over a sequence of times) for a SignalGroupID."]
+    #[doc = "*"]
+    #[doc = "* @field eventState: Consisting of: Phase state (the basic 11 states), Directional, protected, or permissive state"]
+    #[doc = "* @field timing: Timing Data in UTC time stamps for event includes start and min/max end times of phase confidence and estimated next occurrence"]
+    #[doc = "* @field speeds: various speed advisories for use by general and specific types of vehicles supporting green-wave and other flow needs"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MovementEvent {
+        #[rasn(identifier = "eventState")]
+        pub event_state: MovementPhaseState,
+        pub timing: Option<TimeChangeDetails>,
+        pub speeds: Option<AdvisorySpeedList>,
+        pub regional: Option<MovementEventRegional>,
+    }
+    impl MovementEvent {
+        pub fn new(
+            event_state: MovementPhaseState,
+            timing: Option<TimeChangeDetails>,
+            speeds: Option<AdvisorySpeedList>,
+            regional: Option<MovementEventRegional>,
+        ) -> Self {
+            Self {
+                event_state,
+                timing,
+                speeds,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref MovementEvent entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct MovementEventList(pub SequenceOf<MovementEvent>);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref MovementState entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=255"))]
+    pub struct MovementList(pub SequenceOf<MovementState>);
+    #[doc = "*"]
+    #[doc = "* This DE provides the overall current state of the movement (in many cases a signal state), including its core phase state"]
+    #[doc = "*  and an indication of whether this state is permissive or protected."]
+    #[doc = "*"]
+    #[doc = "* It is expected that the allowed transitions from one state to another will be defined by regional deployments. Not all"]
+    #[doc = "* regions will use all states; however, no new states are to be defined. In most regions a regulatory body provides precise"]
+    #[doc = "* legal definitions of these state changes. For example, in the US the MUTCD is used, as is indicated in the US regional"]
+    #[doc = "* variant of the above image. In various regions and modes of transportation, the visual expression of these states varies"]
+    #[doc = "* (the precise meaning of various color combinations, shapes, and/or flashing etc.). The below definition is designed to to"]
+    #[doc = "* be independent of these regional conventions."]
+    #[doc = "*"]
+    #[doc = "* Values:"]
+    #[doc = "* - `unavailable` - 0:         This state is used for unknown or error"]
+    #[doc = "* - `dark` - 1:                The signal head is dark (unlit)"]
+    #[doc = "* - `stop-Then-Proceed` - 2:   Often called **flashing red**"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Stop vehicle at stop line."]
+    #[doc = "*                              - Do not proceed unless it is safe."]
+    #[doc = "*                              Note that the right to proceed either right or left when it is safe may be contained in the lane description to"]
+    #[doc = "*                              handle what is called a **right on red**"]
+    #[doc = "* - `stop-And-Remain` - 3:     e.g. called **red light**"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Stop vehicle at stop line."]
+    #[doc = "*                              - Do not proceed."]
+    #[doc = "*                              Note that the right to proceed either right or left when it is safe may be contained in the lane description to"]
+    #[doc = "*                              handle what is called a **right on red**"]
+    #[doc = "* - `pre-Movement` - 4:        Not used in the US, red+yellow partly in EU"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Stop vehicle."]
+    #[doc = "*                              - Prepare to proceed (pending green)"]
+    #[doc = "*                              - (Prepare for transition to green/go)"]
+    #[doc = "* - `permissive-Movement-Allowed` - 5: Often called **permissive green**"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Proceed with caution,"]
+    #[doc = "*                              - must yield to all conflicting traffic"]
+    #[doc = "*                              Conflicting traffic may be present in the intersection conflict area"]
+    #[doc = "* - `protected-Movement-Allowed` - 6: Often called **protected green**"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Proceed, tossing caution to the wind, in indicated (allowed) direction."]
+    #[doc = "* - `permissive-clearance` - 7: Often called **permissive yellow**."]
+    #[doc = "*                              The vehicle is not allowed to cross the stop bar if it is possible"]
+    #[doc = "*                              to stop without danger."]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Prepare to stop."]
+    #[doc = "*                              - Proceed if unable to stop,"]
+    #[doc = "*                              - Clear Intersection."]
+    #[doc = "*                              Conflicting traffic may be present in the intersection conflict area"]
+    #[doc = "* - `protected-clearance` - 8:  Often called **protected yellow**"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Prepare to stop."]
+    #[doc = "*                              - Proceed if unable to stop, in indicated direction (to connected lane)"]
+    #[doc = "*                              - Clear Intersection."]
+    #[doc = "* - `caution-Conflicting-Traffic` - 9: Often called **flashing yellow**"]
+    #[doc = "*                              Often used for extended periods of time"]
+    #[doc = "*                              Driver Action:"]
+    #[doc = "*                              - Proceed with caution,"]
+    #[doc = "*                              Conflicting traffic may be present in the intersection conflict area"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum MovementPhaseState {
+        unavailable = 0,
+        dark = 1,
+        #[rasn(identifier = "stop-Then-Proceed")]
+        stop_Then_Proceed = 2,
+        #[rasn(identifier = "stop-And-Remain")]
+        stop_And_Remain = 3,
+        #[rasn(identifier = "pre-Movement")]
+        pre_Movement = 4,
+        #[rasn(identifier = "permissive-Movement-Allowed")]
+        permissive_Movement_Allowed = 5,
+        #[rasn(identifier = "protected-Movement-Allowed")]
+        protected_Movement_Allowed = 6,
+        #[rasn(identifier = "permissive-clearance")]
+        permissive_clearance = 7,
+        #[rasn(identifier = "protected-clearance")]
+        protected_clearance = 8,
+        #[rasn(identifier = "caution-Conflicting-Traffic")]
+        caution_Conflicting_Traffic = 9,
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousMovementStateRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousMovementStateRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousMovementStateRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegMovementState_Type, D::Error> {
+            RegMovementState_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct MovementStateRegional(pub SequenceOf<AnonymousMovementStateRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey various information about the current or future movement state of"]
+    #[doc = "* a designated collection of one or more lanes of a common type. This is referred to as the GroupID. Note that lane object"]
+    #[doc = "* types supported include both motorized vehicle lanes as well as pedestrian lanes and dedicated rail and transit lanes. Of"]
+    #[doc = "* the reported data elements, the time to change (the time remaining in the current state) is often of the most value. Lanes"]
+    #[doc = "* with a common state (typically adjacent sets of lanes in an approach) in a signalized intersection will have individual lane"]
+    #[doc = "* values such as total vehicle counts, summed. It is used in the SPAT message to convey every active movement in a"]
+    #[doc = "* given intersection so that vehicles, when combined with certain map information, can determine the state of the signal phases."]
+    #[doc = "*"]
+    #[doc = "* @field movementName: uniquely defines movement by name human readable name for intersection to be used only in debug mode."]
+    #[doc = "* @field signalGroup: is used to map to lists of lanes (and their descriptions) which this MovementState data applies to."]
+    #[doc = "* @field state-time-speed: Consisting of sets of movement data with @ref SignalPhaseState, @ref TimeChangeDetail and @ref AdvisorySpeed"]
+    #[doc = "*                          *Note:* one or more of the movement events may be for a future time and that this allows conveying multiple"]
+    #[doc = "*                          predictive phase and movement timing for various uses for the current signal group."]
+    #[doc = "* @field maneuverAssistList: This information may also be placed in the @ref IntersectionState when common information applies to different lanes in the same way"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @note: Note that the value given for the time to change will vary in many actuated signalized intersections based on"]
+    #[doc = "*      the sensor data received during the phase. The data transmitted always reflects the then most current timemark value"]
+    #[doc = "*      (which is the point in UTC time when the change will occur). As an example, in a phase which may vary from 15 to 25"]
+    #[doc = "*      seconds of duration based on observed traffic flows, a time to change value of 15 seconds in the future might be"]
+    #[doc = "*      transmitted for many consecutive seconds (and the time mark value extended for as much as 10 seconds depending on"]
+    #[doc = "*      the extension time logic used by the controller before it either times out or gaps out), followed by a final time mark value"]
+    #[doc = "*      reflecting the decreasing values as the time runs out, presuming the value was not again extended to a new time mark"]
+    #[doc = "*      due to other detection events. The time to change element can therefore generally be regarded as a guaranteed minimum"]
+    #[doc = "*      value of the time that will elapse unless a preemption event occurs."]
+    #[doc = "*"]
+    #[doc = "*      In use, the @ref SignalGroupID element is matched to lanes that are members of that ID. The type of lane (vehicle, crosswalk,"]
+    #[doc = "*      etc.) is known by the lane description as well as its allowed maneuvers and any vehicle class restrictions. Every lane type"]
+    #[doc = "*      is treated the same way (cross walks map to suitable meanings, etc.). Lane objects which are not part of the sequence of"]
+    #[doc = "*      signalized lanes do not appear in any GroupID. The visual details of how a given signal phase is presented to a mobile"]
+    #[doc = "*      user will vary based on lane type and with regional conventions. Not all signal states will be used in all regional"]
+    #[doc = "*      deployments. For example, a pre-green visual indication is not generally found in US deployments. Under such operating"]
+    #[doc = "*      conditions, the unused phase states are simply skipped."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MovementState {
+        #[rasn(identifier = "movementName")]
+        pub movement_name: Option<DescriptiveName>,
+        #[rasn(identifier = "signalGroup")]
+        pub signal_group: SignalGroupID,
+        #[rasn(identifier = "state-time-speed")]
+        pub state_time_speed: MovementEventList,
+        #[rasn(identifier = "maneuverAssistList")]
+        pub maneuver_assist_list: Option<ManeuverAssistList>,
+        pub regional: Option<MovementStateRegional>,
+    }
+    impl MovementState {
+        pub fn new(
+            movement_name: Option<DescriptiveName>,
+            signal_group: SignalGroupID,
+            state_time_speed: MovementEventList,
+            maneuver_assist_list: Option<ManeuverAssistList>,
+            regional: Option<MovementStateRegional>,
+        ) -> Self {
+            Self {
+                movement_name,
+                signal_group,
+                state_time_speed,
+                maneuver_assist_list,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide a sequence number within a stream of messages with the same DSRCmsgID and from the same sender."]
+    #[doc = "* A sender may initialize this element to any value in the range 0-127 when sending the first message with a given DSRCmsgID,"]
+    #[doc = "* or if the sender has changed identity (e.g. by changing its TemporaryID) since sending the most recent message with that DSRCmsgID."]
+    #[doc = "*"]
+    #[doc = "* Depending on the application the sequence number may change with every message or may remain fixed during a stream of messages when the content within each"]
+    #[doc = "* message has not changed from the prior message sent. For this element, the value after 127 is zero."]
+    #[doc = "*"]
+    #[doc = "* The receipt of a non-sequential MsgCount value (from the same sending device and message type) implies that one or"]
+    #[doc = "* more messages from that sending device may have been lost, unless MsgCount has been re-initialized due to an identity"]
+    #[doc = "* change."]
+    #[doc = "*"]
+    #[doc = "* @note: In the absence of additional requirements defined in a standard using this data element, the follow guidelines shall be used."]
+    #[doc = "*"]
+    #[doc = "* In usage, some devices change their Temporary ID frequently, to prevent identity tracking, while others do not. A change"]
+    #[doc = "* in Temporary ID data element value (which also changes the message contents in which it appears) implies that the"]
+    #[doc = "* MsgCount may also change value."]
+    #[doc = "*"]
+    #[doc = "* If a sender is composing a message with new content with a given DSRCmsgID, and the TemporaryID has not changed"]
+    #[doc = "* since it sent the previous message, the sender shall increment the previous value."]
+    #[doc = "* If a sender is composing a message with new content with a given DSRCmsgID, and the TemporaryID has changed since"]
+    #[doc = "* it sent the previous message, the sender may set the MsgCount element to any valid value in the range (including"]
+    #[doc = "* incrementing the previous value)."]
+    #[doc = "*"]
+    #[doc = "* If a sender is composing a message with the same content as the most recent message with the same DSRCmsgID, and"]
+    #[doc = "* less than 10 seconds have elapsed since it sent the previous message with that DSRCmsgID, the sender will use the"]
+    #[doc = "* same MsgCount as sent in the previous message."]
+    #[doc = "*"]
+    #[doc = "* If a sender is composing a message with the same content as the most recent message with the same DSRCmsgID, and"]
+    #[doc = "* at least 10 seconds have elapsed since it sent the previous message with that DSRCmsgID, the sender may set the"]
+    #[doc = "* MsgCount element to any valid value in the range; this includes the re-use of the previous value."]
+    #[doc = "*"]
+    #[doc = "* If a sending device sends more than one stream of messages from message types that utilize the MsgCount element, it"]
+    #[doc = "* shall maintain a separate MsgCount state for each message type so that the MsgCount value in a given message"]
+    #[doc = "* identifies its place in the stream of that message type. The MsgCount element is a function only of the message type in a"]
+    #[doc = "* given sending device, not of the one or more applications in that device which may be sending the same type of message."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=127"))]
+    pub struct MsgCount(pub u8);
+    #[doc = "*"]
+    #[doc = "* A 64-bit node type with lat-long values expressed in one tenth of a micro degree."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-LLmD-64b")]
+    pub struct NodeLLmD64b {
+        pub lon: Longitude,
+        pub lat: Latitude,
+    }
+    impl NodeLLmD64b {
+        pub fn new(lon: Longitude, lat: Latitude) -> Self {
+            Self { lon, lat }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 20-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-20b")]
+    pub struct NodeXY20b {
+        pub x: OffsetB10,
+        pub y: OffsetB10,
+    }
+    impl NodeXY20b {
+        pub fn new(x: OffsetB10, y: OffsetB10) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 22-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-22b")]
+    pub struct NodeXY22b {
+        pub x: OffsetB11,
+        pub y: OffsetB11,
+    }
+    impl NodeXY22b {
+        pub fn new(x: OffsetB11, y: OffsetB11) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 24-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-24b")]
+    pub struct NodeXY24b {
+        pub x: OffsetB12,
+        pub y: OffsetB12,
+    }
+    impl NodeXY24b {
+        pub fn new(x: OffsetB12, y: OffsetB12) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 26-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-26b")]
+    pub struct NodeXY26b {
+        pub x: OffsetB13,
+        pub y: OffsetB13,
+    }
+    impl NodeXY26b {
+        pub fn new(x: OffsetB13, y: OffsetB13) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 28-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-28b")]
+    pub struct NodeXY28b {
+        pub x: OffsetB14,
+        pub y: OffsetB14,
+    }
+    impl NodeXY28b {
+        pub fn new(x: OffsetB14, y: OffsetB14) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 32-bit node type with offset values from the last point in X and Y."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Node-XY-32b")]
+    pub struct NodeXY32b {
+        pub x: OffsetB16,
+        pub y: OffsetB16,
+    }
+    impl NodeXY32b {
+        pub fn new(x: OffsetB16, y: OffsetB16) -> Self {
+            Self { x, y }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousNodeAttributeSetXYRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousNodeAttributeSetXYRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousNodeAttributeSetXYRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegNodeAttributeSetXY_Type, D::Error> {
+            RegNodeAttributeSetXY_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct NodeAttributeSetXYRegional(pub SequenceOf<AnonymousNodeAttributeSetXYRegional>);
+    #[doc = "*"]
+    #[doc = "* All the node attributes defined in this DF are valid in the direction of"]
+    #[doc = "* node declaration and not in driving direction (i.e. along the sequence of the declared nodes). E.g. node"]
+    #[doc = "* attributes of an **ingress** or an **egress** lane are defined from the conflict area (first node) to the"]
+    #[doc = "* outside of the intersection (last node). Node attributes with **left** and **right** in their name are also"]
+    #[doc = "* defined in the direction of the node declaration. This allows using attributes in a unambigious way also"]
+    #[doc = "* for lanes with biderctional driving. See the following attribuets examples for additianl explanations."]
+    #[doc = "*"]
+    #[doc = "* @field localNode: Attribute states which pertain to this node point"]
+    #[doc = "* @field disabled: Attribute states which are disabled at this node point"]
+    #[doc = "* @field enabled: Attribute states which are enabled at this node point and which remain enabled until disabled or the lane ends"]
+    #[doc = "* @field data: Attributes which require an additional data values some of these are local to the node point, while others"]
+    #[doc = "*              persist with the provided values until changed and this is indicated in each entry"]
+    #[doc = "* @field dWidth: A value added to the current lane width at this node and from this node onwards, in 1cm steps"]
+    #[doc = "*               lane width between nodes are a linear taper between pts the value of zero shall not be sent here."]
+    #[doc = "* @field dElevation: A value added to the current Elevation at this node from this node onwards, in 10cm steps"]
+    #[doc = "*                    elevations between nodes are a linear taper between pts the value of zero shall not be sent here"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct NodeAttributeSetXY {
+        #[rasn(identifier = "localNode")]
+        pub local_node: Option<NodeAttributeXYList>,
+        pub disabled: Option<SegmentAttributeXYList>,
+        pub enabled: Option<SegmentAttributeXYList>,
+        pub data: Option<LaneDataAttributeList>,
+        #[rasn(identifier = "dWidth")]
+        pub d_width: Option<OffsetB10>,
+        #[rasn(identifier = "dElevation")]
+        pub d_elevation: Option<OffsetB10>,
+        pub regional: Option<NodeAttributeSetXYRegional>,
+    }
+    impl NodeAttributeSetXY {
+        pub fn new(
+            local_node: Option<NodeAttributeXYList>,
+            disabled: Option<SegmentAttributeXYList>,
+            enabled: Option<SegmentAttributeXYList>,
+            data: Option<LaneDataAttributeList>,
+            d_width: Option<OffsetB10>,
+            d_elevation: Option<OffsetB10>,
+            regional: Option<NodeAttributeSetXYRegional>,
+        ) -> Self {
+            Self {
+                local_node,
+                disabled,
+                enabled,
+                data,
+                d_width,
+                d_elevation,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is an enumerated list of attributes which can pertain to the current node"]
+    #[doc = "* point. The **scope** of these values is limited to the node itself. That is, unlike other types of attributes which can be"]
+    #[doc = "* switched on or off at any given node (and hence pertains to one or more segments), the DE_NodeAttribute is local to the"]
+    #[doc = "* node in which it is found. These attributes are all binary flags in that they do not need to convey any additional data. Other"]
+    #[doc = "* attributes allow sending short data values to reflect a setting which is set and persists in a similar fashion."]
+    #[doc = "*"]
+    #[doc = "*  - reserved:             do not use"]
+    #[doc = "*  - stopLine:             point where a mid-path stop line exists. See also **do not block** for segments"]
+    #[doc = "*  - roundedCapStyleA:     Used to control final path rounded end shape with edge of curve at final point in a circle"]
+    #[doc = "*  - roundedCapStyleB:     Used to control final path rounded end shape with edge of curve extending 50% of width past final point in a circle"]
+    #[doc = "*  - mergePoint:           merge with 1 or more lanes"]
+    #[doc = "*  - divergePoint:         diverge with 1 or more lanes"]
+    #[doc = "*  - downstreamStopLine:   downstream intersection (a 2nd intersection) stop line"]
+    #[doc = "*  - downstreamStartNode:  downstream intersection (a 2nd intersection) start node"]
+    #[doc = "*  - closedToTraffic:      where a pedestrian may NOT go to be used during construction events"]
+    #[doc = "*  - safeIsland:           a pedestrian safe stopping point also called a traffic island"]
+    #[doc = "*                          This usage described a point feature on a path, other entries can describe a path"]
+    #[doc = "*  - curbPresentAtStepOff: the sidewalk to street curb is NOT angled where it meets the edge of the roadway (user must step up/down)"]
+    #[doc = "*  - hydrantPresent:       Or other services access"]
+    #[doc = "*"]
+    #[doc = "* @note: See usage examples in [ISO TS 19091] G.8.2.8"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum NodeAttributeXY {
+        reserved = 0,
+        stopLine = 1,
+        roundedCapStyleA = 2,
+        roundedCapStyleB = 3,
+        mergePoint = 4,
+        divergePoint = 5,
+        downstreamStopLine = 6,
+        downstreamStartNode = 7,
+        closedToTraffic = 8,
+        safeIsland = 9,
+        curbPresentAtStepOff = 10,
+        hydrantPresent = 11,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref NodeAttributeXY entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8"))]
+    pub struct NodeAttributeXYList(pub SequenceOf<NodeAttributeXY>);
+    #[doc = "*"]
+    #[doc = "* This DF provides the sequence of signed offset node point values for determining the Xs and Ys"]
+    #[doc = "* (and possibly Width or Zs when present), using the then current Position3D object to build a path for the centerline of"]
+    #[doc = "* the subject lane type. Each X,Y point is referred to as a Node Point. The straight line paths between these points are"]
+    #[doc = "* referred to as Segments."]
+    #[doc = "* All nodes may have various optional attributes the state of which can vary along the path and which are enabled and"]
+    #[doc = "* disabled by the sequence of objects found in the list of node structures. Refer to the explanatory text in Section 11 for a"]
+    #[doc = "* description of how to correctly encode and decode this type of the data element. As a simple example, a motor vehicle"]
+    #[doc = "* lane may have a section of the overall lane path marked \"do not block\", indicating that vehicles should not come to a stop"]
+    #[doc = "* and remain in that region. This is encoded in the Node data structures by an element in one node to indicate the start of"]
+    #[doc = "* the \"do not block\" lane attributes at a given offset, and then by a termination element when this attribute is set false. Other"]
+    #[doc = "* types of elements in the segment choice allow inserting attributes containing data values affecting the segment or the"]
+    #[doc = "* node."]
+    #[doc = "*"]
+    #[doc = "* @field nodes: a lane made up of two or more XY node points and any attributes defined in those nodes"]
+    #[doc = "* @field computed: a lane path computed by translating the data defined by another lane"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum NodeListXY {
+        nodes(NodeSetXY),
+        computed(ComputedLane),
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NodeOffsetPointXYRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl NodeOffsetPointXYRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl NodeOffsetPointXYRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegNodeOffsetPointXY_Type, D::Error> {
+            RegNodeOffsetPointXY_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF presents a structure to hold different sized data frames for a single node"]
+    #[doc = "* point in a lane. Nodes are described in terms of X and Y offsets in units of 1 centimeter (when zoom is 1:1). Changes in"]
+    #[doc = "* elevation and in the lane width can be expressed in a similar way with the optional Attributes data entry which appears"]
+    #[doc = "* alongside the NodeOffsetPoint in use."]
+    #[doc = "*"]
+    #[doc = "* The choice of which node type is driven by the magnitude (size) of the offset data to be encoded. When the distance from"]
+    #[doc = "* the last node point is smaller, the smaller entries can (and should) be chosen"]
+    #[doc = "* Each single selected node is computed as an X and Y offset from the prior node point unless one of the entries reflecting"]
+    #[doc = "* a complete lat-long representation is selected. In this case, subsequent entries become offsets from that point. This ability"]
+    #[doc = "* was added for assistance with the development, storage, and back office exchange of messages where message size is"]
+    #[doc = "* not a concern and should not be sent over the air due to its additional message payload size."]
+    #[doc = "*"]
+    #[doc = "* The general usage guidance is to construct the content of each lane node point with the smallest possible element to"]
+    #[doc = "* conserve message size. However, using an element which is larger than needed is not a violation of the ASN.1 rules."]
+    #[doc = "*"]
+    #[doc = "* @field node-XY1:    node is within 5.11m of last node"]
+    #[doc = "* @field node-XY2:    node is within 10.23m of last node"]
+    #[doc = "* @field node-XY3:    node is within 20.47m of last node"]
+    #[doc = "* @field node-XY4:    node is within 40.96m of last node"]
+    #[doc = "* @field node-XY5:    node is within 81.91m of last node"]
+    #[doc = "* @field node-XY6:    node is within 327.67m of last node"]
+    #[doc = "* @field node-LatLon: node is a full 32b Lat/Lon range"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum NodeOffsetPointXY {
+        #[rasn(identifier = "node-XY1")]
+        node_XY1(NodeXY20b),
+        #[rasn(identifier = "node-XY2")]
+        node_XY2(NodeXY22b),
+        #[rasn(identifier = "node-XY3")]
+        node_XY3(NodeXY24b),
+        #[rasn(identifier = "node-XY4")]
+        node_XY4(NodeXY26b),
+        #[rasn(identifier = "node-XY5")]
+        node_XY5(NodeXY28b),
+        #[rasn(identifier = "node-XY6")]
+        node_XY6(NodeXY32b),
+        #[rasn(identifier = "node-LatLon")]
+        node_LatLon(NodeLLmD64b),
+        regional(NodeOffsetPointXYRegional),
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of Node entries using XY offsets."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("2..=63"))]
+    pub struct NodeSetXY(pub SequenceOf<NodeXY>);
+    #[doc = "*"]
+    #[doc = "* This DF presents a structure to hold data for a single node point in a path. Each selected node"]
+    #[doc = "* has an X and Y offset from the prior node point (or a complete lat-long representation in some cases) as well as optional"]
+    #[doc = "* attribute information. The node list for a lane (or other object) is made up of a sequence of these to describe the desired"]
+    #[doc = "* path. The X,Y points are selected to reflect the centerline of the path with sufficient accuracy for the intended applications."]
+    #[doc = "* Simple lanes can be adequately described with only two node points, while lanes with curvature may require more points."]
+    #[doc = "* Changes to the lane width and elevation can be expressed in the NodeAttributes entry, as well as various attributes that"]
+    #[doc = "* pertain to either the current node point or to one of more subsequent segments along the list of lane node points. As a"]
+    #[doc = "* broad concept, NodeAttributes are used to describe aspects of the lane that persist for only a portion of the overall lane"]
+    #[doc = "* path (either at a node or over a set of segments)."]
+    #[doc = "* A further description of the use of the NodeOffsetPoint and the Attributes data concepts can be found in the data"]
+    #[doc = "* dictionary entries for each one. Note that each allows regional variants to be supported as well."]
+    #[doc = "*"]
+    #[doc = "* @field delta:      A choice of which X,Y offset value to use this includes various delta values as well a regional choices."]
+    #[doc = "* @field attributes: Any optional Attributes which are needed. This includes changes to the current lane width and elevation."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct NodeXY {
+        pub delta: NodeOffsetPointXY,
+        pub attributes: Option<NodeAttributeSetXY>,
+    }
+    impl NodeXY {
+        pub fn new(delta: NodeOffsetPointXY, attributes: Option<NodeAttributeSetXY>) -> Self {
+            Self { delta, attributes }
+        }
+    }
+    #[doc = "* This DF is the ODG Addition for Legancy R09 telegrams."]
+    #[doc = "* "]
+    #[doc = "* @field reportingPoint: reporting point as of R09 (maps to R09 field M Meldepunktnummer)"]
+    #[doc = "* @field priorityLevel:  priority level as of R09 (maps to R09 field P Prioritaet)"]
+    #[doc = "* @field length:         train length point as of R09 (maps to R09 field A Zuglaenge)"]
+    #[doc = "* @field route:          route as of R09 (maps to R09 field K Kursnummer)"]
+    #[doc = "* @field line:           line as of R09 (maps to R09 field L Liniennummer)"]
+    #[doc = "* @field direction:      direction as of R09 (maps to R09 field H Richtung von Hand)"]
+    #[doc = "* @field tour:           tour as of R09 (maps to R09 field Z Zielnummer)"]
+    #[doc = "* @field version:        version of R09"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct OcitRequestorDescriptionContainer {
+        #[rasn(identifier = "reportingPoint")]
+        pub reporting_point: Option<ReportingPoint>,
+        #[rasn(identifier = "priorityLevel")]
+        pub priority_level: Option<PriorityLevel>,
+        pub length: Option<TrainLength>,
+        pub route: Option<RouteNumber>,
+        pub line: Option<LineNumber>,
+        pub direction: Option<TransitDirection>,
+        pub tour: Option<TourNumber>,
+        pub version: Option<VersionId>,
+    }
+    impl OcitRequestorDescriptionContainer {
+        pub fn new(
+            reporting_point: Option<ReportingPoint>,
+            priority_level: Option<PriorityLevel>,
+            length: Option<TrainLength>,
+            route: Option<RouteNumber>,
+            line: Option<LineNumber>,
+            direction: Option<TransitDirection>,
+            tour: Option<TourNumber>,
+            version: Option<VersionId>,
+        ) -> Self {
+            Self {
+                reporting_point,
+                priority_level,
+                length,
+                route,
+                line,
+                direction,
+                tour,
+                version,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 9-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to"]
+    #[doc = "* indicate an unknown value."]
+    #[doc = "* a range of +- 2.55 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B09", value("-256..=255"))]
+    pub struct OffsetB09(pub i16);
+    #[doc = "*"]
+    #[doc = "* A 10-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to"]
+    #[doc = "* indicate an unknown value."]
+    #[doc = "* a range of +- 5.11 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B10", value("-512..=511"))]
+    pub struct OffsetB10(pub i16);
+    #[doc = "*"]
+    #[doc = "* An 11-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to"]
+    #[doc = "* indicate an unknown value."]
+    #[doc = "* a range of +- 10.23 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B11", value("-1024..=1023"))]
+    pub struct OffsetB11(pub i16);
+    #[doc = "*"]
+    #[doc = "* A 12-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, non-vehicle centric coordinate frames of reference, offset is positive to the East (X) and to the North (Y)"]
+    #[doc = "* directions. The most negative value shall be used to indicate an unknown value."]
+    #[doc = "* a range of +- 20.47 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B12", value("-2048..=2047"))]
+    pub struct OffsetB12(pub i16);
+    #[doc = "*"]
+    #[doc = "* A 13-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to"]
+    #[doc = "* indicate an unknown value."]
+    #[doc = "* a range of +- 40.95 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B13", value("-4096..=4095"))]
+    pub struct OffsetB13(pub i16);
+    #[doc = "*"]
+    #[doc = "* A 14-bit delta offset in X or Y direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions."]
+    #[doc = "* a range of +- 81.91 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B14", value("-8192..=8191"))]
+    pub struct OffsetB14(pub i16);
+    #[doc = "*"]
+    #[doc = "* A 16-bit delta offset in X, Y or Z direction from some known point. For non-vehicle centric coordinate frames of"]
+    #[doc = "* reference, offset is positive to the East (X) and to the North (Y) directions. The most negative value shall be used to"]
+    #[doc = "* indicate an unknown value."]
+    #[doc = "* a range of +- 327.68 meters"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Offset-B16", value("-32768..=32767"))]
+    pub struct OffsetB16(pub i16);
+    #[doc = "*"]
+    #[doc = "* This DF is a sequence of lane IDs which refers to lane objects that overlap or overlay the current lane's spatial path."]
+    #[doc = "*"]
+    #[doc = "* Contains the unique ID numbers for any lane object which have spatial paths that overlay (run on top of, and not"]
+    #[doc = "* simply cross with) the current lane."]
+    #[doc = "* Such as a train path that overlays a motor vehicle lane object for a roadway segment."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=5"))]
+    pub struct OverlayLaneList(pub SequenceOf<LaneID>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide an indication of whether Pedestrians and/or Bicyclists have been detected in the crossing lane."]
+    #[doc = "* true if ANY Pedestrians or Bicyclists are detected crossing the target lane or lanes"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(delegate)]
+    pub struct PedestrianBicycleDetect(pub bool);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousPosition3DRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousPosition3DRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousPosition3DRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegPosition3D_Type, D::Error> {
+            RegPosition3D_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct Position3DRegional(pub SequenceOf<AnonymousPosition3DRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF provides a precise location in the WGS-84 coordinate system, from which short"]
+    #[doc = "* offsets may be used to create additional data using a flat earth projection centered on this location. Position3D is typically"]
+    #[doc = "* used in the description of maps and intersections, as well as signs and traveler data."]
+    #[doc = "*"]
+    #[doc = "* @field lat: Latitude in 1/10th microdegrees"]
+    #[doc = "* @field long: Longitude in 1/10th microdegrees"]
+    #[doc = "* @field elevation: The elevation information is defined by the regional extension (see module ETSI-ITS-DSRC-AddGrpC). "]
+    #[doc = "*                   Therefore, the **elevation** data element of **DF_Position3D** is not used."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Position3D {
+        pub lat: Latitude,
+        pub long: Longitude,
+        pub elevation: Option<Elevation>,
+        pub regional: Option<Position3DRegional>,
+    }
+    impl Position3D {
+        pub fn new(
+            lat: Latitude,
+            long: Longitude,
+            elevation: Option<Elevation>,
+            regional: Option<Position3DRegional>,
+        ) -> Self {
+            Self {
+                lat,
+                long,
+                elevation,
+                regional,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum PositionConfidence {
+        unavailable = 0,
+        a500m = 1,
+        a200m = 2,
+        a100m = 3,
+        a50m = 4,
+        a20m = 5,
+        a10m = 6,
+        a5m = 7,
+        a2m = 8,
+        a1m = 9,
+        a50cm = 10,
+        a20cm = 11,
+        a10cm = 12,
+        a5cm = 13,
+        a2cm = 14,
+        a1cm = 15,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF combines multiple related bit fields into a single concept."]
+    #[doc = "*"]
+    #[doc = "* @field pos:       confidence for both horizontal directions"]
+    #[doc = "* @field elevation: confidence for vertical direction"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PositionConfidenceSet {
+        pub pos: PositionConfidence,
+        pub elevation: ElevationConfidence,
+    }
+    impl PositionConfidenceSet {
+        pub fn new(pos: PositionConfidence, elevation: ElevationConfidence) -> Self {
+            Self { pos, elevation }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of various parameters of quality used to model the accuracy of the"]
+    #[doc = "* positional determination with respect to each given axis."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PositionalAccuracy {
+        #[rasn(identifier = "semiMajor")]
+        pub semi_major: SemiMajorAxisAccuracy,
+        #[rasn(identifier = "semiMinor")]
+        pub semi_minor: SemiMinorAxisAccuracy,
+        pub orientation: SemiMajorAxisOrientation,
+    }
+    impl PositionalAccuracy {
+        pub fn new(
+            semi_major: SemiMajorAxisAccuracy,
+            semi_minor: SemiMinorAxisAccuracy,
+            orientation: SemiMajorAxisOrientation,
+        ) -> Self {
+            Self {
+                semi_major,
+                semi_minor,
+                orientation,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of RegionalSignalControlZone entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct PreemptPriorityList(pub SequenceOf<SignalControlZone>);
+    #[doc = "*"]
+    #[doc = "* This DE is used in the @ref PrioritizationResponse data frame to indicate the"]
+    #[doc = "* general status of a prior prioritization request."]
+    #[doc = "*"]
+    #[doc = "* - `unknown`           - 0: Unknown state"]
+    #[doc = "* - `requested`         - 1: This prioritization request was detected by the traffic controller"]
+    #[doc = "* - `processing`        - 2: Checking request (request is in queue, other requests are prior)"]
+    #[doc = "* - `watchOtherTraffic` - 3: Cannot give full permission, therefore watch for other traffic. Note that other requests may be present"]
+    #[doc = "* - `granted`           - 4: Intervention was successful and now prioritization is active"]
+    #[doc = "* - `rejected`          - 5: The prioritization or preemption request was rejected by the traffic controller"]
+    #[doc = "* - `maxPresence`       - 6: The Request has exceeded maxPresence time. Used when the controller has determined that the requester should then back off and request an alternative."]
+    #[doc = "* - `reserviceLocked`   - 7: Prior conditions have resulted in a reservice"]
+    #[doc = "*                            locked event: the controller requires the passage of time before another similar request will be accepted"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum PrioritizationResponseStatus {
+        unknown = 0,
+        requested = 1,
+        processing = 2,
+        watchOtherTraffic = 3,
+        granted = 4,
+        rejected = 5,
+        maxPresence = 6,
+        reserviceLocked = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 priority."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct PriorityLevel(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE provides a means to indicate if a request (found in the Signal RequestMessage) represents"]
+    #[doc = "* a new service request, a request update, or a request cancellation for either preemption or priority services."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum PriorityRequestType {
+        priorityRequestTypeReserved = 0,
+        priorityRequest = 1,
+        priorityRequestUpdate = 2,
+        priorityCancellation = 3,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE provides the specific revision of the RTCM standard which is being used. This is"]
+    #[doc = "* helpful to know precisely the mapping of the message types to their definitions, as well as some minor transport layer"]
+    #[doc = "* ordering details when received in the mobile unit. All RTCM SC-104 messages follow a common message numbering"]
+    #[doc = "* method (wherein all defined messages are given unique values) which can be decoded from the initial octets of the"]
+    #[doc = "* message. This operation is typically performed by the GNSS rover that consumes the messages, so it is transparent at"]
+    #[doc = "* the DSRC message set level."]
+    #[doc = "*"]
+    #[doc = "* Values:"]
+    #[doc = "* - `rtcmRev2`:  Std 10402.x et al"]
+    #[doc = "* - `rtcmRev3`:  Std 10403.x et al"]
+    #[doc = "*"]
+    #[doc = "* @note:: In order to fully support the use of networked transport of RTCM corrections (so-called Ntrip systems), the"]
+    #[doc = "*         enumerated list of protocol types provides for all the common types outlined in RTCM Standard 10410.0, Appendix B. It is"]
+    #[doc = "*         anticipated that revisions 3.x and 2.3 will predominate in practice as they do today. It should also be noted that RTCM"]
+    #[doc = "*         standards use the term `byte` for an 8-bit value, while in this standard the term `octet` is used."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated, identifier = "RTCM-Revision")]
+    #[non_exhaustive]
+    pub enum RTCMRevision {
+        unknown = 0,
+        rtcmRev2 = 1,
+        rtcmRev3 = 2,
+        reserved = 3,
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousRTCMcorrectionsRegional {
+        #[rasn(value("0..=255"), identifier = "regionId")]
+        pub region_id: u8,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousRTCMcorrectionsRegional {
+        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousRTCMcorrectionsRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegRTCMcorrections_Type, D::Error> {
+            RegRTCMcorrections_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct RTCMcorrectionsRegional(pub SequenceOf<AnonymousRTCMcorrectionsRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to encapsulate RTCM differential corrections for GPS and other radio"]
+    #[doc = "* navigation signals as defined by the RTCM (Radio Technical Commission For Maritime Services) special committee"]
+    #[doc = "* number 104 in its various standards. Here, in the work of DSRC, these messages are \"wrapped\" for transport on the"]
+    #[doc = "* DSRC media, and then can be re-constructed back into the final expected formats defined by the RTCM standard and"]
+    #[doc = "* used directly by various positioning systems to increase the absolute and relative accuracy estimates produced."]
+    #[doc = "*"]
+    #[doc = "* @field msgCnt: monotonic incrementing identifier."]
+    #[doc = "* @field rev: the specific edition of the standard that is being sent."]
+    #[doc = "* @field timeStamp: time reference"]
+    #[doc = "* @field anchorPoint: Observer position, if needed."]
+    #[doc = "* @field rtcmHeader: Precise antenna position and noise data for a rover"]
+    #[doc = "* @field msgs: one or more RTCM messages."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RTCMcorrections {
+        #[rasn(identifier = "msgCnt")]
+        pub msg_cnt: MsgCount,
+        pub rev: RTCMRevision,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<MinuteOfTheYear>,
+        #[rasn(identifier = "anchorPoint")]
+        pub anchor_point: Option<FullPositionVector>,
+        #[rasn(identifier = "rtcmHeader")]
+        pub rtcm_header: Option<RTCMheader>,
+        pub msgs: RTCMmessageList,
+        pub regional: Option<RTCMcorrectionsRegional>,
+    }
+    impl RTCMcorrections {
+        pub fn new(
+            msg_cnt: MsgCount,
+            rev: RTCMRevision,
+            time_stamp: Option<MinuteOfTheYear>,
+            anchor_point: Option<FullPositionVector>,
+            rtcm_header: Option<RTCMheader>,
+            msgs: RTCMmessageList,
+            regional: Option<RTCMcorrectionsRegional>,
+        ) -> Self {
+            Self {
+                msg_cnt,
+                rev,
+                time_stamp,
+                anchor_point,
+                rtcm_header,
+                msgs,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is a collection of data values used to convey RTCM information between users. It"]
+    #[doc = "* is not required or used when sending RTCM data from a corrections source to end users (from a base station to devices"]
+    #[doc = "* deployed in the field which are called rovers)."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RTCMheader {
+        pub status: GNSSstatus,
+        #[rasn(identifier = "offsetSet")]
+        pub offset_set: AntennaOffsetSet,
+    }
+    impl RTCMheader {
+        pub fn new(status: GNSSstatus, offset_set: AntennaOffsetSet) -> Self {
+            Self { status, offset_set }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE contains the stream of octets of the actual RTCM message that is being sent."]
+    #[doc = "* The message’s contents are defined in RTCM Standard 10403.1 and in RTCM Standard 10402.1 and its successors."]
+    #[doc = "* Note that most RTCM messages are considerably smaller than the size limit defined here, but that some messages may"]
+    #[doc = "* need to be broken into smaller messages (as per the rules defined in the RTCM work) in order to be transmitted over DSRC."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=1023"))]
+    pub struct RTCMmessage(pub OctetString);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref RTCMmessage entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=5"))]
+    pub struct RTCMmessageList(pub SequenceOf<RTCMmessage>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to define regions where unique additional content may be added and"]
+    #[doc = "* used in the message set. The index values defined below represent various regions known at the time of publication. This"]
+    #[doc = "* list is expected to grow over time. The index values assigned here can be augmented by local (uncoordinated)"]
+    #[doc = "* assignments in the allowed range. It should be noted that such a local value is specified in the \"REGION\" ASN module, so"]
+    #[doc = "* there is no need to edit the DSRC ASN specification of the standard. This process is further described in Section 11.1."]
+    #[doc = "*"]
+    #[doc = "* - `noRegion` - 0: Use default supplied stubs"]
+    #[doc = "* - `addGrpA`  - 1: USA"]
+    #[doc = "* - `addGrpB`  - 2: Japan"]
+    #[doc = "* - `addGrpC`  - 3: EU"]
+    #[doc = "*"]
+    #[doc = "* @note: new registered regional IDs will be added here"]
+    #[doc = "*        The values 128 and above are for local region use"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RegionId(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey a regulatory speed about a lane, lanes, or roadway segment."]
+    #[doc = "*"]
+    #[doc = "* @field type: The type of regulatory speed which follows"]
+    #[doc = "* @field speed: The speed in units of 0.02 m/s"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RegulatorySpeedLimit {
+        #[rasn(identifier = "type")]
+        pub r_type: SpeedLimitType,
+        pub speed: Velocity,
+    }
+    impl RegulatorySpeedLimit {
+        pub fn new(r_type: SpeedLimitType, speed: Velocity) -> Self {
+            Self { r_type, speed }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 reporting point."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct ReportingPoint(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide a unique ID between two parties for various dialog exchanges."]
+    #[doc = "* Combined with the sender's VehicleID (consisting of a TempID or a Station ID), this provides a unique string for some"]
+    #[doc = "* mutually defined period of time. A typical example of use would be a signal preemption or priority request dialog"]
+    #[doc = "* containing multiple requests from one sender (denoted by the unique RequestID with each). When such a request is"]
+    #[doc = "* processed and reflected in the signal status messages, the original sender and the specific request can both be determined."]
+    #[doc = "*"]
+    #[doc = "* @note: In typical use, this value is simply incremented in a modulo fashion to ensure a unique stream of values for the"]
+    #[doc = "*        device creating it. Any needs for uniqueness across multiple dialogs to one or more parties shall be the responsibility of"]
+    #[doc = "*        the device to manage. There are often normative restrictions on the device changing its TempID during various dialogs"]
+    #[doc = "*        when this data element is used. Further details of these operational concepts can be found in the relevant standards."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RequestID(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to state what type of signal request is being made to a signal"]
+    #[doc = "* controller by a DSRC device in a defined role (such as a police vehicle). The levels of the request typically convey a"]
+    #[doc = "* sense of urgency or importance with respect to other demands to allow the controller to use predefined business rules to"]
+    #[doc = "* determine how to respond. These rules will vary in terms of how details of overall importance and urgency are to be"]
+    #[doc = "* ranked, so they are to be implemented locally. As a result of this regional process, the list below should be assigned well-"]
+    #[doc = "* defined meanings by the local deployment. These meaning will typically result in assigning a set of values to list for each"]
+    #[doc = "* vehicle role type that is to be supported."]
+    #[doc = "*"]
+    #[doc = "* - `requestImportanceLevel1`     1: The least important request"]
+    #[doc = "* - `requestImportanceLevel14`   14: The most important request"]
+    #[doc = "* - `requestImportanceReserved`  15: Reserved for future use"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RequestImportanceLevel {
+        requestImportanceLevelUnKnown = 0,
+        requestImportanceLevel1 = 1,
+        requestImportanceLevel2 = 2,
+        requestImportanceLevel3 = 3,
+        requestImportanceLevel4 = 4,
+        requestImportanceLevel5 = 5,
+        requestImportanceLevel6 = 6,
+        requestImportanceLevel7 = 7,
+        requestImportanceLevel8 = 8,
+        requestImportanceLevel9 = 9,
+        requestImportanceLevel10 = 10,
+        requestImportanceLevel11 = 11,
+        requestImportanceLevel12 = 12,
+        requestImportanceLevel13 = 13,
+        requestImportanceLevel14 = 14,
+        requestImportanceReserved = 15,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to further define the details of the role which any DSRC device might"]
+    #[doc = "* play when making a request to a signal controller. This value is not always needed. For example, perhaps in a"]
+    #[doc = "* deployment all police vehicles are to be treated equally. The taxonomy of what details are selected to be entered into the"]
+    #[doc = "* list is a regional choice but should be devised to allow the controller to use predefined business rules to respond using the"]
+    #[doc = "* data. As another example, perhaps in a regional deployment a cross-city express type of transit vehicle is given a different"]
+    #[doc = "* service response for the same request than another type of transit vehicle making an otherwise similar request. As a"]
+    #[doc = "* result of this regional process, the list below should be assigned well-defined meanings by the local deployment. These"]
+    #[doc = "* meanings will typically result in assigning a set of values to list for each vehicle role type that is to be supported."]
+    #[doc = "*"]
+    #[doc = "* - `requestSubRole1`        - 1:  The first type of sub role"]
+    #[doc = "* - `requestSubRole14`       - 14: The last type of sub role"]
+    #[doc = "* - `requestSubRoleReserved` - 15: Reserved for future use"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum RequestSubRole {
+        requestSubRoleUnKnown = 0,
+        requestSubRole1 = 1,
+        requestSubRole2 = 2,
+        requestSubRole3 = 3,
+        requestSubRole4 = 4,
+        requestSubRole5 = 5,
+        requestSubRole6 = 6,
+        requestSubRole7 = 7,
+        requestSubRole8 = 8,
+        requestSubRole9 = 9,
+        requestSubRole10 = 10,
+        requestSubRole11 = 11,
+        requestSubRole12 = 12,
+        requestSubRole13 = 13,
+        requestSubRole14 = 14,
+        requestSubRoleReserved = 15,
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousRequestorDescriptionRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousRequestorDescriptionRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousRequestorDescriptionRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegRequestorDescription_Type, D::Error> {
+            RegRequestorDescription_Type::decode(
+                decoder,
+                Some(&self.reg_ext_value),
+                &self.region_id,
+            )
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct RequestorDescriptionRegional(pub SequenceOf<AnonymousRequestorDescriptionRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide identity information about a selected vehicle or users."]
+    #[doc = "* This data frame is typically used with fleet type vehicles which can (or which must) safely release such information for use"]
+    #[doc = "* with probe measurements or with other interactions (such as a signal request)."]
+    #[doc = "*"]
+    #[doc = "* @field id:               The ID used in the CAM of the requestor. This ID is presumed not to change during the exchange."]
+    #[doc = "* @field type:             Information regarding all type and class data about the requesting vehicle"]
+    #[doc = "* @field position:         The location of the requesting vehicle"]
+    #[doc = "* @field name:             A human readable name for debugging use"]
+    #[doc = "* @field routeName:        A string for transit operations use"]
+    #[doc = "* @field transitStatus:    current vehicle state (loading, etc.)"]
+    #[doc = "* @field transitOccupancy: current vehicle occupancy"]
+    #[doc = "* @field transitSchedule:  current vehicle schedule adherence"]
+    #[doc = "* @field regional:         optional region specific data."]
+    #[doc = "* @field ocit:             Extension container for Legacy R09 data (as defined by [OCIT])."]
+    #[doc = "*"]
+    #[doc = "* @note: Note that the requestor description elements which are used when the request (the req) is made differ from"]
+    #[doc = "*        those used when the status of an active or pending request is reported (the ack). Typically, when reporting the status to"]
+    #[doc = "*        other parties, less information is required and only the temporaryID (contained in the VehicleID) and request number (a"]
+    #[doc = "*        unique ID used in the orginal request) are used."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RequestorDescription {
+        pub id: VehicleID,
+        #[rasn(identifier = "type")]
+        pub r_type: Option<RequestorType>,
+        pub position: Option<RequestorPositionVector>,
+        pub name: Option<DescriptiveName>,
+        #[rasn(identifier = "routeName")]
+        pub route_name: Option<DescriptiveName>,
+        #[rasn(identifier = "transitStatus")]
+        pub transit_status: Option<TransitVehicleStatus>,
+        #[rasn(identifier = "transitOccupancy")]
+        pub transit_occupancy: Option<TransitVehicleOccupancy>,
+        #[rasn(identifier = "transitSchedule")]
+        pub transit_schedule: Option<DeltaTime>,
+        pub regional: Option<RequestorDescriptionRegional>,
+        #[rasn(extension_addition)]
+        pub ocit: OcitRequestorDescriptionContainer,
+    }
+    impl RequestorDescription {
+        pub fn new(
+            id: VehicleID,
+            r_type: Option<RequestorType>,
+            position: Option<RequestorPositionVector>,
+            name: Option<DescriptiveName>,
+            route_name: Option<DescriptiveName>,
+            transit_status: Option<TransitVehicleStatus>,
+            transit_occupancy: Option<TransitVehicleOccupancy>,
+            transit_schedule: Option<DeltaTime>,
+            regional: Option<RequestorDescriptionRegional>,
+            ocit: OcitRequestorDescriptionContainer,
+        ) -> Self {
+            Self {
+                id,
+                r_type,
+                position,
+                name,
+                route_name,
+                transit_status,
+                transit_occupancy,
+                transit_schedule,
+                regional,
+                ocit,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF provides a report of the requestor's position, speed, and heading."]
+    #[doc = "* Used by a vehicle or other type of user to request services and at other times when the larger FullPositionVector is not required."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RequestorPositionVector {
+        pub position: Position3D,
+        pub heading: Option<Angle>,
+        pub speed: Option<TransmissionAndSpeed>,
+    }
+    impl RequestorPositionVector {
+        pub fn new(
+            position: Position3D,
+            heading: Option<Angle>,
+            speed: Option<TransmissionAndSpeed>,
+        ) -> Self {
+            Self {
+                position,
+                heading,
+                speed,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RequestorTypeRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl RequestorTypeRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl RequestorTypeRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegRequestorType_Type, D::Error> {
+            RegRequestorType_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used when a DSRC-equipped device is requesting service from another"]
+    #[doc = "* device. The most common use case is when a vehicle is requesting a signal preemption or priority service call from the"]
+    #[doc = "* signal controller in an intersection. This data frame provides the details of the requestor class taxonomy required to"]
+    #[doc = "* support the request. Depending on the precise use case and the local implementation, these details can vary"]
+    #[doc = "* considerably. As a result, besides the basic role of the vehicle, the other classification systems supported are optional. It"]
+    #[doc = "* should also be observed that often only a subset of the information in the RequestorType data frame is used to report the"]
+    #[doc = "* \"results\" of such a request to others. As an example, a police vehicle might request service based on being in a police"]
+    #[doc = "* vehicle role (and any further sub-type if required) and on the type of service call to which the vehicle is then responding"]
+    #[doc = "* (perhaps a greater degree of emergency than another type of call), placing these information elements in the"]
+    #[doc = "* RequestorType, which is then part of the Signal Request Message (SRM). This allows the roadway operator to define"]
+    #[doc = "* suitable business rules regarding how to reply. When informing the requestor and other nearby drivers of the outcome,"]
+    #[doc = "* using the Signal Status Message (SSM) message, only the fact that the preemption was granted or denied to some"]
+    #[doc = "* vehicle with a unique request ID is conveyed."]
+    #[doc = "*"]
+    #[doc = "* @field role:     Basic role of this user at this time."]
+    #[doc = "* @field subrole:  A local list with role based items."]
+    #[doc = "* @field request:  A local list with request items"]
+    #[doc = "* @field iso3883:  Additional classification details"]
+    #[doc = "* @field hpmsType: HPMS classification types"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RequestorType {
+        pub role: BasicVehicleRole,
+        pub subrole: Option<RequestSubRole>,
+        pub request: Option<RequestImportanceLevel>,
+        pub iso3883: Option<Iso3833VehicleType>,
+        #[rasn(identifier = "hpmsType")]
+        pub hpms_type: Option<VehicleType>,
+        pub regional: Option<RequestorTypeRegional>,
+    }
+    impl RequestorType {
+        pub fn new(
+            role: BasicVehicleRole,
+            subrole: Option<RequestSubRole>,
+            request: Option<RequestImportanceLevel>,
+            iso3883: Option<Iso3833VehicleType>,
+            hpms_type: Option<VehicleType>,
+            regional: Option<RequestorTypeRegional>,
+        ) -> Self {
+            Self {
+                role,
+                subrole,
+                request,
+                iso3883,
+                hpms_type,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The RestrictionAppliesTo data element provides a short list of common vehicle types which may have one or more"]
+    #[doc = "* special movements at an intersection. In general, these movements are not visible to other traffic with signal heads, but"]
+    #[doc = "* the SPAT data reflects the state of the movement. Various restricted movements at an intersection can be expressed"]
+    #[doc = "* using this element to indicate where the movement applies."]
+    #[doc = "*"]
+    #[doc = "* - `none` :              applies to nothing"]
+    #[doc = "* - `equippedTransit`:    buses etc."]
+    #[doc = "* - `equippedTaxis`:"]
+    #[doc = "* - `equippedOther`:      other vehicle types with necessary signal phase state reception equipment"]
+    #[doc = "* - `emissionCompliant`:  regional variants with more definitive items also exist"]
+    #[doc = "* - `equippedBicycle`:"]
+    #[doc = "* - `weightCompliant`:"]
+    #[doc = "* - `heightCompliant`:    Items dealing with traveler needs serviced by the infrastructure. These end users (which are not vehicles) are presumed to be suitably equipped"]
+    #[doc = "* - `pedestrians`:"]
+    #[doc = "* - `slowMovingPersons`:"]
+    #[doc = "* - `wheelchairUsers`:"]
+    #[doc = "* - `visualDisabilities`:"]
+    #[doc = "* - `audioDisabilities`:  hearing"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum RestrictionAppliesTo {
+        none = 0,
+        equippedTransit = 1,
+        equippedTaxis = 2,
+        equippedOther = 3,
+        emissionCompliant = 4,
+        equippedBicycle = 5,
+        weightCompliant = 6,
+        heightCompliant = 7,
+        pedestrians = 8,
+        slowMovingPersons = 9,
+        wheelchairUsers = 10,
+        visualDisabilities = 11,
+        audioDisabilities = 12,
+        otherUnknownDisabilities = 13,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to assign (or bind) a single RestrictionClassID data"]
+    #[doc = "* element to a list of all user classes to which it applies. A collection of these bindings is conveyed in the"]
+    #[doc = "* RestrictionClassList data frame in the MAP message to travelers. The established index is then used in the lane object of"]
+    #[doc = "* the MAP message, in the ConnectTo data frame, to qualify to whom a signal group ID applies when it is sent by the SPAT"]
+    #[doc = "* message about a movement."]
+    #[doc = "*"]
+    #[doc = "* @field id: the unique value (within an intersection or local region) that is assigned to this group of users."]
+    #[doc = "* @field users: The list of user types/classes to which this restriction ID applies."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RestrictionClassAssignment {
+        pub id: RestrictionClassID,
+        pub users: RestrictionUserTypeList,
+    }
+    impl RestrictionClassAssignment {
+        pub fn new(id: RestrictionClassID, users: RestrictionUserTypeList) -> Self {
+            Self { id, users }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE defines an intersection-unique value to convey data about classes of users."]
+    #[doc = "* The mapping used varies with each intersection and is defined in the MAP message if needed. The defined mappings"]
+    #[doc = "* found there are used to determine when a given class is meant. The typical use of this element is to map additional"]
+    #[doc = "* movement restrictions or rights (in both the MAP and SPAT messages) to special classes of users (trucks, high sided"]
+    #[doc = "* vehicles, special vehicles etc.). There is the general presumption that in the absence of this data, any allowed movement"]
+    #[doc = "* extends to all users."]
+    #[doc = "*"]
+    #[doc = "* An index value to identify data about classes of users the value used varies with each intersection's"]
+    #[doc = "* needs and is defined in the map to the assigned classes of supported users."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct RestrictionClassID(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DF is used to enumerate a list of user classes which belong to a given"]
+    #[doc = "* assigned index. The resulting collection is treated as a group by the signal controller when it issues movement data"]
+    #[doc = "* (signal phase information) with the GroupID for this group. This data frame is typically static for long periods of time"]
+    #[doc = "* (months) and conveyed to the user by means of the MAP message."]
+    #[doc = "*"]
+    #[doc = "* @note: The overall restriction class assignment process allows dynamic support within the framework of the common"]
+    #[doc = "*        message set for the various special cases that some signalized intersections must support. While the assigned value"]
+    #[doc = "*        needs to be unique only within the scope of the intersection that uses it, the resulting assignment lists will tend to be static"]
+    #[doc = "*        and stable for regional deployment areas such as a metropolitan area based on their operational practices and needs."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=254"))]
+    pub struct RestrictionClassList(pub SequenceOf<RestrictionClassAssignment>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousRestrictionUserTypeRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousRestrictionUserTypeRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousRestrictionUserTypeRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegRestrictionUserType_Type, D::Error> {
+            RegRestrictionUserType_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct RestrictionUserTypeRegional(pub SequenceOf<AnonymousRestrictionUserTypeRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide a means to select one, and only one, user type or class"]
+    #[doc = "* from a number of well-known lists. The selected entry is then used in the overall Restriction Class assignment process to"]
+    #[doc = "* indicate that a given GroupID (a way of expressing a movement in the SPAT/MAP system) applies to (is restricted to) this"]
+    #[doc = "* class of user."]
+    #[doc = "*"]
+    #[doc = "* @field basicType: a set of the most commonly used types."]
+    #[doc = "* @field regional:  optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum RestrictionUserType {
+        basicType(RestrictionAppliesTo),
+        regional(RestrictionUserTypeRegional),
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref RestrictionUserType entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct RestrictionUserTypeList(pub SequenceOf<RestrictionUserType>);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of GenericLane entries used to describe a segment of roadway."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=255"))]
+    pub struct RoadLaneSetList(pub SequenceOf<GenericLane>);
+    #[doc = "*"]
+    #[doc = "* This DE is a 16-bit globally unique identifier assigned to an entity responsible for assigning"]
+    #[doc = "* Intersection IDs in the region over which it has such authority. The value zero shall be used for testing, and should only be"]
+    #[doc = "* used in the absence of a suitable assignment. A single entity which assigns intersection IDs may be assigned several"]
+    #[doc = "* RoadRegulatorIDs. These assignments are presumed to be permanent."]
+    #[doc = "*"]
+    #[doc = "* The value zero shall be used for testing only"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct RoadRegulatorID(pub u16);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousRoadSegmentRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousRoadSegmentRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousRoadSegmentRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegRoadSegment_Type, D::Error> {
+            RegRoadSegment_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct RoadSegmentRegional(pub SequenceOf<AnonymousRoadSegmentRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is a complete description of a RoadSegment including its geometry and its"]
+    #[doc = "* allowed navigational paths (independent of any additional regulatory restrictions that may apply over time or from user"]
+    #[doc = "* classification) and any current disruptions such as a work zone or incident event."]
+    #[doc = "*"]
+    #[doc = "* @field name: some descriptive text."]
+    #[doc = "* @field id: a globally unique value for the segment."]
+    #[doc = "* @field revision: ."]
+    #[doc = "* @field refPoint: the reference from which subsequent data points are offset until a new point is used."]
+    #[doc = "* @field laneWidth: Reference width used by all subsequent lanes unless a new width is given."]
+    #[doc = "* @field speedLimits: Reference regulatory speed limits used by all subsequent lanes unless a new speed is given."]
+    #[doc = "* @field roadLaneSet: Data describing disruptions in the RoadSegment such as work zones etc will be added here."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct RoadSegment {
+        pub name: Option<DescriptiveName>,
+        pub id: RoadSegmentReferenceID,
+        pub revision: MsgCount,
+        #[rasn(identifier = "refPoint")]
+        pub ref_point: Position3D,
+        #[rasn(identifier = "laneWidth")]
+        pub lane_width: Option<LaneWidth>,
+        #[rasn(identifier = "speedLimits")]
+        pub speed_limits: Option<SpeedLimitList>,
+        #[rasn(identifier = "roadLaneSet")]
+        pub road_lane_set: RoadLaneSetList,
+        pub regional: Option<RoadSegmentRegional>,
+    }
+    impl RoadSegment {
+        pub fn new(
+            name: Option<DescriptiveName>,
+            id: RoadSegmentReferenceID,
+            revision: MsgCount,
+            ref_point: Position3D,
+            lane_width: Option<LaneWidth>,
+            speed_limits: Option<SpeedLimitList>,
+            road_lane_set: RoadLaneSetList,
+            regional: Option<RoadSegmentRegional>,
+        ) -> Self {
+            Self {
+                name,
+                id,
+                revision,
+                ref_point,
+                lane_width,
+                speed_limits,
+                road_lane_set,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to uniquely define a section of roadway within a country or region in a 16-bit field."]
+    #[doc = "* Assignment rules for this value are established elsewhere and may use regional assignment schemas that vary. Within"]
+    #[doc = "* the region the policies used to ensure an assigned value’s uniqueness before that value is reused is the responsibility of"]
+    #[doc = "* that region. Such reuse is expected to occur, but over somewhat lengthy epoch (months)."]
+    #[doc = "*"]
+    #[doc = "* The values zero to 255 shall be used for testing only"]
+    #[doc = "* Note that the value assigned to an RoadSegment will be"]
+    #[doc = "* unique within a given regional ID only during its use"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct RoadSegmentID(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref RoadSegment entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct RoadSegmentList(pub SequenceOf<RoadSegment>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey theRoadSegmentID which is unique to a given road segment of interest,"]
+    #[doc = "* and also the RoadRegulatorID assigned to the region in which it is operating (when required)."]
+    #[doc = "*"]
+    #[doc = "* @field region: a globally unique regional assignment value typically assigned to a regional DOT authority the value zero shall be used for testing needs."]
+    #[doc = "* @field id:     a unique mapping to the road segment in question within the above region of use during its period of assignment and use"]
+    #[doc = "*                note that unlike intersectionID values, this value can be reused by the region."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RoadSegmentReferenceID {
+        pub region: Option<RoadRegulatorID>,
+        pub id: RoadSegmentID,
+    }
+    impl RoadSegmentReferenceID {
+        pub fn new(region: Option<RoadRegulatorID>, id: RoadSegmentID) -> Self {
+            Self { region, id }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* The RoadwayCrownAngle data element relates the gross tangential angle of the roadway surface with respect to"]
+    #[doc = "* the local horizontal axis and is measured at the indicated part of the lane. This measurement is typically made at the"]
+    #[doc = "* crown (centerline) or at an edge of the lane path. Its typical use is to relate data used in speed warning and traction"]
+    #[doc = "* calculations for the lane segment or roadway segment in which the measurement is taken."]
+    #[doc = "*"]
+    #[doc = "* - The value -128 shall be used for unknown"]
+    #[doc = "* - The value zero shall be used for angles which are between -0.15 and +0.15"]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.3 degrees of angle over a range of -38.1 to + 38.1 degrees"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-128..=127"))]
+    pub struct RoadwayCrownAngle(pub i8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 route information."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct RouteNumber(pub u32);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSPATRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSPATRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSPATRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSPAT_Type, D::Error> {
+            RegSPAT_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SPATRegional(pub SequenceOf<AnonymousSPATRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to convey the current status of one or more signalized"]
+    #[doc = "* intersections. Along with the MapData message (which describes a full geometric layout of an intersection) the"]
+    #[doc = "* receiver of this message can determine the state of the signal phasing and when the next expected phase will occur."]
+    #[doc = "* The SPAT message sends the current movement state of each active phase in the system as needed (such as values of"]
+    #[doc = "* what states are active and values at what time a state has begun/does begin earliest, is expected to begin most likely and"]
+    #[doc = "* will end latest). The state of inactive movements is not normally transmitted. Movements are mapped to specific"]
+    #[doc = "* approaches and connections of ingress to egress lanes and by use of the SignalGroupID in the MapData message"]
+    #[doc = "*"]
+    #[doc = "* The current signal preemption and priority status values (when present or active) are also sent. A more complete"]
+    #[doc = "* summary of any pending priority or preemption events can be found in the Signal Status message."]
+    #[doc = "*"]
+    #[doc = "* @field timeStamp: time reference"]
+    #[doc = "* @field name: human readable name for this collection. to be used only in debug mode."]
+    #[doc = "* @field intersections: sets of SPAT data (one per intersection)"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SPAT {
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<MinuteOfTheYear>,
+        pub name: Option<DescriptiveName>,
+        pub intersections: IntersectionStateList,
+        pub regional: Option<SPATRegional>,
+    }
+    impl SPAT {
+        pub fn new(
+            time_stamp: Option<MinuteOfTheYear>,
+            name: Option<DescriptiveName>,
+            intersections: IntersectionStateList,
+            regional: Option<SPATRegional>,
+        ) -> Self {
+            Self {
+                time_stamp,
+                name,
+                intersections,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* A 12-bit signed scaling factor supporting scales from zero (which is not used) to >200%. In this data element, the"]
+    #[doc = "* value zero is taken to represent a value of one (scale 1:1). Values above and below this add or remove exactly 0.05%"]
+    #[doc = "* from the initial value of 100%. Hence, a value of 2047 adds 102.35% to 100%, resulting in a scale of 202.35% exactly (the"]
+    #[doc = "* largest valid scale value). Negative values which would result in an effective final value below zero are not supported. The"]
+    #[doc = "* smallest valid value allowed is -1999 and the remaining negative values are reserved for future definition."]
+    #[doc = "*"]
+    #[doc = "* @unit: in steps of 0.05 percent"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "Scale-B12", value("-2048..=2047"))]
+    pub struct ScaleB12(pub i16);
+    #[doc = "*"]
+    #[doc = "* This DE is an enumerated list of attributes about the current lane segment which"]
+    #[doc = "* may be enabled or disabled to indicate the presence or absence of the selected attribute on the segment. A segment is"]
+    #[doc = "* one or more of the straight lines formed between each set of node points. It is common for a segment attribute to persist"]
+    #[doc = "* for more than one set of node points if there is any curvature in the lane itself. The described attributes are all binary flags"]
+    #[doc = "* in that they do not need to convey any additional data. Other attributes allow sending short data values to reflect a setting"]
+    #[doc = "* which is set and persists in a similar fashion."]
+    #[doc = "*"]
+    #[doc = "* Various values which can be Enabled and Disabled for a lane segment"]
+    #[doc = "* - reserved:"]
+    #[doc = "* - doNotBlock: segment where a vehicle may not come to a stop"]
+    #[doc = "* - whiteLine:  segment where lane crossing not allowed such as the final few meters of a lane "]
+    #[doc = "* - mergingLaneLeft: indicates porous lanes"]
+    #[doc = "* - mergingLaneRight: indicates porous lanes"]
+    #[doc = "* - curbOnLeft: indicates presence of curbs"]
+    #[doc = "* - curbOnRight: indicates presence of curbs"]
+    #[doc = "* - loadingzoneOnLeft:  loading or drop off zones"]
+    #[doc = "* - loadingzoneOnRight: loading or drop off zones"]
+    #[doc = "* - turnOutPointOnLeft: opening to adjacent street/alley/road"]
+    #[doc = "* - turnOutPointOnRight: opening to adjacent street/alley/road"]
+    #[doc = "* - adjacentParkingOnLeft: side of road parking"]
+    #[doc = "* - adjacentParkingOnRight: side of road parking"]
+    #[doc = "* - adjacentBikeLaneOnLeft: presence of marked bike lanes"]
+    #[doc = "* - adjacentBikeLaneOnRight: presence of marked bike lanes"]
+    #[doc = "* - sharedBikeLane: right of way is shared with bikes who may occupy entire lane width"]
+    #[doc = "* - bikeBoxInFront:"]
+    #[doc = "* - transitStopOnLeft: any form of bus/transit loading, with pull in-out access to lane on left"]
+    #[doc = "* - transitStopOnRight: any form of bus/transit loading, with pull in-out access to lane on right"]
+    #[doc = "* - transitStopInLane: any form of bus/transit loading, in mid path of the lane"]
+    #[doc = "* - sharedWithTrackedVehicle: lane is shared with train or trolley, not used for crossing tracks "]
+    #[doc = "* - safeIsland: begin/end a safety island in path"]
+    #[doc = "* - lowCurbsPresent: for ADA support"]
+    #[doc = "* - rumbleStripPresent: for ADA support"]
+    #[doc = "* - audibleSignalingPresent: for ADA support"]
+    #[doc = "* - adaptiveTimingPresent: for ADA support"]
+    #[doc = "* - rfSignalRequestPresent: Supports RF push to walk technologies"]
+    #[doc = "* - partialCurbIntrusion: path is blocked by a median or curb but at least 1 meter remains open for use"]
+    #[doc = "*                         and at-grade passage Lane geometry details"]
+    #[doc = "* - taperToLeft: Used to control final path shape (see standard for defined shapes)"]
+    #[doc = "* - taperToRight: Used to control final path shape (see standard for defined shapes)"]
+    #[doc = "* - taperToCenterLine: Used to control final path shape (see standard for defined shapes)"]
+    #[doc = "* - parallelParking: Parking at an angle with the street"]
+    #[doc = "* - headInParking:   Parking at an angle with the street"]
+    #[doc = "* - freeParking:     No restriction on use of parking"]
+    #[doc = "* - timeRestrictionsOnParking: Parking is not permitted at all times"]
+    #[doc = "*                              typically used when the **parking** lane becomes a driving lane at times"]
+    #[doc = "* - costToPark: Used where parking has a cost"]
+    #[doc = "* - midBlockCurbPresent: a protruding curb near lane edge"]
+    #[doc = "* - unEvenPavementPresent: a disjoint height at lane edge"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum SegmentAttributeXY {
+        reserved = 0,
+        doNotBlock = 1,
+        whiteLine = 2,
+        mergingLaneLeft = 3,
+        mergingLaneRight = 4,
+        curbOnLeft = 5,
+        curbOnRight = 6,
+        loadingzoneOnLeft = 7,
+        loadingzoneOnRight = 8,
+        turnOutPointOnLeft = 9,
+        turnOutPointOnRight = 10,
+        adjacentParkingOnLeft = 11,
+        adjacentParkingOnRight = 12,
+        adjacentBikeLaneOnLeft = 13,
+        adjacentBikeLaneOnRight = 14,
+        sharedBikeLane = 15,
+        bikeBoxInFront = 16,
+        transitStopOnLeft = 17,
+        transitStopOnRight = 18,
+        transitStopInLane = 19,
+        sharedWithTrackedVehicle = 20,
+        safeIsland = 21,
+        lowCurbsPresent = 22,
+        rumbleStripPresent = 23,
+        audibleSignalingPresent = 24,
+        adaptiveTimingPresent = 25,
+        rfSignalRequestPresent = 26,
+        partialCurbIntrusion = 27,
+        taperToLeft = 28,
+        taperToRight = 29,
+        taperToCenterLine = 30,
+        parallelParking = 31,
+        headInParking = 32,
+        freeParking = 33,
+        timeRestrictionsOnParking = 34,
+        costToPark = 35,
+        midBlockCurbPresent = 36,
+        unEvenPavementPresent = 37,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref SegmentAttributeXY entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=8"))]
+    pub struct SegmentAttributeXYList(pub SequenceOf<SegmentAttributeXY>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to express the radius (length) of the semi-major axis of an"]
+    #[doc = "* ellipsoid representing the accuracy which can be expected from a GNSS system in 5cm steps,"]
+    #[doc = "* typically at a one sigma level of confidence."]
+    #[doc = "*"]
+    #[doc = "* Value is semi-major axis accuracy at one standard dev."]
+    #[doc = "* - Range 0-12.7 meter, LSB = .05m"]
+    #[doc = "* - 254 = any value equal or greater than 12.70 meter"]
+    #[doc = "* - 255 = unavailable semi-major axis value"]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.05m"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SemiMajorAxisAccuracy(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to orientate the angle of the semi-major axis of an"]
+    #[doc = "* ellipsoid representing the accuracy which can be expected from a GNSS system with respect to the coordinate system."]
+    #[doc = "*"]
+    #[doc = "* Value is orientation of semi-major axis"]
+    #[doc = "* - relative to true north (0-359.9945078786 degrees)"]
+    #[doc = "* - LSB units of 360/65535 deg = 0.0054932479"]
+    #[doc = "* - a value of 0 shall be 0 degrees"]
+    #[doc = "* - a value of 1 shall be 0.0054932479 degrees"]
+    #[doc = "* - a value of 65534 shall be 359.9945078786 deg"]
+    #[doc = "* - a value of 65535 shall be used for orientation unavailable"]
+    #[doc = "*"]
+    #[doc = "* @unit: 360/65535 degree"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct SemiMajorAxisOrientation(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DE is used to express the radius of the semi-minor axis of an ellipsoid"]
+    #[doc = "* representing the accuracy which can be expected from a GNSS system in 5cm steps, typically at a one sigma level of"]
+    #[doc = "* confidence."]
+    #[doc = "*"]
+    #[doc = "* Value is semi-minor axis accuracy at one standard dev"]
+    #[doc = "* - range 0-12.7 meter, LSB = .05m"]
+    #[doc = "* - 254 = any value equal or greater than 12.70 meter"]
+    #[doc = "* - 255 = unavailable semi-minor axis value"]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.05m"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SemiMinorAxisAccuracy(pub u8);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SignalControlZoneZone {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl SignalControlZoneZone {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl SignalControlZoneZone {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalControlZone_Type, D::Error> {
+            RegSignalControlZone_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is a dummy placeholder to contain a regional SignalControlZone DF."]
+    #[doc = "* It is not used, yet here for backwards compatibility."]
+    #[doc = "*"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalControlZone {
+        pub zone: SignalControlZoneZone,
+    }
+    impl SignalControlZone {
+        pub fn new(zone: SignalControlZoneZone) -> Self {
+            Self { zone }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is an index used to map between the internal state machine of one or more signal controllers (or"]
+    #[doc = "* other types of traffic flow devices) and a common numbering system that can represent all possible combinations of active"]
+    #[doc = "* states (movements and phases in US traffic terminology). All possible movement variations are assigned a unique value"]
+    #[doc = "* within the intersection. Conceptually, the ID represents a means to provide a list of lanes in a set which would otherwise"]
+    #[doc = "* need to be enumerated in the message. The values zero and 255 are reserved, so there may up to 254 different signal"]
+    #[doc = "* group IDs within one single intersection. The value 255 represents a protected-Movement-Allowed or permissive-"]
+    #[doc = "* Movement-Allowed condition that exists at all times. This value is applied to lanes, with or without traffic control devices,"]
+    #[doc = "* that operate as free-flow lanes. Typically referred to as Channelized Right/Left Turn Lanes (in right/left-hand drive"]
+    #[doc = "* countries)."]
+    #[doc = "*"]
+    #[doc = "* Values:"]
+    #[doc = "* - the value `0` shall be used when the ID is not available or not known"]
+    #[doc = "* - the value `255` is reserved to indicate a permanent green movement state"]
+    #[doc = "* - therefore a simple 8 phase signal controller device might use 1..9 as its groupIDs"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct SignalGroupID(pub u8);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalRequestRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalRequestRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalRequestRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalRequest_Type, D::Error> {
+            RegSignalRequest_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalRequestRegional(pub SequenceOf<AnonymousSignalRequestRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used (as part of a request message) to request either a priority or a preemption service"]
+    #[doc = "* from a signalized intersection. It relates the intersection ID as well as the specific request information. Additional"]
+    #[doc = "* information includes the approach and egress values or lanes to be used."]
+    #[doc = "*"]
+    #[doc = "* @field id: the unique ID of the target intersection"]
+    #[doc = "* @field requestID: The unique requestID used by the requestor"]
+    #[doc = "* @field requestType: The type of request or cancel for priority or preempt use when a prior request is canceled, only the requestID is needed."]
+    #[doc = "* @field inBoundLane: desired entry approach or lane."]
+    #[doc = "* @field outBoundLane: desired exit approach or lane. the value zero is used to indicate intent to stop within the intersection."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @note: In typical use either an approach or a lane number would be given, this indicates the requested"]
+    #[doc = "*        path through the intersection to the degree it is known."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalRequest {
+        pub id: IntersectionReferenceID,
+        #[rasn(identifier = "requestID")]
+        pub request_id: RequestID,
+        #[rasn(identifier = "requestType")]
+        pub request_type: PriorityRequestType,
+        #[rasn(identifier = "inBoundLane")]
+        pub in_bound_lane: IntersectionAccessPoint,
+        #[rasn(identifier = "outBoundLane")]
+        pub out_bound_lane: Option<IntersectionAccessPoint>,
+        pub regional: Option<SignalRequestRegional>,
+    }
+    impl SignalRequest {
+        pub fn new(
+            id: IntersectionReferenceID,
+            request_id: RequestID,
+            request_type: PriorityRequestType,
+            in_bound_lane: IntersectionAccessPoint,
+            out_bound_lane: Option<IntersectionAccessPoint>,
+            regional: Option<SignalRequestRegional>,
+        ) -> Self {
+            Self {
+                id,
+                request_id,
+                request_type,
+                in_bound_lane,
+                out_bound_lane,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref SignalRequest entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct SignalRequestList(pub SequenceOf<SignalRequestPackage>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalRequestMessageRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalRequestMessageRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalRequestMessageRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalRequestMessage_Type, D::Error> {
+            RegSignalRequestMessage_Type::decode(
+                decoder,
+                Some(&self.reg_ext_value),
+                &self.region_id,
+            )
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalRequestMessageRegional(pub SequenceOf<AnonymousSignalRequestMessageRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is a message sent by a DSRC equipped entity (such as a vehicle) to the RSU in a"]
+    #[doc = "* signalized intersection. It is used for either a priority signal request or a preemption signal request depending on the way"]
+    #[doc = "* each request is set. Each request defines a path through the intersection which is desired in terms of lanes and"]
+    #[doc = "* approaches to be used. Each request can also contain the time of arrival and the expected duration of the service."]
+    #[doc = "* Multiple requests to multiple intersections are supported. The requestor identifies itself in various ways (using methods"]
+    #[doc = "* supported by the @refRequestorDescription data frame), and its current speed, heading and location can be placed in this"]
+    #[doc = "* structure as well. The specific request for service is typically based on previously decoding and examining the list of lanes"]
+    #[doc = "* and approaches for that intersection (sent in MAP messages). The outcome of all of the pending requests to a signal can"]
+    #[doc = "* be found in the Signal Status Message (SSM), and may be reflected in the SPAT message contents if successful."]
+    #[doc = "*"]
+    #[doc = "* @field timeStamp: time reference"]
+    #[doc = "* @field second: time reference"]
+    #[doc = "* @field sequenceNumber: monotonic incrementing identifier"]
+    #[doc = "* @field requests: Request Data for one or more signalized intersections that support SRM dialogs"]
+    #[doc = "* @field requestor: Requesting Device and other User Data contains vehicle ID (if from a vehicle) as well as type data and current"]
+    #[doc = "*                   position and may contain additional transit data"]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalRequestMessage {
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<MinuteOfTheYear>,
+        pub second: DSecond,
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: Option<MsgCount>,
+        pub requests: Option<SignalRequestList>,
+        pub requestor: RequestorDescription,
+        pub regional: Option<SignalRequestMessageRegional>,
+    }
+    impl SignalRequestMessage {
+        pub fn new(
+            time_stamp: Option<MinuteOfTheYear>,
+            second: DSecond,
+            sequence_number: Option<MsgCount>,
+            requests: Option<SignalRequestList>,
+            requestor: RequestorDescription,
+            regional: Option<SignalRequestMessageRegional>,
+        ) -> Self {
+            Self {
+                time_stamp,
+                second,
+                sequence_number,
+                requests,
+                requestor,
+                regional,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalRequestPackageRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalRequestPackageRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalRequestPackageRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalRequestPackage_Type, D::Error> {
+            RegSignalRequestPackage_Type::decode(
+                decoder,
+                Some(&self.reg_ext_value),
+                &self.region_id,
+            )
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalRequestPackageRegional(pub SequenceOf<AnonymousSignalRequestPackageRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF contains both the service request itself (the preemption and priority"]
+    #[doc = "* details and the inbound-outbound path details for an intersection) and the time period (start and end time) over which this"]
+    #[doc = "* service is sought from one single intersection. One or more of these packages are contained in a list in the Signal"]
+    #[doc = "* Request Message (SREM)."]
+    #[doc = "*"]
+    #[doc = "* @field request:  The specific request to the intersection contains IntersectionID, request type, requested action (approach/lane request)."]
+    #[doc = "* @field minute:   Time period start."]
+    #[doc = "* @field second:   Time period start."]
+    #[doc = "* @field duration: The duration value is used to provide a short interval that extends the ETA so that the requesting vehicle can arrive at"]
+    #[doc = "*                  the point of service with uncertainty or with some desired duration of service. This concept can be used to avoid needing"]
+    #[doc = "*                  to frequently update the request. The requester must update the ETA and duration values if the"]
+    #[doc = "*                  period of services extends beyond the duration time. It should be assumed that if the vehicle does not clear the"]
+    #[doc = "*                  intersection when the duration is reached, the request will be cancelled and the intersection will revert to normal operation."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalRequestPackage {
+        pub request: SignalRequest,
+        pub minute: Option<MinuteOfTheYear>,
+        pub second: Option<DSecond>,
+        pub duration: Option<DSecond>,
+        pub regional: Option<SignalRequestPackageRegional>,
+    }
+    impl SignalRequestPackage {
+        pub fn new(
+            request: SignalRequest,
+            minute: Option<MinuteOfTheYear>,
+            second: Option<DSecond>,
+            duration: Option<DSecond>,
+            regional: Option<SignalRequestPackageRegional>,
+        ) -> Self {
+            Self {
+                request,
+                minute,
+                second,
+                duration,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to contain information regarding the entity that requested a given"]
+    #[doc = "* signal behavior. In addition to the VehicleID, the data frame also contains a request reference number used to uniquely"]
+    #[doc = "* refer to the request and some basic type information about the request maker which may be used by other parties."]
+    #[doc = "*"]
+    #[doc = "* @field id: to uniquely identify the requester and the specific request to all parties."]
+    #[doc = "* @field request: to uniquely identify the requester and the specific request to all parties."]
+    #[doc = "* @field sequenceNumber: to uniquely identify the requester and the specific request to all parties."]
+    #[doc = "* @field role: vehicle role"]
+    #[doc = "* @field typeData: Used when addition data besides the role is needed, at which point the role entry above is not sent."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalRequesterInfo {
+        pub id: VehicleID,
+        pub request: RequestID,
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: MsgCount,
+        pub role: Option<BasicVehicleRole>,
+        #[rasn(identifier = "typeData")]
+        pub type_data: Option<RequestorType>,
+    }
+    impl SignalRequesterInfo {
+        pub fn new(
+            id: VehicleID,
+            request: RequestID,
+            sequence_number: MsgCount,
+            role: Option<BasicVehicleRole>,
+            type_data: Option<RequestorType>,
+        ) -> Self {
+            Self {
+                id,
+                request,
+                sequence_number,
+                role,
+                type_data,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalStatusRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalStatusRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalStatusRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalStatus_Type, D::Error> {
+            RegSignalStatus_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalStatusRegional(pub SequenceOf<AnonymousSignalStatusRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide the status of a single intersection to others, including any active"]
+    #[doc = "* preemption or priority state in effect."]
+    #[doc = "*"]
+    #[doc = "* @field sequenceNumber: changed whenever the below contents have change"]
+    #[doc = "* @field id:             this provides a unique mapping to the intersection map in question which provides complete location"]
+    #[doc = "*                        and approach/movement/lane data as well as zones for priority/preemption."]
+    #[doc = "* @field sigStatus:      a list of detailed status containing all priority or preemption state data, both active and pending,"]
+    #[doc = "*                        and who requested it requests which are denied are also listed here for a short period of time."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalStatus {
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: MsgCount,
+        pub id: IntersectionReferenceID,
+        #[rasn(identifier = "sigStatus")]
+        pub sig_status: SignalStatusPackageList,
+        pub regional: Option<SignalStatusRegional>,
+    }
+    impl SignalStatus {
+        pub fn new(
+            sequence_number: MsgCount,
+            id: IntersectionReferenceID,
+            sig_status: SignalStatusPackageList,
+            regional: Option<SignalStatusRegional>,
+        ) -> Self {
+            Self {
+                sequence_number,
+                id,
+                sig_status,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref SignalStatus entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct SignalStatusList(pub SequenceOf<SignalStatus>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalStatusMessageRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalStatusMessageRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalStatusMessageRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalStatusMessage_Type, D::Error> {
+            RegSignalStatusMessage_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalStatusMessageRegional(pub SequenceOf<AnonymousSignalStatusMessageRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF is a message sent by an RSU in a signalized intersection. It is used to relate the current"]
+    #[doc = "* status of the signal and the collection of pending or active preemption or priority requests acknowledged by the controller."]
+    #[doc = "* It is also used to send information about preemption or priority requests which were denied. This in turn allows a dialog"]
+    #[doc = "* acknowledgment mechanism between any requester and the signal controller. The data contained in this message allows"]
+    #[doc = "* other users to determine their \"ranking\" for any request they have made as well as to see the currently active events."]
+    #[doc = "* When there have been no recently received requests for service messages, this message may not be sent. While the"]
+    #[doc = "* outcome of all pending requests to a signal can be found in the Signal Status Message, the current active event (if any)"]
+    #[doc = "* will be reflected in the SPAT message contents."]
+    #[doc = "*"]
+    #[doc = "* @field timeStamp: time reference"]
+    #[doc = "* @field second: time reference"]
+    #[doc = "* @field sequenceNumber: monotonic incrementing identifier"]
+    #[doc = "* @field status: Status Data for one of more signalized intersections."]
+    #[doc = "* @field regional: optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalStatusMessage {
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<MinuteOfTheYear>,
+        pub second: DSecond,
+        #[rasn(identifier = "sequenceNumber")]
+        pub sequence_number: Option<MsgCount>,
+        pub status: SignalStatusList,
+        pub regional: Option<SignalStatusMessageRegional>,
+    }
+    impl SignalStatusMessage {
+        pub fn new(
+            time_stamp: Option<MinuteOfTheYear>,
+            second: DSecond,
+            sequence_number: Option<MsgCount>,
+            status: SignalStatusList,
+            regional: Option<SignalStatusMessageRegional>,
+        ) -> Self {
+            Self {
+                time_stamp,
+                second,
+                sequence_number,
+                status,
+                regional,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    pub struct AnonymousSignalStatusPackageRegional {
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
+        #[rasn(identifier = "regExtValue")]
+        pub reg_ext_value: Any,
+    }
+    impl AnonymousSignalStatusPackageRegional {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
+            Self {
+                region_id,
+                reg_ext_value,
+            }
+        }
+    }
+    impl AnonymousSignalStatusPackageRegional {
+        pub fn decode_reg_ext_value<D: Decoder>(
+            &self,
+            decoder: &mut D,
+        ) -> Result<RegSignalStatusPackage_Type, D::Error> {
+            RegSignalStatusPackage_Type::decode(decoder, Some(&self.reg_ext_value), &self.region_id)
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct SignalStatusPackageRegional(pub SequenceOf<AnonymousSignalStatusPackageRegional>);
+    #[doc = "*"]
+    #[doc = "* This DF contains all the data needed to describe the preemption or priority state"]
+    #[doc = "* of the signal controller with respect to a given request and to uniquely identify the party who requested that state to occur."]
+    #[doc = "* It should be noted that this data frame describes both active and anticipated states of the controller. A requested service"]
+    #[doc = "* may not be active when the message is created and issued. A requested service may be rejected. This structure allows"]
+    #[doc = "* the description of pending requests that have been granted (accepted rather than rejected) but are not yet active and"]
+    #[doc = "* being serviced. It also provides for the description of rejected requests so that the initial message is acknowledged"]
+    #[doc = "* (completing a dialog using the broadcast messages)."]
+    #[doc = "*"]
+    #[doc = "* @field requester:  The party that made the initial SREM request."]
+    #[doc = "* @field inboundOn:  estimated lane / approach of vehicle."]
+    #[doc = "* @field outboundOn: estimated lane / approach of vehicle."]
+    #[doc = "* @field minute:     The Estimated Time of Arrival (ETA) when the service is requested. This data echos the data of the request."]
+    #[doc = "* @field second:     seconds part of ETA."]
+    #[doc = "* @field duration:   duration part of ETA."]
+    #[doc = "* @field status:     Status of request, this may include rejection."]
+    #[doc = "* @field regional:   optional region specific data."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalStatusPackage {
+        pub requester: Option<SignalRequesterInfo>,
+        #[rasn(identifier = "inboundOn")]
+        pub inbound_on: IntersectionAccessPoint,
+        #[rasn(identifier = "outboundOn")]
+        pub outbound_on: Option<IntersectionAccessPoint>,
+        pub minute: Option<MinuteOfTheYear>,
+        pub second: Option<DSecond>,
+        pub duration: Option<DSecond>,
+        pub status: PrioritizationResponseStatus,
+        pub regional: Option<SignalStatusPackageRegional>,
+    }
+    impl SignalStatusPackage {
+        pub fn new(
+            requester: Option<SignalRequesterInfo>,
+            inbound_on: IntersectionAccessPoint,
+            outbound_on: Option<IntersectionAccessPoint>,
+            minute: Option<MinuteOfTheYear>,
+            second: Option<DSecond>,
+            duration: Option<DSecond>,
+            status: PrioritizationResponseStatus,
+            regional: Option<SignalStatusPackageRegional>,
+        ) -> Self {
+            Self {
+                requester,
+                inbound_on,
+                outbound_on,
+                minute,
+                second,
+                duration,
+                status,
+                regional,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of @ref SignalStatusPackage entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct SignalStatusPackageList(pub SequenceOf<SignalStatusPackage>);
+    #[doc = "*"]
+    #[doc = "* This data element represents the recommended velocity of an object, typically a vehicle speed along a roadway,"]
+    #[doc = "* expressed in unsigned units of 0.1 meters per second."]
+    #[doc = "*"]
+    #[doc = "* - LSB units are 0.1 m/s"]
+    #[doc = "* - the value 499 shall be used for values at or greater than 49.9 m/s"]
+    #[doc = "* - the value 500 shall be used to indicate that speed is unavailable"]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.1 m/s"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=500"))]
+    pub struct SpeedAdvice(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the 95% confidence level for the currently reported"]
+    #[doc = "* value of @ref Speed, taking into account the current calibration and precision of the sensor(s) used to measure and/or"]
+    #[doc = "* calculate the value. This data element is only to provide the listener with information on the limitations of the sensing"]
+    #[doc = "* system, not to support any type of automatic error correction or to imply a guaranteed maximum error. This data element"]
+    #[doc = "* should not be used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should"]
+    #[doc = "* be increased accordingly."]
+    #[doc = "*"]
+    #[doc = "* - 0 - `unavailable` : Not Equipped or unavailable"]
+    #[doc = "* - 1 - `prec100ms`   : 100  meters / sec"]
+    #[doc = "* - 2 - `prec10ms`    : 10   meters / sec"]
+    #[doc = "* - 3 - `prec5ms`     : 5    meters / sec"]
+    #[doc = "* - 4 - `prec1ms`     : 1    meters / sec"]
+    #[doc = "* - 5 - `prec0-1ms`   : 0.1  meters / sec"]
+    #[doc = "* - 6 - `prec0-05ms`  : 0.05 meters / sec"]
+    #[doc = "* - 7 - `prec0-01ms`  : 0.01 meters / sec"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum SpeedConfidenceDSRC {
+        unavailable = 0,
+        prec100ms = 1,
+        prec10ms = 2,
+        prec5ms = 3,
+        prec1ms = 4,
+        #[rasn(identifier = "prec0-1ms")]
+        prec0_1ms = 5,
+        #[rasn(identifier = "prec0-05ms")]
+        prec0_05ms = 6,
+        #[rasn(identifier = "prec0-01ms")]
+        prec0_01ms = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF consists of a list of SpeedLimit entries."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=9"))]
+    pub struct SpeedLimitList(pub SequenceOf<RegulatorySpeedLimit>);
+    #[doc = "*"]
+    #[doc = "* This DE relates the type of speed limit to which a given speed refers."]
+    #[doc = "*"]
+    #[doc = "* - unknown: Speed limit type not available"]
+    #[doc = "* - maxSpeedInSchoolZone: Only sent when the limit is active"]
+    #[doc = "* - maxSpeedInSchoolZoneWhenChildrenArePresent: Sent at any time"]
+    #[doc = "* - maxSpeedInConstructionZone: Used for work zones, incident zones, etc. where a reduced speed is present"]
+    #[doc = "* - vehicleMinSpeed: Regulatory speed limit for general traffic"]
+    #[doc = "* - vehicleMaxSpeed: Regulatory speed limit for general traffic"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum SpeedLimitType {
+        unknown = 0,
+        maxSpeedInSchoolZone = 1,
+        maxSpeedInSchoolZoneWhenChildrenArePresent = 2,
+        maxSpeedInConstructionZone = 3,
+        vehicleMinSpeed = 4,
+        vehicleMaxSpeed = 5,
+        vehicleNightMaxSpeed = 6,
+        truckMinSpeed = 7,
+        truckMaxSpeed = 8,
+        truckNightMaxSpeed = 9,
+        vehiclesWithTrailersMinSpeed = 10,
+        vehiclesWithTrailersMaxSpeed = 11,
+        vehiclesWithTrailersNightMaxSpeed = 12,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is a single data frame combining multiple related bit fields into one concept."]
+    #[doc = "*"]
+    #[doc = "* @field heading: confidence for heading values"]
+    #[doc = "* @field speed: confidence for speed values"]
+    #[doc = "* @field throttle: confidence for throttle values "]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SpeedandHeadingandThrottleConfidence {
+        pub heading: HeadingConfidenceDSRC,
+        pub speed: SpeedConfidenceDSRC,
+        pub throttle: ThrottleConfidence,
+    }
+    impl SpeedandHeadingandThrottleConfidence {
+        pub fn new(
+            heading: HeadingConfidenceDSRC,
+            speed: SpeedConfidenceDSRC,
+            throttle: ThrottleConfidence,
+        ) -> Self {
+            Self {
+                heading,
+                speed,
+                throttle,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This is the 4 octet random device identifier, called the TemporaryID. When used for a mobile OBU device, this value"]
+    #[doc = "* will change periodically to ensure the overall anonymity of the vehicle, unlike a typical wireless or wired 802 device ID."]
+    #[doc = "* Because this value is used as a means to identify the local vehicles that are interacting during an encounter, it is used in"]
+    #[doc = "* the message set. Other devices, such as infrastructure (RSUs), may have a fixed value for the temporary ID value. See"]
+    #[doc = "* also @ref StationId which is used in other deployment regions."]
+    #[doc = "*"]
+    #[doc = "* @note: The circumstances and times at which various DSRC devices (notably OBUs) create and change their current"]
+    #[doc = "*        Temporary ID is a complex application level topic. It should be noted that the Temporary ID is not the same as a device"]
+    #[doc = "*        MAC value, although when used as a means to uniquely identify a device, both have many common properties. It should"]
+    #[doc = "*        further be noted that the MAC value for a mobile OBU device (unlike a typical wireless or wired 802 device) will"]
+    #[doc = "*        periodically change to a new random value to ensure the overall anonymity of the vehicle."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct TemporaryID(pub FixedOctetString<4usize>);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the 95% confidence level for the currently reported"]
+    #[doc = "* value of DE @ref Throttle, taking into account the current calibration and precision of the sensor(s) used to measure and/or"]
+    #[doc = "* calculate the value. This data element is only to provide information on the limitations of the sensing system, not to"]
+    #[doc = "* support any type of automatic error correction or to imply a guaranteed maximum error. This data element should not be"]
+    #[doc = "* used for fault detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should be increased"]
+    #[doc = "* accordingly. If a fault that triggers the MIL is of a nature to render throttle performance unreliable, then ThrottleConfidence"]
+    #[doc = "* should be represented as \"notEquipped.\""]
+    #[doc = "*"]
+    #[doc = "* - 0 - `unavailable`:    B'00 Not Equipped or unavailable"]
+    #[doc = "* - 1 - `prec10percent`:  B'01 10 percent Confidence level"]
+    #[doc = "* - 2 - `prec1percent`:   B'10 1 percent Confidence level"]
+    #[doc = "* - 3 - `prec0-5percent`: B'11 0.5 percent Confidence level"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum ThrottleConfidence {
+        unavailable = 0,
+        prec10percent = 1,
+        prec1percent = 2,
+        #[rasn(identifier = "prec0-5percent")]
+        prec0_5percent = 3,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF conveys details about the timing of a phase within a movement. The core"]
+    #[doc = "* data concept expressed is the time stamp (time mark) at which the related phase will change to the next state. This is"]
+    #[doc = "* often found in the MinEndTime element, but the other elements may be needed to convey the full concept when adaptive"]
+    #[doc = "* timing is employed."]
+    #[doc = "*"]
+    #[doc = "* @field startTime: is used to relate when the phase itself started or is expected to start. This in turn allows the"]
+    #[doc = "*                   indication that a set of time change details refers to a future phase, rather than a currently active phase."]
+    #[doc = "*                   By this method, timing information about \"pre\" phase events (which are the short transitional phase used to alert OBUs to"]
+    #[doc = "*                   an impending green/go or yellow/caution phase) and the longer yellow-caution phase data is supported in the same form"]
+    #[doc = "*                   as various green/go phases. In theory, the time change details could be sent for a large sequence of phases if the signal"]
+    #[doc = "*                   timing was not adaptive and the operator wished to do so. In practice, it is expected only the \"next\" future phase will"]
+    #[doc = "*                   commonly be sent. It should be noted that this also supports the sending of time periods regarding various red phases;"]
+    #[doc = "*                   however, this is not expected to be done commonly."]
+    #[doc = "* @field minEndTime: is used to convey the earliest time possible at which the phase could change, except when"]
+    #[doc = "*                   unpredictable events relating to a preemption or priority call disrupt a currently active timing plan. In a phase where the"]
+    #[doc = "*                   time is fixed (as in a fixed yellow or clearance time), this element shall be used alone. This value can be viewed as the"]
+    #[doc = "*                   earliest possible time at which the phase could change, except when unpredictable events relating to a preemption or"]
+    #[doc = "*                   priority call come into play and disrupt a currently active timing plan."]
+    #[doc = "* @field maxEndTime: is used to convey the latest time possible which the phase could change,"]
+    #[doc = "*                   except when unpredictable events relating to a preemption or priority"]
+    #[doc = "*                   call come into play and disrupt a currently active timing plan. In a phase where the time is fixed (as in a fixed yellow or"]
+    #[doc = "*                   clearance time), this element shall be used alone."]
+    #[doc = "* @field likelyTime: is used to convey the most likely time the phase changes. This occurs between MinEndTime and"]
+    #[doc = "*                   MaxEndTime and is only relevant for traffic-actuated control programs. This time might be calculated out of logged"]
+    #[doc = "*                   historical values, detected events (e.g., from inductive loops), or from other sources."]
+    #[doc = "* @field confidence: is used to convey basic confidence data about the likelyTime."]
+    #[doc = "* @field nextTime:   is used to express a general (and presumably less precise) value regarding when this phase will"]
+    #[doc = "*                   next occur. This is intended to be used to alert the OBU when the next green/go may occur so that various ECO driving"]
+    #[doc = "*                   applications can better manage the vehicle during the intervening stopped time."]
+    #[doc = "*"]
+    #[doc = "* @note: Remarks: It should be noted that all times are expressed as absolute values and not as countdown timer values. When"]
+    #[doc = "*          the stated time mark is reached, the state changes to the next state. Several technical reasons led to this choice; among"]
+    #[doc = "*          these was that with a countdown embodiment, there is an inherent need to update the remaining time every time a SPAT"]
+    #[doc = "*          message is issued. This would require re-formulating the message content as as well as cryptographically signing the"]
+    #[doc = "*          message each time. With the use of absolute values (time marks) chosen here, the current count down time when the"]
+    #[doc = "*          message is created is added to the then-current time to create an absolute value and can be used thereafter without"]
+    #[doc = "*          change. The message content need only change when the signal controller makes a timing decision to be published. This"]
+    #[doc = "*          allows a clean separation of the logical functions of message creation from the logical functions of message scheduling"]
+    #[doc = "*          and sending, and fulfills the need to minimize further real time processing when possible. This Standard sets no limits on"]
+    #[doc = "*          where each of these functions is performed in the overall roadside system."]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct TimeChangeDetails {
+        #[rasn(identifier = "startTime")]
+        pub start_time: Option<TimeMark>,
+        #[rasn(identifier = "minEndTime")]
+        pub min_end_time: TimeMark,
+        #[rasn(identifier = "maxEndTime")]
+        pub max_end_time: Option<TimeMark>,
+        #[rasn(identifier = "likelyTime")]
+        pub likely_time: Option<TimeMark>,
+        pub confidence: Option<TimeIntervalConfidence>,
+        #[rasn(identifier = "nextTime")]
+        pub next_time: Option<TimeMark>,
+    }
+    impl TimeChangeDetails {
+        pub fn new(
+            start_time: Option<TimeMark>,
+            min_end_time: TimeMark,
+            max_end_time: Option<TimeMark>,
+            likely_time: Option<TimeMark>,
+            confidence: Option<TimeIntervalConfidence>,
+            next_time: Option<TimeMark>,
+        ) -> Self {
+            Self {
+                start_time,
+                min_end_time,
+                max_end_time,
+                likely_time,
+                confidence,
+                next_time,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the 95% confidence level for the currently reported value"]
+    #[doc = "* of time, taking into account the current calibration and precision of the sensor(s) used to measure and/or calculate the"]
+    #[doc = "* value. This data element is only to provide information on the limitations of the sensing system, not to support any type of"]
+    #[doc = "* automatic error correction or to imply a guaranteed maximum error. This data element should not be used for fault"]
+    #[doc = "* detection or diagnosis, but if a vehicle is able to detect a fault, the confidence interval should be increased accordingly."]
+    #[doc = "*"]
+    #[doc = "* - 0 - `unavailable`  : Not Equipped or unavailable"]
+    #[doc = "* - 1 - `time-100-000` : Better than 100 Seconds"]
+    #[doc = "* - 2 - `time-050-000` : Better than 50 Seconds"]
+    #[doc = "* - 3 - `time-020-000` : Better than 20 Seconds"]
+    #[doc = "* - 4 - `time-010-000` : Better than 10 Seconds"]
+    #[doc = "* - 5 - `time-002-000` : Better than 2 Seconds"]
+    #[doc = "* - 6 - `time-001-000` : Better than 1 Second"]
+    #[doc = "* - 7 - `time-000-500` : Better than 0.5 Seconds"]
+    #[doc = "* - 8 - `time-000-200` : Better than 0.2 Seconds"]
+    #[doc = "* - 9 - `time-000-100` : Better than 0.1 Seconds"]
+    #[doc = "* - 10 - `time-000-050` : Better than 0.05 Seconds"]
+    #[doc = "* - 11 - `time-000-020` : Better than 0.02 Seconds"]
+    #[doc = "* - 12 - `time-000-010` : Better than 0.01 Seconds"]
+    #[doc = "* - 13 - `time-000-005` : Better than 0.005 Seconds"]
+    #[doc = "* - 14 - `time-000-002` : Better than 0.001 Seconds"]
+    #[doc = "* - 15 - `time-000-001` : Better than 0.001 Seconds"]
+    #[doc = "* - 16 - `time-000-000-5` : Better than 0.000,5 Seconds"]
+    #[doc = "* - 17 - `time-000-000-2` : Better than 0.000,2 Seconds"]
+    #[doc = "* - 18 - `time-000-000-1` : Better than 0.000,1 Seconds"]
+    #[doc = "* - 19 - `time-000-000-05` : Better than 0.000,05 Seconds"]
+    #[doc = "* - 20 - `time-000-000-02` : Better than 0.000,02 Seconds"]
+    #[doc = "* - 21 - `time-000-000-01` : Better than 0.000,01 Seconds"]
+    #[doc = "* - 22 - `time-000-000-005` : Better than 0.000,005 Seconds"]
+    #[doc = "* - 23 - `time-000-000-002` : Better than 0.000,002 Seconds"]
+    #[doc = "* - 24 - `time-000-000-001` : Better than 0.000,001 Seconds"]
+    #[doc = "* - 25 - `time-000-000-000-5` : Better than 0.000,000,5 Seconds"]
+    #[doc = "* - 26 - `time-000-000-000-2` : Better than 0.000,000,2 Seconds"]
+    #[doc = "* - 27 - `time-000-000-000-1` : Better than 0.000,000,1 Seconds"]
+    #[doc = "* - 28 - `time-000-000-000-05` : Better than 0.000,000,05 Seconds"]
+    #[doc = "* - 29 - `time-000-000-000-02` : Better than 0.000,000,02 Seconds"]
+    #[doc = "* - 30 - `time-000-000-000-01` : Better than 0.000,000,01 Seconds"]
+    #[doc = "* - 31 - `time-000-000-000-005` : Better than 0.000,000,005 Seconds"]
+    #[doc = "* - 32 - `time-000-000-000-002` : Better than 0.000,000,002 Seconds"]
+    #[doc = "* - 33 - `time-000-000-000-001` : Better than 0.000,000,001 Seconds"]
+    #[doc = "* - 34 - `time-000-000-000-000-5` : Better than 0.000,000,000,5 Seconds"]
+    #[doc = "* - 35 - `time-000-000-000-000-2` : Better than 0.000,000,000,2 Seconds"]
+    #[doc = "* - 36 - `time-000-000-000-000-1` : Better than 0.000,000,000,1 Seconds"]
+    #[doc = "* - 37 - `time-000-000-000-000-05` : Better than 0.000,000,000,05 Seconds"]
+    #[doc = "* - 38 - `time-000-000-000-000-02` : Better than 0.000,000,000,02 Seconds"]
+    #[doc = "* - 39 - `time-000-000-000-000-01` : Better than 0.000,000,000,01 Seconds"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TimeConfidence {
+        unavailable = 0,
+        #[rasn(identifier = "time-100-000")]
+        time_100_000 = 1,
+        #[rasn(identifier = "time-050-000")]
+        time_050_000 = 2,
+        #[rasn(identifier = "time-020-000")]
+        time_020_000 = 3,
+        #[rasn(identifier = "time-010-000")]
+        time_010_000 = 4,
+        #[rasn(identifier = "time-002-000")]
+        time_002_000 = 5,
+        #[rasn(identifier = "time-001-000")]
+        time_001_000 = 6,
+        #[rasn(identifier = "time-000-500")]
+        time_000_500 = 7,
+        #[rasn(identifier = "time-000-200")]
+        time_000_200 = 8,
+        #[rasn(identifier = "time-000-100")]
+        time_000_100 = 9,
+        #[rasn(identifier = "time-000-050")]
+        time_000_050 = 10,
+        #[rasn(identifier = "time-000-020")]
+        time_000_020 = 11,
+        #[rasn(identifier = "time-000-010")]
+        time_000_010 = 12,
+        #[rasn(identifier = "time-000-005")]
+        time_000_005 = 13,
+        #[rasn(identifier = "time-000-002")]
+        time_000_002 = 14,
+        #[rasn(identifier = "time-000-001")]
+        time_000_001 = 15,
+        #[rasn(identifier = "time-000-000-5")]
+        time_000_000_5 = 16,
+        #[rasn(identifier = "time-000-000-2")]
+        time_000_000_2 = 17,
+        #[rasn(identifier = "time-000-000-1")]
+        time_000_000_1 = 18,
+        #[rasn(identifier = "time-000-000-05")]
+        time_000_000_05 = 19,
+        #[rasn(identifier = "time-000-000-02")]
+        time_000_000_02 = 20,
+        #[rasn(identifier = "time-000-000-01")]
+        time_000_000_01 = 21,
+        #[rasn(identifier = "time-000-000-005")]
+        time_000_000_005 = 22,
+        #[rasn(identifier = "time-000-000-002")]
+        time_000_000_002 = 23,
+        #[rasn(identifier = "time-000-000-001")]
+        time_000_000_001 = 24,
+        #[rasn(identifier = "time-000-000-000-5")]
+        time_000_000_000_5 = 25,
+        #[rasn(identifier = "time-000-000-000-2")]
+        time_000_000_000_2 = 26,
+        #[rasn(identifier = "time-000-000-000-1")]
+        time_000_000_000_1 = 27,
+        #[rasn(identifier = "time-000-000-000-05")]
+        time_000_000_000_05 = 28,
+        #[rasn(identifier = "time-000-000-000-02")]
+        time_000_000_000_02 = 29,
+        #[rasn(identifier = "time-000-000-000-01")]
+        time_000_000_000_01 = 30,
+        #[rasn(identifier = "time-000-000-000-005")]
+        time_000_000_000_005 = 31,
+        #[rasn(identifier = "time-000-000-000-002")]
+        time_000_000_000_002 = 32,
+        #[rasn(identifier = "time-000-000-000-001")]
+        time_000_000_000_001 = 33,
+        #[rasn(identifier = "time-000-000-000-000-5")]
+        time_000_000_000_000_5 = 34,
+        #[rasn(identifier = "time-000-000-000-000-2")]
+        time_000_000_000_000_2 = 35,
+        #[rasn(identifier = "time-000-000-000-000-1")]
+        time_000_000_000_000_1 = 36,
+        #[rasn(identifier = "time-000-000-000-000-05")]
+        time_000_000_000_000_05 = 37,
+        #[rasn(identifier = "time-000-000-000-000-02")]
+        time_000_000_000_000_02 = 38,
+        #[rasn(identifier = "time-000-000-000-000-01")]
+        time_000_000_000_000_01 = 39,
+    }
+    #[doc = "*"]
+    #[doc = "* This is the statistical confidence for the predicted time of signal group state change. For evaluation, the formula"]
+    #[doc = "* 10^(x/a)-b with a=82.5 and b=1.3 was used. The values are encoded as probability classes with proposed values listed in"]
+    #[doc = "* the below table in the ASN.1 specification."]
+    #[doc = "*"]
+    #[doc = "* Value: Probability"]
+    #[doc = "* - 0 - 21%"]
+    #[doc = "* - 1 - 36%"]
+    #[doc = "* - 2 - 47%"]
+    #[doc = "* - 3 - 56%"]
+    #[doc = "* - 4 - 62%"]
+    #[doc = "* - 5 - 68%"]
+    #[doc = "* - 6 - 73%"]
+    #[doc = "* - 7 - 77%"]
+    #[doc = "* - 8 - 81%"]
+    #[doc = "* - 9 - 85%"]
+    #[doc = "* - 10 - 88%"]
+    #[doc = "* - 11 - 91%"]
+    #[doc = "* - 12 - 94%"]
+    #[doc = "* - 13 - 96%"]
+    #[doc = "* - 14 - 98%"]
+    #[doc = "* - 15 - 100%"]
+    #[doc = "*"]
+    #[doc = "* @unit: percent"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=15"))]
+    pub struct TimeIntervalConfidence(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to relate a moment in UTC (Coordinated Universal Time)-based time when a"]
+    #[doc = "* signal phase is predicted to change, with a precision of 1/10 of a second. A range of 60 full minutes is supported and it"]
+    #[doc = "* can be presumed that the receiver shares a common sense of time with the sender which is kept aligned to within a"]
+    #[doc = "* fraction of a second or better."]
+    #[doc = "*"]
+    #[doc = "* If there is a need to send a value greater than the range allowed by the data element (over one hour in the future), the"]
+    #[doc = "* value 36000 shall be sent and shall be interpreted to indicate an indefinite future time value. When the value to be used is"]
+    #[doc = "* undefined or unknown a value of 36001 shall be sent. Note that leap seconds are also supported."]
+    #[doc = "*"]
+    #[doc = "* The value is tenths of a second in the current or next hour in units of 1/10th second from UTC time"]
+    #[doc = "* - A range of 0-36000 covers one hour"]
+    #[doc = "* - The values 35991..35999 are used when a leap second occurs"]
+    #[doc = "* - The value 36000 is used to indicate time >3600 seconds"]
+    #[doc = "* - 36001 is to be used when value undefined or unknown"]
+    #[doc = "*"]
+    #[doc = "* @note: Note that this is NOT expressed in GPS time or in local time"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=36001"))]
+    pub struct TimeMark(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 tour information."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct TourNumber(pub u32);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 train length."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=7"))]
+    pub struct TrainLength(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 direction information."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct TransitDirection(pub u8);
+    #[doc = "*"]
+    #[doc = "*  This DE is used to relate basic level of current ridership."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TransitVehicleOccupancy {
+        occupancyUnknown = 0,
+        occupancyEmpty = 1,
+        occupancyVeryLow = 2,
+        occupancyLow = 3,
+        occupancyMed = 4,
+        occupancyHigh = 5,
+        occupancyNearlyFull = 6,
+        occupancyFull = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to relate basic information about the transit run in progress. This is"]
+    #[doc = "* typically used in a priority request to a signalized system and becomes part of the input processing for how that system"]
+    #[doc = "* will respond to the request."]
+    #[doc = "*"]
+    #[doc = "* - 0 - `loading`:     parking and unable to move at this time"]
+    #[doc = "* - 1 - `anADAuse`:    an ADA access is in progress (wheelchairs, kneeling, etc.)"]
+    #[doc = "* - 2 - `aBikeLoad`:   loading of a bicycle is in progress"]
+    #[doc = "* - 3 - `doorOpen`:    a vehicle door is open for passenger access"]
+    #[doc = "* - 4 - `charging`:    a vehicle is connected to charging point"]
+    #[doc = "* - 5 - `atStopLine`:  a vehicle is at the stop line for the lane it is in"]
+    #[doc = "*"]
+    #[doc = "* @note: Most of these values are used to detect that the transit vehicle in not in a state where movement can occur"]
+    #[doc = "* (and that therefore any priority signal should be ignored until the vehicle is again ready to depart)."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct TransitVehicleStatus(pub FixedBitString<8usize>);
+    #[doc = "*"]
+    #[doc = "* This DF expresses the speed of the vehicle and the state of the transmission."]
+    #[doc = "* The transmission state of **reverse** can be used as a sign value for the speed element when needed."]
+    #[doc = "*"]
+    #[doc = "* @field transmisson: state of the transmission"]
+    #[doc = "* @field speed: speed of the vehicle"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct TransmissionAndSpeed {
+        pub transmisson: TransmissionState,
+        pub speed: Velocity,
+    }
+    impl TransmissionAndSpeed {
+        pub fn new(transmisson: TransmissionState, speed: Velocity) -> Self {
+            Self { transmisson, speed }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the current state of the vehicle transmission."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum TransmissionState {
+        neutral = 0,
+        park = 1,
+        forwardGears = 2,
+        reverseGears = 3,
+        reserved1 = 4,
+        reserved2 = 5,
+        reserved3 = 6,
+        unavailable = 7,
+    }
+    #[doc = "*"]
+    #[doc = "* The height of the vehicle, measured from the ground to the highest surface, excluding any antenna(s), and"]
+    #[doc = "* expressed in units of 5 cm. In cases of vehicles with adjustable ride heights, camper shells, and other devices which may"]
+    #[doc = "* cause the overall height to vary, the largest possible height will be used."]
+    #[doc = "*"]
+    #[doc = "* Value is the height of the vehicle, LSB units of 5 cm, range to 6.35 meters"]
+    #[doc = "*"]
+    #[doc = "* @unit: 5cm"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=127"))]
+    pub struct VehicleHeight(pub u8);
+    #[doc = "*"]
+    #[doc = "* This DF is used to contain either a (US) TemporaryID or an (EU) StationID in a simple frame."]
+    #[doc = "* These two different value domains are used to uniquely identify a vehicle or other object in these two regional DSRC"]
+    #[doc = "* value is unavailable but needed by another type of user (such as the roadside infrastructure sending data about an"]
+    #[doc = "* environments. In normal use cases, this value changes over time to prevent tracking of the subject vehicle. When this"]
+    #[doc = "* unequipped vehicle), the value zero shall be used. A typical restriction on the use of this value during a dialog or other"]
+    #[doc = "* exchange is that the value remains constant for the duration of that exchange. Refer to the performance requirements for"]
+    #[doc = "* a given application for details."]
+    #[doc = "*"]
+    #[doc = "* @field entityID: representation for US stations"]
+    #[doc = "* @field stationID: representation for EU stations"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum VehicleID {
+        entityID(TemporaryID),
+        stationID(StationID),
+    }
+    #[doc = "*"]
+    #[doc = "* This DE is a type list (i.e., a classification list) of the vehicle in terms of overall size. The"]
+    #[doc = "* data element entries follow the definitions defined in the US DOT Highway Performance Monitoring System (HPMS)."]
+    #[doc = "* Many infrastructure roadway operators collect and classify data according to this list for regulatory reporting needs."]
+    #[doc = "* Within the ITS industry and within the DSRC message set standards work, there are many similar lists of types for"]
+    #[doc = "* overlapping needs and uses."]
+    #[doc = "*"]
+    #[doc = "* - 0 - `none`:       Not Equipped, Not known or unavailable"]
+    #[doc = "* - 1 - `unknown`:    Does not fit any other category"]
+    #[doc = "* - 2 - `special`:    Special use"]
+    #[doc = "* - 3 - `moto`:       Motorcycle"]
+    #[doc = "* - 4 - `car`:        Passenger car"]
+    #[doc = "* - 5 - `carOther`:   Four tire single units"]
+    #[doc = "* - 6 - `bus`:        Buses"]
+    #[doc = "* - 7 - `axleCnt2`:   Two axle, six tire single units"]
+    #[doc = "* - 8 - `axleCnt3`:   Three axle, single units"]
+    #[doc = "* - 9 - `axleCnt4`:   Four or more axle, single unit"]
+    #[doc = "* - 10 - `axleCnt4Trailer`:        Four or less axle, single trailer"]
+    #[doc = "* - 11 - `axleCnt5Trailer`:        Five or less axle, single trailer"]
+    #[doc = "* - 12 - `axleCnt6Trailer`:        Six or more axle, single trailer"]
+    #[doc = "* - 13 - `axleCnt5MultiTrailer`:   Five or less axle, multi-trailer"]
+    #[doc = "* - 14 - `axleCnt6MultiTrailer`:   Six axle, multi-trailer"]
+    #[doc = "* - 15 - `axleCnt7MultiTrailer`:   Seven or more axle, multi-trailer"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum VehicleType {
+        none = 0,
+        unknown = 1,
+        special = 2,
+        moto = 3,
+        car = 4,
+        carOther = 5,
+        bus = 6,
+        axleCnt2 = 7,
+        axleCnt3 = 8,
+        axleCnt4 = 9,
+        axleCnt4Trailer = 10,
+        axleCnt5Trailer = 11,
+        axleCnt6Trailer = 12,
+        axleCnt5MultiTrailer = 13,
+        axleCnt6MultiTrailer = 14,
+        axleCnt7MultiTrailer = 15,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE represents the velocity of an object, typically a vehicle speed or the recommended speed of"]
+    #[doc = "* travel along a roadway, expressed in unsigned units of 0.02 meters per second. When used with motor vehicles it may be"]
+    #[doc = "* combined with the transmission state to form a data frame for use. A value of 8191 shall be used when the speed is"]
+    #[doc = "* unavailable. Note that Velocity as used here is intended to be a scalar value and not a vector."]
+    #[doc = "*"]
+    #[doc = "* The value 8191 indicates that velocity is unavailable"]
+    #[doc = "*"]
+    #[doc = "* @unit: 0.02 m/s"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=8191"))]
+    pub struct Velocity(pub u16);
+    #[doc = "*"]
+    #[doc = "* This DE is used to provide the R09 version information."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V2.2.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=4294967295"))]
+    pub struct VersionId(pub u32);
+    #[doc = "*"]
+    #[doc = "* This DE is used to indicate to the vehicle that it must stop at the stop line and not move past."]
+    #[doc = "*"]
+    #[doc = "* If \"true\", the vehicles on this specific connecting maneuver have to stop on the stop-line and not to enter the collision area"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(delegate)]
+    pub struct WaitOnStopline(pub bool);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=10000"))]
+    pub struct ZoneLength(pub u16);
+    pub const ADD_GRP_A: RegionId = RegionId(1);
+    pub const ADD_GRP_B: RegionId = RegionId(2);
+    pub const ADD_GRP_C: RegionId = RegionId(3);
+    pub const DIESEL: FuelType = FuelType(3);
+    pub const ELECTRIC: FuelType = FuelType(4);
+    pub const ETHANOL: FuelType = FuelType(2);
+    pub const GASOLINE: FuelType = FuelType(1);
+    pub const HYBRID: FuelType = FuelType(5);
+    pub const HYDROGEN: FuelType = FuelType(6);
+    pub const NAT_GAS_COMP: FuelType = FuelType(8);
+    pub const NAT_GAS_LIQUID: FuelType = FuelType(7);
+    pub const NO_REGION: RegionId = RegionId(0);
+    pub const PROPANE: FuelType = FuelType(9);
+    pub const UNKNOWN_FUEL: FuelType = FuelType(0);
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod etsi_its_dsrc_add_grp_c {
+    extern crate alloc;
+    use super::etsi_its_cdd::{Altitude, DeltaAltitude, StationID, VehicleMass};
+    use super::etsi_its_dsrc::{
+        DeltaTime, FuelType, IntersectionID, LaneConnectionID, LaneID, NodeOffsetPointXY,
+        NodeSetXY, PrioritizationResponseStatus, SignalGroupID, VehicleHeight,
+    };
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* This DE defines an enumerated list of battery states."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum BatteryStatus {
+        unknown = 0,
+        critical = 1,
+        low = 2,
+        good = 3,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF adds positioning support from the infrastructure to the vehicle."]
+    #[doc = "*"]
+    #[doc = "* @field itsStationPositions: defines a list of ITS stations (e.g. vehicles) and their corresponding position on"]
+    #[doc = "*                             the driving lane as defined in the lane topology of the MapData message or the GNSS position"]
+    #[doc = "*                             deviation of the ITS Station from the high precision reference position in X/Y coordinates. It"]
+    #[doc = "*                             enables accurate, real-time positioning support to the moving ITS entities by the infrastructure.*"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "ConnectionManeuverAssist-addGrpC")]
+    #[non_exhaustive]
+    pub struct ConnectionManeuverAssistAddGrpC {
+        #[rasn(identifier = "itsStationPosition")]
+        pub its_station_position: Option<ItsStationPositionList>,
+    }
+    impl ConnectionManeuverAssistAddGrpC {
+        pub fn new(its_station_position: Option<ItsStationPositionList>) -> Self {
+            Self {
+                its_station_position,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines the trajectory for travelling through the conflict area of an intersection and connects "]
+    #[doc = "* e.g an ingress with an egress lane. The trajectory is defined by two or more nodes. "]
+    #[doc = "* The starting node overlaps e.g. with the node of the ingress lane towards the"]
+    #[doc = "* conflict zone. The ending node overlaps e.g. with the first node of the connected egress lane. "]
+    #[doc = "* See the example in clause [ISO TS 19091] G.8.2.5."]
+    #[doc = "*"]
+    #[doc = "* @field nodes: defines a list of nodes for the trajectory. It defines e.g. a geometric trajectory from an ingressing"]
+    #[doc = "*               to a connected egressing lane and the X/Y position value of the first node of the trajectory is the same as"]
+    #[doc = "*               the node of the ingress lane. The X/Y position of the last node is the same as the X/Y position of the first"]
+    #[doc = "*               node of the egressing lane."]
+    #[doc = "* @field connectionID: defines the identifier of an allowed `maneuver` (e.g. ingress / egress relation). "]
+    #[doc = "*               A generic Lane offers one or more allowed `maneuvers`, therefore the trajectory is reference to the related `maneuver`."]
+    #[doc = "*"]
+    #[doc = "* @note: @ref Reg-GenericLane allows providing up to 4 connecting trajectories. In case a lane has more than 4 connecting trajectories,"]
+    #[doc = "* priority should be given to connecting trajectories of motorized traffic and complex manoeuvres."]
+    #[doc = "*"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "ConnectionTrajectory-addGrpC")]
+    #[non_exhaustive]
+    pub struct ConnectionTrajectoryAddGrpC {
+        pub nodes: NodeSetXY,
+        #[rasn(identifier = "connectionID")]
+        pub connection_id: LaneConnectionID,
+    }
+    impl ConnectionTrajectoryAddGrpC {
+        pub fn new(nodes: NodeSetXY, connection_id: LaneConnectionID) -> Self {
+            Self {
+                nodes,
+                connection_id,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE defines an enumerated list of toxic emission types for vehicles."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum EmissionType {
+        euro1 = 0,
+        euro2 = 1,
+        euro3 = 2,
+        euro4 = 3,
+        euro5 = 4,
+        euro6 = 5,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE defines a list of reasons for sudden changes in"]
+    #[doc = "* eventState parameters, thereby offering a reason for extended waiting times."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum ExceptionalCondition {
+        unknown = 0,
+        publicTransportPriority = 1,
+        emergencyVehiclePriority = 2,
+        trainPriority = 3,
+        bridgeOpen = 4,
+        vehicleHeight = 5,
+        weather = 6,
+        trafficJam = 7,
+        tunnelClosure = 8,
+        meteringActive = 9,
+        truckPriority = 10,
+        bicyclePlatoonPriority = 11,
+        vehiclePlatoonPriority = 12,
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines a list of prioritization responses e.g. public transport acceleration."]
+    #[doc = "* The signal prioritization (e.g. public transport) procedure in this profile follows two strategies."]
+    #[doc = "* - For simple prioritization requests, the CAM/SPAT messages are used. "]
+    #[doc = "*   This allows the migration of old legal systems towards C-ITS."]
+    #[doc = "*   In this case, the CAM message is used to trigger the request towards the traffic light controller. "]
+    #[doc = "*   The traffic light controller checks the request and broadcasts the status for the priority request with this DF (see [ISO TS 19091] G.5.1.9)."]
+    #[doc = "* - For more complex signal requests, the SignalRequestMessage/SignalStatusMessage messages are to be used."]
+    #[doc = "*"]
+    #[doc = "* @field activePrioritizations: list of Prioritizations."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "IntersectionState-addGrpC")]
+    #[non_exhaustive]
+    pub struct IntersectionStateAddGrpC {
+        #[rasn(identifier = "activePrioritizations")]
+        pub active_prioritizations: Option<PrioritizationResponseList>,
+    }
+    impl IntersectionStateAddGrpC {
+        pub fn new(active_prioritizations: Option<PrioritizationResponseList>) -> Self {
+            Self {
+                active_prioritizations,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide real-time positioning information feedback to a specific ITS station "]
+    #[doc = "* (e.g. vehicle, pedestrian, bicycle) by infrastructure equipment."]
+    #[doc = "*  The position information includes, for example, the driving, crossing lane and/or the X/Y coordinates in relation to"]
+    #[doc = "* the reference position of the MapData. The `timeReference` indicates the time stamp of the the"]
+    #[doc = "* message (received from an ITS station) for which the positioning feedback has been computed."]
+    #[doc = "* "]
+    #[doc = "* @field stationID: unique identifier."]
+    #[doc = "* @field laneID: LaneID."]
+    #[doc = "* @field nodeXY: NodeOffsetPointXY."]
+    #[doc = "* @field timeReference: TimeReference."]
+    #[doc = "*"]
+    #[doc = "* @note: The computation of the positioning feedback is out of focus of this standard."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ItsStationPosition {
+        #[rasn(identifier = "stationID")]
+        pub station_id: StationID,
+        #[rasn(identifier = "laneID")]
+        pub lane_id: Option<LaneID>,
+        #[rasn(identifier = "nodeXY")]
+        pub node_xy: Option<NodeOffsetPointXY>,
+        #[rasn(identifier = "timeReference")]
+        pub time_reference: Option<TimeReference>,
+    }
+    impl ItsStationPosition {
+        pub fn new(
+            station_id: StationID,
+            lane_id: Option<LaneID>,
+            node_xy: Option<NodeOffsetPointXY>,
+            time_reference: Option<TimeReference>,
+        ) -> Self {
+            Self {
+                station_id,
+                lane_id,
+                node_xy,
+                time_reference,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=5"))]
+    pub struct ItsStationPositionList(pub SequenceOf<ItsStationPosition>);
+    #[doc = "*"]
+    #[doc = "* Lanes may have limitations regarding vehicle height (e.g. due to a tunnel) and vehicle weight (e.g. due to a bridge). "]
+    #[doc = "*"]
+    #[doc = "* @field maxVehicleHeight: maximum allowed vehicle height"]
+    #[doc = "* @field maxVehicleWeight: maximum allowed vehicle mass"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "LaneAttributes-addGrpC")]
+    #[non_exhaustive]
+    pub struct LaneAttributesAddGrpC {
+        #[rasn(identifier = "maxVehicleHeight")]
+        pub max_vehicle_height: Option<VehicleHeight>,
+        #[rasn(identifier = "maxVehicleWeight")]
+        pub max_vehicle_weight: Option<VehicleMass>,
+    }
+    impl LaneAttributesAddGrpC {
+        pub fn new(
+            max_vehicle_height: Option<VehicleHeight>,
+            max_vehicle_weight: Option<VehicleMass>,
+        ) -> Self {
+            Self {
+                max_vehicle_height,
+                max_vehicle_weight,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines a list of three-dimensional positions of signal heads in an intersection. "]
+    #[doc = "* It enables vehicles to identify the signal head location for optical evaluation of the traffic light. "]
+    #[doc = "* Combined with the SPAT/MapData messages, it enables e.g. driving vehicles to enhance safety decision in critical situations."]
+    #[doc = "*"]
+    #[doc = "* @field signalHeadLocations: list of geo positions"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "MapData-addGrpC")]
+    #[non_exhaustive]
+    pub struct MapDataAddGrpC {
+        #[rasn(identifier = "signalHeadLocations")]
+        pub signal_head_locations: Option<SignalHeadLocationList>,
+    }
+    impl MapDataAddGrpC {
+        pub fn new(signal_head_locations: Option<SignalHeadLocationList>) -> Self {
+            Self {
+                signal_head_locations,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* Priority and preemption have a considerable impact to the timing parameters in the SPAT message (eventState)."]
+    #[doc = "* User acceptance is expected to increase if the reason for sudden changes in timing parameters is communicated to them."]
+    #[doc = "*"]
+    #[doc = "* @field stateChangeReason: reason code"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "MovementEvent-addGrpC")]
+    #[non_exhaustive]
+    pub struct MovementEventAddGrpC {
+        #[rasn(identifier = "stateChangeReason")]
+        pub state_change_reason: Option<ExceptionalCondition>,
+    }
+    impl MovementEventAddGrpC {
+        pub fn new(state_change_reason: Option<ExceptionalCondition>) -> Self {
+            Self {
+                state_change_reason,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to to identify a node of a lane (waypoint) by its `lane` and node identifier `id`. "]
+    #[doc = "*"]
+    #[doc = "* The `intersectionID` is used if the referenced lane belongs to an adjacent intersection. If the node"]
+    #[doc = "* belongs to a connection trajectory ([ISO TS 19091] G.5.1.2) the `connectionID` is used."]
+    #[doc = "*"]
+    #[doc = "* @field id: unique identifier."]
+    #[doc = "* @field lane: identifier from lane."]
+    #[doc = "* @field connectionID: identifier from connection."]
+    #[doc = "* @field intersectionID: identifier from intersection."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Node {
+        pub id: Integer,
+        pub lane: Option<LaneID>,
+        #[rasn(identifier = "connectionID")]
+        pub connection_id: Option<LaneConnectionID>,
+        #[rasn(identifier = "intersectionID")]
+        pub intersection_id: Option<IntersectionID>,
+    }
+    impl Node {
+        pub fn new(
+            id: Integer,
+            lane: Option<LaneID>,
+            connection_id: Option<LaneConnectionID>,
+            intersection_id: Option<IntersectionID>,
+        ) -> Self {
+            Self {
+                id,
+                lane,
+                connection_id,
+                intersection_id,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines additional attributes to support public transport and to enable a simple way of defining lane links."]
+    #[doc = "*"]
+    #[doc = "* @field ptvRequest: defines control types attached to a node on a lane used by public transport for triggering"]
+    #[doc = "*                    the transmission of messages (e.g. prioritization request). It includes control points for public transport prioritization. "]
+    #[doc = "*                    These control points are currently implemented by legacy systems using hardware sensors mounted on the roadside."]
+    #[doc = "* @field nodeLink:   defines a link to one or to a set of another node/lane from this node. The nodeLink allows to set a link between specific nodes "]
+    #[doc = "*                    of generic lanes or trajectories. This supports e.g. lane merging/diverging situations ([ISO TS 19091] G.8.2.7) and the linking of trajectories "]
+    #[doc = "*                    in the conflict zone to lanes (see example [ISO TS 19091] G.8.2.5)."]
+    #[doc = "* @field node:       defines an identifier of this node."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "NodeAttributeSet-addGrpC")]
+    #[non_exhaustive]
+    pub struct NodeAttributeSetAddGrpC {
+        #[rasn(identifier = "ptvRequest")]
+        pub ptv_request: Option<PtvRequestType>,
+        #[rasn(identifier = "nodeLink")]
+        pub node_link: Option<NodeLink>,
+        pub node: Option<Node>,
+    }
+    impl NodeAttributeSetAddGrpC {
+        pub fn new(
+            ptv_request: Option<PtvRequestType>,
+            node_link: Option<NodeLink>,
+            node: Option<Node>,
+        ) -> Self {
+            Self {
+                ptv_request,
+                node_link,
+                node,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=5"))]
+    pub struct NodeLink(pub SequenceOf<Node>);
+    #[doc = "*"]
+    #[doc = "* This DF includes the altitude data element defined in the common data dictionary [ETSI CDD]."]
+    #[doc = "*"]
+    #[doc = "* @field elevation: the data element is replaced by the ETSI `altitude` data element using the regional extension. "]
+    #[doc = "*                   The `altitude` data element is defined in Position3D-addGrpC of this profile."]
+    #[doc = "*                   Position3D-addGrpC extends the @ref Position3D using the regional extension framework."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "Position3D-addGrpC")]
+    #[non_exhaustive]
+    pub struct Position3DAddGrpC {
+        pub altitude: Altitude,
+    }
+    impl Position3DAddGrpC {
+        pub fn new(altitude: Altitude) -> Self {
+            Self { altitude }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF is used to provide the prioritization status response and the"]
+    #[doc = "* signal group identifier for a specific ITS station (e.g. vehicle)."]
+    #[doc = "*"]
+    #[doc = "* @field stationID: StationID."]
+    #[doc = "* @field priorState: PrioritizationResponseStatus."]
+    #[doc = "* @field signalGroup: SignalGroupID."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PrioritizationResponse {
+        #[rasn(identifier = "stationID")]
+        pub station_id: StationID,
+        #[rasn(identifier = "priorState")]
+        pub prior_state: PrioritizationResponseStatus,
+        #[rasn(identifier = "signalGroup")]
+        pub signal_group: SignalGroupID,
+    }
+    impl PrioritizationResponse {
+        pub fn new(
+            station_id: StationID,
+            prior_state: PrioritizationResponseStatus,
+            signal_group: SignalGroupID,
+        ) -> Self {
+            Self {
+                station_id,
+                prior_state,
+                signal_group,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=10"))]
+    pub struct PrioritizationResponseList(pub SequenceOf<PrioritizationResponse>);
+    #[doc = "*"]
+    #[doc = "* This DE defines a list of activation requests used for C-ITS migration of legacy public "]
+    #[doc = "* transport prioritization systems. "]
+    #[doc = "* The activation points are used while approaching to an intersection."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum PtvRequestType {
+        preRequest = 0,
+        mainRequest = 1,
+        doorCloseRequest = 2,
+        cancelRequest = 3,
+        emergencyRequest = 4,
+    }
+    #[doc = "*"]
+    #[doc = "* This DE defines a list of reasons for rejected priority requests."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum RejectedReason {
+        unknown = 0,
+        exceptionalCondition = 1,
+        maxWaitingTimeExceeded = 2,
+        ptPriorityDisabled = 3,
+        higherPTPriorityGranted = 4,
+        vehicleTrackingUnknown = 5,
+    }
+    #[doc = "*"]
+    #[doc = "* Some road authorities like to give priority to vehicles based on the type of fuel they use. In addition,"]
+    #[doc = "* electric vehicles may receive priority based on their battery status."]
+    #[doc = "*"]
+    #[doc = "* @field fuel: fuel used by vehicle."]
+    #[doc = "* @field batteryStatus: current batter status of vehicle."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "RequestorDescription-addGrpC")]
+    #[non_exhaustive]
+    pub struct RequestorDescriptionAddGrpC {
+        pub fuel: Option<FuelType>,
+        #[rasn(identifier = "batteryStatus")]
+        pub battery_status: Option<BatteryStatus>,
+    }
+    impl RequestorDescriptionAddGrpC {
+        pub fn new(fuel: Option<FuelType>, battery_status: Option<BatteryStatus>) -> Self {
+            Self {
+                fuel,
+                battery_status,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines the driving restriction based on toxic emission type. "]
+    #[doc = "* The meaning of the word `restriction` is ambiguous as it may have a double interpretation, being:"]
+    #[doc = "*  - only these vehicles are allowed OR "]
+    #[doc = "*  - these vehicles are not allowed and all others are. "]
+    #[doc = "* The former is what is intended by the base standard."]
+    #[doc = "*"]
+    #[doc = "* @field emission: restriction baesed on emission."]
+    #[doc = "* @field fuel: restriction baesed on fuel."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "RestrictionUserType-addGrpC")]
+    #[non_exhaustive]
+    pub struct RestrictionUserTypeAddGrpC {
+        pub emission: Option<EmissionType>,
+        pub fuel: Option<FuelType>,
+    }
+    impl RestrictionUserTypeAddGrpC {
+        pub fn new(emission: Option<EmissionType>, fuel: Option<FuelType>) -> Self {
+            Self { emission, fuel }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DF defines the XYZ position of a signal head within an intersection"]
+    #[doc = "* and indicates the related signal group identifier."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct SignalHeadLocation {
+        #[rasn(identifier = "nodeXY")]
+        pub node_xy: NodeOffsetPointXY,
+        #[rasn(identifier = "nodeZ")]
+        pub node_z: DeltaAltitude,
+        #[rasn(identifier = "signalGroupID")]
+        pub signal_group_id: SignalGroupID,
+    }
+    impl SignalHeadLocation {
+        pub fn new(
+            node_xy: NodeOffsetPointXY,
+            node_z: DeltaAltitude,
+            signal_group_id: SignalGroupID,
+        ) -> Self {
+            Self {
+                node_xy,
+                node_z,
+                signal_group_id,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct SignalHeadLocationList(pub SequenceOf<SignalHeadLocation>);
+    #[doc = "*"]
+    #[doc = "* The traffic control centre (TCC) may advice a public transport vehicle (e.g. bus) to synchronize his travel time. "]
+    #[doc = "* This may happen when, for example, two busses, due to special traffic conditions, are out of schedule. "]
+    #[doc = "* The first might be too late, the second too fast. The consequence is that the second is driving"]
+    #[doc = "* just behind the first and is empty as all passengers are within the first one. To avoid this often-occurring"]
+    #[doc = "* situation, the TCC transmits time synchronization advices to the public transport vehicles using the"]
+    #[doc = "* signal status message. "]
+    #[doc = "*"]
+    #[doc = "* @field synchToSchedule: DeltaTime."]
+    #[doc = "* @field rejectedReason: RejectedReason."]
+    #[doc = "*"]
+    #[doc = "* @Note: The @ref PrioritizationResponseStatus provides optionally the reason for prioritization response rejection."]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SignalStatusPackage-addGrpC")]
+    #[non_exhaustive]
+    pub struct SignalStatusPackageAddGrpC {
+        #[rasn(identifier = "synchToSchedule")]
+        pub synch_to_schedule: Option<DeltaTime>,
+        #[rasn(identifier = "rejectedReason")]
+        pub rejected_reason: Option<RejectedReason>,
+    }
+    impl SignalStatusPackageAddGrpC {
+        pub fn new(
+            synch_to_schedule: Option<DeltaTime>,
+            rejected_reason: Option<RejectedReason>,
+        ) -> Self {
+            Self {
+                synch_to_schedule,
+                rejected_reason,
+            }
+        }
+    }
+    #[doc = "*"]
+    #[doc = "* This DE defines a value in milliseconds in the current minute related to UTC time. "]
+    #[doc = "* The range of 60 000 covers one minute (60 seconds * 1 000 milliseconds)"]
+    #[doc = "*"]
+    #[doc = "* @category: Infrastructure information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=60000"))]
+    pub struct TimeReference(pub u16);
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod etsi_its_dsrc_region {
+    extern crate alloc;
+    use super::etsi_its_dsrc::*;
+    use super::etsi_its_dsrc_add_grp_c::{
+        ConnectionManeuverAssistAddGrpC, ConnectionTrajectoryAddGrpC, IntersectionStateAddGrpC,
+        LaneAttributesAddGrpC, MapDataAddGrpC, MovementEventAddGrpC, NodeAttributeSetAddGrpC,
+        Position3DAddGrpC, RequestorDescriptionAddGrpC, RestrictionUserTypeAddGrpC,
+        SignalStatusPackageAddGrpC,
+    };
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegAdvisorySpeed_Type {}
+    impl RegAdvisorySpeed_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegAdvisorySpeed_id {}
+    impl RegAdvisorySpeed_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegComputedLane_Type {}
+    impl RegComputedLane_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegComputedLane_id {}
+    impl RegComputedLane_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegConnectionManeuverAssist_Type {
+        AddGrpC(ConnectionManeuverAssistAddGrpC),
+    }
+    impl RegConnectionManeuverAssist_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegGenericLane_Type {
+        AddGrpC(ConnectionTrajectoryAddGrpC),
+    }
+    impl RegGenericLane_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegIntersectionGeometry_Type {}
+    impl RegIntersectionGeometry_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegIntersectionGeometry_id {}
+    impl RegIntersectionGeometry_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegIntersectionState_Type {
+        AddGrpC(IntersectionStateAddGrpC),
+    }
+    impl RegIntersectionState_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegLaneAttributes_Type {
+        AddGrpC(LaneAttributesAddGrpC),
+    }
+    impl RegLaneAttributes_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegLaneDataAttribute_Type {}
+    impl RegLaneDataAttribute_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegLaneDataAttribute_id {}
+    impl RegLaneDataAttribute_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegMapData_Type {
+        AddGrpC(MapDataAddGrpC),
+    }
+    impl RegMapData_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegMovementEvent_Type {
+        AddGrpC(MovementEventAddGrpC),
+    }
+    impl RegMovementEvent_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegMovementState_Type {}
+    impl RegMovementState_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegMovementState_id {}
+    impl RegMovementState_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegNodeAttributeSetXY_Type {
+        AddGrpC(NodeAttributeSetAddGrpC),
+    }
+    impl RegNodeAttributeSetXY_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegNodeOffsetPointXY_Type {}
+    impl RegNodeOffsetPointXY_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegNodeOffsetPointXY_id {}
+    impl RegNodeOffsetPointXY_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegPosition3D_Type {
+        AddGrpC(Position3DAddGrpC),
+    }
+    impl RegPosition3D_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRTCMcorrections_Type {}
+    impl RegRTCMcorrections_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRTCMcorrections_id {}
+    impl RegRTCMcorrections_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRequestorDescription_Type {
+        AddGrpC(RequestorDescriptionAddGrpC),
+    }
+    impl RegRequestorDescription_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRequestorType_Type {}
+    impl RegRequestorType_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRequestorType_id {}
+    impl RegRequestorType_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRestrictionUserType_Type {
+        AddGrpC(RestrictionUserTypeAddGrpC),
+    }
+    impl RegRestrictionUserType_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRoadSegment_Type {}
+    impl RegRoadSegment_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegRoadSegment_id {}
+    impl RegRoadSegment_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSPAT_Type {}
+    impl RegSPAT_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSPAT_id {}
+    impl RegSPAT_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalControlZone_Type {}
+    impl RegSignalControlZone_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalControlZone_id {}
+    impl RegSignalControlZone_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequest_Type {}
+    impl RegSignalRequest_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequest_id {}
+    impl RegSignalRequest_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequestMessage_Type {}
+    impl RegSignalRequestMessage_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequestMessage_id {}
+    impl RegSignalRequestMessage_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequestPackage_Type {}
+    impl RegSignalRequestPackage_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalRequestPackage_id {}
+    impl RegSignalRequestPackage_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalStatus_Type {}
+    impl RegSignalStatus_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalStatus_id {}
+    impl RegSignalStatus_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalStatusMessage_Type {}
+    impl RegSignalStatusMessage_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalStatusMessage_id {}
+    impl RegSignalStatusMessage_id {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum RegSignalStatusPackage_Type {
+        AddGrpC(SignalStatusPackageAddGrpC),
+    }
+    impl RegSignalStatusPackage_Type {
+        pub fn decode<D: Decoder>(
+            decoder: &mut D,
+            open_type_payload: Option<&Any>,
+            identifier: &RegionId,
+        ) -> Result<Self, D::Error> {
+            match identifier {
+                i if i == &ADD_GRP_C => Ok(decoder
+                    .codec()
+                    .decode_from_binary(
+                        open_type_payload
+                            .ok_or_else(|| {
+                                rasn::error::DecodeError::from_kind(
+                                    rasn::error::DecodeErrorKind::Custom {
+                                        msg: "Failed to decode open type! No input data given."
+                                            .into(),
+                                    },
+                                    decoder.codec(),
+                                )
+                                .into()
+                            })?
+                            .as_bytes(),
+                    )
+                    .map(Self::AddGrpC)?),
+                _ => Err(rasn::error::DecodeError::from_kind(
+                    rasn::error::DecodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    decoder.codec(),
+                )
+                .into()),
+            }
+        }
+        pub fn encode<E: Encoder>(
+            &self,
+            encoder: &mut E,
+            identifier: &RegionId,
+        ) -> Result<(), E::Error> {
+            match (self, identifier) {
+                (Self::AddGrpC(inner), i) if i == &ADD_GRP_C => inner.encode(encoder),
+                _ => Err(rasn::error::EncodeError::from_kind(
+                    rasn::error::EncodeErrorKind::Custom {
+                        msg: alloc::format!(
+                            "Unknown unique identifier for information object class instance."
+                        ),
+                    },
+                    encoder.codec(),
+                )
+                .into()),
+            }
+        }
+    }
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod mapem_pdu_descriptions {
+    extern crate alloc;
+    use super::etsi_its_cdd::ItsPduHeader;
+    use super::etsi_its_dsrc::MapData;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* Map (lane topology) extended Message"]
+    #[doc = "* This DF includes DEs for the MAPEM: protocolVersion, the MAPEM message type identifier `messageID`, "]
+    #[doc = "* the station identifier `stationID` of the originating ITS-S and the Map data from ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @field header:  The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. "]
+    #[doc = "*                 It shall be set to 2."]
+    #[doc = "*                 The DE `messageID` shall be mapem(5)."]
+    #[doc = "* @field map:     contains the MAP data as defined in ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MAPEM {
+        pub header: ItsPduHeader,
+        pub map: MapData,
+    }
+    impl MAPEM {
+        pub fn new(header: ItsPduHeader, map: MapData) -> Self {
+            Self { header, map }
+        }
+    }
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod rtcmem_pdu_descriptions {
+    extern crate alloc;
+    use super::etsi_its_cdd::ItsPduHeader;
+    use super::etsi_its_dsrc::RTCMcorrections;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* RTCM corrections extended extended Message"]
+    #[doc = "* This DF includes DEs for the RTCMEM: protocolVersion, the RTCMEM message type identifier `messageID`,"]
+    #[doc = "* the station identifier `stationID` of the originating ITS-S and the RTCM corrections as of ETSI-ITS-DSRC."]
+    #[doc = "*"]
+    #[doc = "* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. "]
+    #[doc = "*                It shall be set to 1."]
+    #[doc = "*                The DE `messageID` shall be rtcmem(13)."]
+    #[doc = "* @field rtcmc:  contains the RTCM corrections data as defined in ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct RTCMEM {
+        pub header: ItsPduHeader,
+        pub rtcmc: RTCMcorrections,
+    }
+    impl RTCMEM {
+        pub fn new(header: ItsPduHeader, rtcmc: RTCMcorrections) -> Self {
+            Self { header, rtcmc }
+        }
+    }
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod spatem_pdu_descriptions {
+    extern crate alloc;
+    use super::etsi_its_cdd::ItsPduHeader;
+    use super::etsi_its_dsrc::*;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* Signal phase and timing extended Message"]
+    #[doc = "*"]
+    #[doc = "* Signal phase and timing extended Message Root"]
+    #[doc = "* This DF includes DEs for the SPATEM: protocolVersion, the SPATEM message type identifier `messageID`,"]
+    #[doc = "* the station identifier `stationID` of the originating ITS-S and the SPaT data from ETSI-ITS-DSRC module."]
+    #[doc = "*"]
+    #[doc = "* @field header:  The DE `protocolVersion` used to select the appropriate protocol decoder at the receiving ITS-S. "]
+    #[doc = "*                 It shall be set to 2."]
+    #[doc = "*                 The DE `messageID` shall be spatem(4)."]
+    #[doc = "* @field spat:    contains the SPaT data as defined in ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SPATEM {
+        pub header: ItsPduHeader,
+        pub spat: SPAT,
+    }
+    impl SPATEM {
+        pub fn new(header: ItsPduHeader, spat: SPAT) -> Self {
+            Self { header, spat }
+        }
+    }
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod srem_pdu_descriptions {
+    extern crate alloc;
+    use super::etsi_its_cdd::ItsPduHeader;
+    use super::etsi_its_dsrc::SignalRequestMessage;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* Signal request extended Message Message"]
+    #[doc = "* This DF includes DEs for the SREM: protocolVersion, the SREM message type identifier `messageID`,"]
+    #[doc = "* the station identifier `stationID` of the originating ITS-S and the signal request data from ETSI-ITS-DSRC."]
+    #[doc = "*"]
+    #[doc = "* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. "]
+    #[doc = "*                It shall be set to 2."]
+    #[doc = "*                The DE `messageID` shall be srem(9)."]
+    #[doc = "* @field srm:    contains the Signal request data as defined in ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SREM {
+        pub header: ItsPduHeader,
+        pub srm: SignalRequestMessage,
+    }
+    impl SREM {
+        pub fn new(header: ItsPduHeader, srm: SignalRequestMessage) -> Self {
+            Self { header, srm }
+        }
+    }
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod ssem_pdu_descriptions {
+    extern crate alloc;
+    use super::etsi_its_cdd::ItsPduHeader;
+    use super::etsi_its_dsrc::SignalStatusMessage;
+    use core::borrow::Borrow;
+    use lazy_static::lazy_static;
+    use rasn::prelude::*;
+    #[doc = "*"]
+    #[doc = "* Signal status extended Message"]
+    #[doc = "* "]
+    #[doc = "* This DF includes DEs for the SSEM: protocolVersion, the SSEM message type identifier `messageID` and"]
+    #[doc = "* the station identifier `stationID` of the originating ITS-S and the signal status data from ETSI-ITS-DSRC."]
+    #[doc = "*"]
+    #[doc = "* @field header: The DE `protocolVersion` is used to select the appropriate protocol decoder at the receiving ITS-S. "]
+    #[doc = "*                It shall be set to 2."]
+    #[doc = "*                The DE `messageID` shall be ssem(10)."]
+    #[doc = "* @field ssm:    contains the Signal status data as defined in ETSI-ITS-DSRC."]
+    #[doc = "* "]
+    #[doc = "* @category: Basic Information"]
+    #[doc = "* @revision: V1.3.1"]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct SSEM {
+        pub header: ItsPduHeader,
+        pub ssm: SignalStatusMessage,
+    }
+    impl SSEM {
+        pub fn new(header: ItsPduHeader, ssm: SignalStatusMessage) -> Self {
+            Self { header, ssm }
+        }
+    }
+}

--- a/standards/its/src/ts103301/ts103301.rs
+++ b/standards/its/src/ts103301/ts103301.rs
@@ -9,13 +9,15 @@ pub mod etsi_its_dsrc {
     extern crate alloc;
     use super::etsi_its_cdd::{Iso3833VehicleType, Latitude, Longitude, StationID};
     use super::etsi_its_dsrc_region::{
-        RegAdvisorySpeed, RegComputedLane, RegConnectionManeuverAssist, RegGenericLane,
-        RegIntersectionGeometry, RegIntersectionState, RegLaneAttributes, RegLaneDataAttribute,
-        RegMapData, RegMovementEvent, RegMovementState, RegNodeAttributeSetXY,
-        RegNodeOffsetPointXY, RegPosition3D, RegRTCMcorrections, RegRequestorDescription,
-        RegRequestorType, RegRestrictionUserType, RegRoadSegment, RegSPAT, RegSignalControlZone,
-        RegSignalRequest, RegSignalRequestMessage, RegSignalRequestPackage, RegSignalStatus,
-        RegSignalStatusMessage, RegSignalStatusPackage,
+        RegAdvisorySpeed_Type, RegComputedLane_Type, RegConnectionManeuverAssist_Type,
+        RegGenericLane_Type, RegIntersectionGeometry_Type, RegIntersectionState_Type,
+        RegLaneAttributes_Type, RegLaneDataAttribute_Type, RegMapData_Type, RegMovementEvent_Type,
+        RegMovementState_Type, RegNodeAttributeSetXY_Type, RegNodeOffsetPointXY_Type,
+        RegPosition3D_Type, RegRTCMcorrections_Type, RegRequestorDescription_Type,
+        RegRequestorType_Type, RegRestrictionUserType_Type, RegRoadSegment_Type, RegSPAT_Type,
+        RegSignalControlZone_Type, RegSignalRequestMessage_Type, RegSignalRequestPackage_Type,
+        RegSignalRequest_Type, RegSignalStatusMessage_Type, RegSignalStatusPackage_Type,
+        RegSignalStatus_Type,
     };
     use core::borrow::Borrow;
     use lazy_static::lazy_static;
@@ -24,13 +26,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousAdvisorySpeedRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousAdvisorySpeedRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -65,7 +67,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -102,7 +103,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct AdvisorySpeedList(pub SequenceOf<AdvisorySpeed>);
@@ -112,7 +112,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -139,7 +138,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*    found in the collection of ConnectsTo entries."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct AllowedManeuvers(pub FixedBitString<12usize>);
@@ -154,7 +152,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.0125 degrees"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=28800"))]
     pub struct Angle(pub u16);
@@ -170,7 +167,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct AntennaOffsetSet {
@@ -205,7 +201,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: zero to be used when valid value is unknown"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=15"))]
     pub struct ApproachID(pub u8);
@@ -252,7 +247,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*    sent within SAE-defined PSIDs) rests with the regional deployment."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -302,13 +296,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousComputedLaneRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousComputedLaneRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -352,7 +346,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -407,7 +400,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct ConnectingLane {
@@ -438,7 +430,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct Connection {
@@ -474,13 +465,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousConnectionManeuverAssistRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousConnectionManeuverAssistRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -539,7 +530,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -587,7 +577,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*   connects shall be listed."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct ConnectsToList(pub SequenceOf<Connection>);
@@ -598,7 +587,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: Note that some elements of this structure may not be sent when not needed. At least one element shall be present."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct DDateTime {
@@ -637,7 +625,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: days"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=31"))]
     pub struct DDay(pub u8);
@@ -648,7 +635,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: hours"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=31"))]
     pub struct DHour(pub u8);
@@ -659,7 +645,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: minutes"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=60"))]
     pub struct DMinute(pub u8);
@@ -670,7 +655,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: months"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=12"))]
     pub struct DMonth(pub u8);
@@ -682,7 +666,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: minutes from UTC time"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-840..=840"))]
     pub struct DOffset(pub i16);
@@ -694,7 +677,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: milliseconds"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct DSecond(pub u16);
@@ -705,7 +687,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: years"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=4095"))]
     pub struct DYear(pub u16);
@@ -714,7 +695,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -752,7 +732,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: degree"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-150..=150"))]
     pub struct DeltaAngle(pub i16);
@@ -771,7 +750,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-122..=121"))]
     pub struct DeltaTime(pub i8);
@@ -783,7 +761,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=63"))]
     pub struct DescriptiveName(pub Ia5String);
@@ -795,7 +772,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: cm"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-32767..=32767"))]
     pub struct DrivenLineOffsetLg(pub i16);
@@ -807,7 +783,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: cm"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-2047..=2047"))]
     pub struct DrivenLineOffsetSm(pub i16);
@@ -824,7 +799,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        projected downward, regardless of vehicle tilt, to the point where the vehicle meets the road surface."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-4096..=61439"))]
     pub struct Elevation(pub i32);
@@ -856,7 +830,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: Encoded as a 4 bit value"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum ElevationConfidence {
@@ -907,7 +880,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct EnabledLaneList(pub SequenceOf<LaneID>);
@@ -916,7 +888,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=15"))]
     pub struct FuelType(pub u8);
@@ -938,7 +909,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1005,7 +975,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct GNSSstatus(pub FixedBitString<8usize>);
@@ -1013,13 +982,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousGenericLaneRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousGenericLaneRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -1083,7 +1052,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*       topology, may be e.g. the same for all lanes within an approach of an intersection."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1151,7 +1119,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum HeadingConfidenceDSRC {
@@ -1184,7 +1151,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.0125 degrees"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=28800"))]
     pub struct HeadingDSRC(pub u16);
@@ -1205,7 +1171,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*    or approach with the same results."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -1218,13 +1183,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousIntersectionGeometryRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousIntersectionGeometryRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -1271,7 +1236,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1321,7 +1285,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct IntersectionGeometryList(pub SequenceOf<IntersectionGeometry>);
@@ -1336,7 +1299,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct IntersectionID(pub u16);
@@ -1353,7 +1315,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        RoadRegulatorID). Taken together these form a unique value which is never repeated."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct IntersectionReferenceID {
@@ -1369,13 +1330,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousIntersectionStateRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousIntersectionStateRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -1423,7 +1384,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1474,7 +1434,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct IntersectionStateList(pub SequenceOf<IntersectionState>);
@@ -1500,7 +1459,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: All zeros indicate normal operating mode with no recent changes. The duration of the term **recent** is defined by the system performance requirement in use."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct IntersectionStatusObject(pub FixedBitString<16usize>);
@@ -1508,13 +1466,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct LaneAttributesRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl LaneAttributesRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -1559,7 +1517,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct LaneAttributes {
@@ -1596,7 +1553,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Barrier")]
     pub struct LaneAttributesBarrier(pub FixedBitString<16usize>);
@@ -1618,7 +1574,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Bike")]
     pub struct LaneAttributesBike(pub FixedBitString<16usize>);
@@ -1643,7 +1598,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Crosswalk")]
     pub struct LaneAttributesCrosswalk(pub FixedBitString<16usize>);
@@ -1660,7 +1614,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Parking")]
     pub struct LaneAttributesParking(pub FixedBitString<16usize>);
@@ -1677,7 +1630,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Sidewalk")]
     pub struct LaneAttributesSidewalk(pub FixedBitString<16usize>);
@@ -1696,7 +1648,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Striping")]
     pub struct LaneAttributesStriping(pub FixedBitString<16usize>);
@@ -1714,7 +1665,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-TrackedVehicle")]
     pub struct LaneAttributesTrackedVehicle(pub FixedBitString<16usize>);
@@ -1730,7 +1680,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "LaneAttributes-Vehicle", size("8", extensible))]
     pub struct LaneAttributesVehicle(pub BitString);
@@ -1746,7 +1695,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        between two lanes. It is not the same as the laneID, which is the unique index to each lane itself."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct LaneConnectionID(pub u8);
@@ -1754,13 +1702,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousLaneDataAttributeRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousLaneDataAttributeRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -1803,7 +1751,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*     positional translation factors to be used (offset, rotate, scale) and any further segment attribute changes."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -1821,7 +1768,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8"))]
     pub struct LaneDataAttributeList(pub SequenceOf<LaneDataAttribute>);
@@ -1844,7 +1790,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        asserting any bit value Bi-Directional Travel (such as a ped crosswalk) is indicated by asserting both of the bits."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct LaneDirection(pub FixedBitString<2usize>);
@@ -1860,7 +1805,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct LaneID(pub u8);
@@ -1869,7 +1813,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=255"))]
     pub struct LaneList(pub SequenceOf<GenericLane>);
@@ -1897,7 +1840,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: All zeros would indicate **not shared** and **not overlapping**"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct LaneSharing(pub FixedBitString<10usize>);
@@ -1925,7 +1867,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -1945,7 +1886,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @units: cm"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=32767"))]
     pub struct LaneWidth(pub u16);
@@ -1968,7 +1908,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=100"))]
     pub struct LayerID(pub u8);
@@ -1979,7 +1918,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -1998,7 +1936,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=4294967295"))]
     pub struct LineNumber(pub u32);
@@ -2007,7 +1944,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct ManeuverAssistList(pub SequenceOf<ConnectionManeuverAssist>);
@@ -2015,13 +1951,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousMapDataRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousMapDataRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -2069,7 +2005,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Road topology information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2125,7 +2060,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 1.5 degrees from north"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-180..=180"))]
     pub struct MergeDivergeNodeAngle(pub i16);
@@ -2143,7 +2077,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        accommodated, as are leap seconds in the DSecond data concept."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=527040"))]
     pub struct MinuteOfTheYear(pub u32);
@@ -2151,13 +2084,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousMovementEventRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousMovementEventRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -2187,7 +2120,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2218,7 +2150,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct MovementEventList(pub SequenceOf<MovementEvent>);
@@ -2227,7 +2158,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=255"))]
     pub struct MovementList(pub SequenceOf<MovementState>);
@@ -2291,7 +2221,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum MovementPhaseState {
@@ -2318,13 +2247,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousMovementStateRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousMovementStateRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -2379,7 +2308,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*      conditions, the unused phase states are simply skipped."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2450,7 +2378,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=127"))]
     pub struct MsgCount(pub u8);
@@ -2459,7 +2386,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-LLmD-64b")]
     pub struct NodeLLmD64b {
@@ -2476,7 +2402,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-20b")]
     pub struct NodeXY20b {
@@ -2493,7 +2418,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-22b")]
     pub struct NodeXY22b {
@@ -2510,7 +2434,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-24b")]
     pub struct NodeXY24b {
@@ -2527,7 +2450,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-26b")]
     pub struct NodeXY26b {
@@ -2544,7 +2466,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-28b")]
     pub struct NodeXY28b {
@@ -2561,7 +2482,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Node-XY-32b")]
     pub struct NodeXY32b {
@@ -2577,13 +2497,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousNodeAttributeSetXYRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousNodeAttributeSetXYRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -2623,7 +2543,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2684,7 +2603,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: See usage examples in [ISO TS 19091] G.8.2.8"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -2707,7 +2625,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8"))]
     pub struct NodeAttributeXYList(pub SequenceOf<NodeAttributeXY>);
@@ -2730,7 +2647,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -2742,13 +2658,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct NodeOffsetPointXYRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl NodeOffsetPointXYRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -2790,7 +2706,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     pub enum NodeOffsetPointXY {
@@ -2815,7 +2730,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("2..=63"))]
     pub struct NodeSetXY(pub SequenceOf<NodeXY>);
@@ -2837,7 +2751,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2863,7 +2776,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -2910,7 +2822,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B09", value("-256..=255"))]
     pub struct OffsetB09(pub i16);
@@ -2922,7 +2833,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B10", value("-512..=511"))]
     pub struct OffsetB10(pub i16);
@@ -2934,7 +2844,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B11", value("-1024..=1023"))]
     pub struct OffsetB11(pub i16);
@@ -2946,7 +2855,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B12", value("-2048..=2047"))]
     pub struct OffsetB12(pub i16);
@@ -2958,7 +2866,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B13", value("-4096..=4095"))]
     pub struct OffsetB13(pub i16);
@@ -2969,7 +2876,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B14", value("-8192..=8191"))]
     pub struct OffsetB14(pub i16);
@@ -2981,7 +2887,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Offset-B16", value("-32768..=32767"))]
     pub struct OffsetB16(pub i16);
@@ -2994,7 +2899,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=5"))]
     pub struct OverlayLaneList(pub SequenceOf<LaneID>);
@@ -3004,7 +2908,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(delegate)]
     pub struct PedestrianBicycleDetect(pub bool);
@@ -3012,13 +2915,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousPosition3DRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousPosition3DRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -3050,7 +2953,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3103,7 +3005,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct PositionConfidenceSet {
@@ -3121,7 +3022,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct PositionalAccuracy {
@@ -3149,7 +3049,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct PreemptPriorityList(pub SequenceOf<SignalControlZone>);
@@ -3169,7 +3068,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -3188,7 +3086,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct PriorityLevel(pub u8);
@@ -3198,7 +3095,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -3227,7 +3123,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated, identifier = "RTCM-Revision")]
     #[non_exhaustive]
@@ -3241,13 +3136,13 @@ pub mod etsi_its_dsrc {
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SEQUENCE")]
     pub struct AnonymousRTCMcorrectionsRegional {
-        #[rasn(value("0..=255"), identifier = "regionId")]
-        pub region_id: u8,
+        #[rasn(identifier = "regionId")]
+        pub region_id: RegionId,
         #[rasn(identifier = "regExtValue")]
         pub reg_ext_value: Any,
     }
     impl AnonymousRTCMcorrectionsRegional {
-        pub fn new(region_id: u8, reg_ext_value: Any) -> Self {
+        pub fn new(region_id: RegionId, reg_ext_value: Any) -> Self {
             Self {
                 region_id,
                 reg_ext_value,
@@ -3283,7 +3178,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3328,7 +3222,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RTCMheader {
@@ -3349,7 +3242,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=1023"))]
     pub struct RTCMmessage(pub OctetString);
@@ -3358,7 +3250,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=5"))]
     pub struct RTCMmessageList(pub SequenceOf<RTCMmessage>);
@@ -3378,7 +3269,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        The values 128 and above are for local region use"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct RegionId(pub u8);
@@ -3390,7 +3280,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RegulatorySpeedLimit {
@@ -3408,7 +3297,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct ReportingPoint(pub u16);
@@ -3425,7 +3313,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        when this data element is used. Further details of these operational concepts can be found in the relevant standards."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct RequestID(pub u8);
@@ -3444,7 +3331,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum RequestImportanceLevel {
@@ -3481,7 +3367,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum RequestSubRole {
@@ -3557,7 +3442,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        unique ID used in the orginal request) are used."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3612,7 +3496,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3683,7 +3566,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3737,7 +3619,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -3769,7 +3650,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RestrictionClassAssignment {
@@ -3794,7 +3674,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct RestrictionClassID(pub u8);
@@ -3810,7 +3689,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        and stable for regional deployment areas such as a metropolitan area based on their operational practices and needs."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=254"))]
     pub struct RestrictionClassList(pub SequenceOf<RestrictionClassAssignment>);
@@ -3854,7 +3732,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     #[non_exhaustive]
@@ -3867,7 +3744,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=16"))]
     pub struct RestrictionUserTypeList(pub SequenceOf<RestrictionUserType>);
@@ -3876,7 +3752,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=255"))]
     pub struct RoadLaneSetList(pub SequenceOf<GenericLane>);
@@ -3890,7 +3765,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct RoadRegulatorID(pub u16);
@@ -3939,7 +3813,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -3992,7 +3865,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct RoadSegmentID(pub u16);
@@ -4001,7 +3873,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct RoadSegmentList(pub SequenceOf<RoadSegment>);
@@ -4015,7 +3886,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RoadSegmentReferenceID {
@@ -4039,7 +3909,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.3 degrees of angle over a range of -38.1 to + 38.1 degrees"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("-128..=127"))]
     pub struct RoadwayCrownAngle(pub i8);
@@ -4048,7 +3917,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=4294967295"))]
     pub struct RouteNumber(pub u32);
@@ -4100,7 +3968,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4136,7 +4003,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: in steps of 0.05 percent"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, identifier = "Scale-B12", value("-2048..=2047"))]
     pub struct ScaleB12(pub i16);
@@ -4192,7 +4058,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -4241,7 +4106,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=8"))]
     pub struct SegmentAttributeXYList(pub SequenceOf<SegmentAttributeXY>);
@@ -4258,7 +4122,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.05m"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct SemiMajorAxisAccuracy(pub u8);
@@ -4277,7 +4140,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 360/65535 degree"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=65535"))]
     pub struct SemiMajorAxisOrientation(pub u16);
@@ -4294,7 +4156,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.05m"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct SemiMinorAxisAccuracy(pub u8);
@@ -4331,7 +4192,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4361,7 +4221,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct SignalGroupID(pub u8);
@@ -4410,7 +4269,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        path through the intersection to the degree it is known."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4450,7 +4308,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct SignalRequestList(pub SequenceOf<SignalRequestPackage>);
@@ -4508,7 +4365,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4592,7 +4448,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4633,7 +4488,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4705,7 +4559,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4737,7 +4590,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct SignalStatusList(pub SequenceOf<SignalStatus>);
@@ -4788,7 +4640,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4867,7 +4718,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -4911,7 +4761,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=32"))]
     pub struct SignalStatusPackageList(pub SequenceOf<SignalStatusPackage>);
@@ -4926,7 +4775,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.1 m/s"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=500"))]
     pub struct SpeedAdvice(pub u16);
@@ -4949,7 +4797,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum SpeedConfidenceDSRC {
@@ -4970,7 +4817,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, size("1..=9"))]
     pub struct SpeedLimitList(pub SequenceOf<RegulatorySpeedLimit>);
@@ -4986,7 +4832,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -5014,7 +4859,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct SpeedandHeadingandThrottleConfidence {
@@ -5049,7 +4893,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*        periodically change to a new random value to ensure the overall anonymity of the vehicle."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct TemporaryID(pub FixedOctetString<4usize>);
@@ -5069,7 +4912,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum ThrottleConfidence {
@@ -5122,7 +4964,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*          where each of these functions is performed in the overall roadside system."]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct TimeChangeDetails {
@@ -5207,7 +5048,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum TimeConfidence {
@@ -5317,7 +5157,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: percent"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=15"))]
     pub struct TimeIntervalConfidence(pub u8);
@@ -5340,7 +5179,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @note: Note that this is NOT expressed in GPS time or in local time"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=36001"))]
     pub struct TimeMark(pub u16);
@@ -5349,7 +5187,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=4294967295"))]
     pub struct TourNumber(pub u32);
@@ -5358,7 +5195,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=7"))]
     pub struct TrainLength(pub u8);
@@ -5367,7 +5203,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=255"))]
     pub struct TransitDirection(pub u8);
@@ -5376,7 +5211,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum TransitVehicleOccupancy {
@@ -5406,7 +5240,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct TransitVehicleStatus(pub FixedBitString<8usize>);
@@ -5419,7 +5252,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct TransmissionAndSpeed {
@@ -5436,7 +5268,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     pub enum TransmissionState {
@@ -5459,7 +5290,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 5cm"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=127"))]
     pub struct VehicleHeight(pub u8);
@@ -5477,7 +5307,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(choice, automatic_tags)]
     pub enum VehicleID {
@@ -5510,7 +5339,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -5543,7 +5371,6 @@ pub mod etsi_its_dsrc {
     #[doc = "* @unit: 0.02 m/s"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=8191"))]
     pub struct Velocity(pub u16);
@@ -5552,7 +5379,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V2.2.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=4294967295"))]
     pub struct VersionId(pub u32);
@@ -5563,7 +5389,6 @@ pub mod etsi_its_dsrc {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(delegate)]
     pub struct WaitOnStopline(pub bool);
@@ -5607,7 +5432,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -5627,7 +5451,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "ConnectionManeuverAssist-addGrpC")]
     #[non_exhaustive]
@@ -5662,7 +5485,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "ConnectionTrajectory-addGrpC")]
     #[non_exhaustive]
@@ -5684,7 +5506,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -5702,7 +5523,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -5734,7 +5554,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "IntersectionState-addGrpC")]
     #[non_exhaustive]
@@ -5765,7 +5584,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -5805,7 +5623,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "LaneAttributes-addGrpC")]
     #[non_exhaustive]
@@ -5835,7 +5652,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "MapData-addGrpC")]
     #[non_exhaustive]
@@ -5858,7 +5674,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "MovementEvent-addGrpC")]
     #[non_exhaustive]
@@ -5886,7 +5701,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -5926,7 +5740,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "NodeAttributeSet-addGrpC")]
     #[non_exhaustive]
@@ -5962,7 +5775,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "Position3D-addGrpC")]
     #[non_exhaustive]
@@ -5984,7 +5796,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -6019,7 +5830,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -6035,7 +5845,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]
     #[non_exhaustive]
@@ -6056,7 +5865,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "RequestorDescription-addGrpC")]
     #[non_exhaustive]
@@ -6085,7 +5893,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "RestrictionUserType-addGrpC")]
     #[non_exhaustive]
@@ -6104,7 +5911,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -6147,7 +5953,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "SignalStatusPackage-addGrpC")]
     #[non_exhaustive]
@@ -6174,7 +5979,6 @@ pub mod etsi_its_dsrc_add_grp_c {
     #[doc = "*"]
     #[doc = "* @category: Infrastructure information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("0..=60000"))]
     pub struct TimeReference(pub u16);
@@ -6218,7 +6022,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6256,7 +6060,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6294,7 +6098,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6332,7 +6136,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6389,7 +6193,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6447,7 +6251,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6486,7 +6290,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6524,7 +6328,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6581,7 +6385,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6639,7 +6443,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6678,7 +6482,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6716,7 +6520,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6773,7 +6577,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6831,7 +6635,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6870,7 +6674,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6908,7 +6712,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -6965,7 +6769,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7004,7 +6808,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7042,7 +6846,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7099,7 +6903,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7138,7 +6942,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7176,7 +6980,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7233,7 +7037,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7272,7 +7076,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7310,7 +7114,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7367,7 +7171,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7406,7 +7210,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7444,7 +7248,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7482,7 +7286,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7520,7 +7324,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7558,7 +7362,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7596,7 +7400,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7634,7 +7438,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7672,7 +7476,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7710,7 +7514,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7748,7 +7552,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7786,7 +7590,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7824,7 +7628,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7862,7 +7666,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7900,7 +7704,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7938,7 +7742,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -7976,7 +7780,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -8033,7 +7837,7 @@ pub mod etsi_its_dsrc_region {
                 .into()),
             }
         }
-        pub fn encode<E: Encoder>(
+        pub fn encode<'encoder, E: rasn::Encoder<'encoder>>(
             &self,
             encoder: &mut E,
             identifier: &RegionId,
@@ -8079,7 +7883,6 @@ pub mod mapem_pdu_descriptions {
     #[doc = "* "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct MAPEM {
@@ -8118,7 +7921,6 @@ pub mod rtcmem_pdu_descriptions {
     #[doc = "* "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct RTCMEM {
@@ -8159,7 +7961,6 @@ pub mod spatem_pdu_descriptions {
     #[doc = "* "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct SPATEM {
@@ -8198,7 +7999,6 @@ pub mod srem_pdu_descriptions {
     #[doc = "* "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct SREM {
@@ -8238,7 +8038,6 @@ pub mod ssem_pdu_descriptions {
     #[doc = "* "]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct SSEM {


### PR DESCRIPTION
This PR adds the ITS standard [ETSI TS 103 301](https://forge.etsi.org/rep/ITS/asn1/cdd_ts102894_2). 

Note: This currently does not compile.

## Compile errors

1. **Incorrect module imports**

The generated `etsi_its_dsrc` module imports types from `etsi_its_dsrc_region` incorrectly.

Relevant code:

- Import section: https://github.com/schphil/rasn/blob/ts103301/standards/its/src/ts103301/ts103301.rs#L10-L18
- Region type definitions: https://github.com/schphil/rasn/blob/ts103301/standards/its/src/ts103301/ts103301.rs#L6189-L8054

2. **Missing lifetime specifier in `encode`**

The generated encode function lacks the required lifetime bounds for rasn::Encoder, which causes compilation failures with the current encoder trait definition.

Current generator implementation:
https://github.com/librasn/compiler/blob/main/rasn-compiler/src/generator/rasn/builder.rs#L1052-L1062

Proposed fix:
```rust
pub fn encode<E: for<'a> rasn::Encoder<'a>>(&self, encoder: &mut E, identifier: & #class_unique_id_type_name) -> Result<(), <E as rasn::Encoder<'_>>::Error> {
    match (self, identifier) {
        #(#en_match_arms)*
        _ => Err(rasn::error::EncodeError::from_kind(
            rasn::error::EncodeErrorKind::Custom {
                msg: alloc::format!("Unknown unique identifier for information object class instance."),
            },
            encoder.codec()
        ).into())
    }
}
```

3. **Inconsistent `RegionId` type generation**

In some generated regional extension structs, the correct alias `RegionId` is used, while in others the type is flattened to the primitive u8. This leads to compile errors because `decode`expects `RegionId` type. 

Example:
https://github.com/schphil/rasn/blob/ts103301/standards/its/src/ts103301/ts103301.rs#L301-L325

## Build output
[build_output.txt](https://github.com/user-attachments/files/26005969/build_output.txt)
