### PR TITLE
feat: support named_values for INTEGER NamedNumberList in derive macros and AVN codec

### DIFF
--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -41,9 +41,10 @@ impl Constraints {
             return None;
         }
         // Emit: named_values("pukAppl1" = 1, "pukAppl2" = 2, ...)
-        let pairs = self.named_values.iter().map(|(val, name)| {
-            quote!(#name = #val)
-        });
+        let pairs = self
+            .named_values
+            .iter()
+            .map(|(val, name)| quote!(#name = #val));
         Some(quote!(named_values(#(#pairs),*)))
     }
 
@@ -72,9 +73,10 @@ impl Constraints {
         if self.named_values.is_empty() {
             return None;
         }
-        let pairs = self.named_values.iter().map(|(val, name)| {
-            quote!((#val as i128, #name))
-        });
+        let pairs = self
+            .named_values
+            .iter()
+            .map(|(val, name)| quote!((#val as i128, #name)));
         Some(quote!(.with_named_values(&[#(#pairs),*])))
     }
 
@@ -1620,9 +1622,7 @@ fn skip_comma(content: &syn::parse::ParseBuffer) {
 
 /// Parse `named_values("name1" = integer1, "name2" = integer2, ...)` from a
 /// `#[rasn(named_values(...))]` attribute and return the list of `(i128, String)` pairs.
-fn parse_named_values_meta(
-    item: &syn::meta::ParseNestedMeta,
-) -> syn::Result<Vec<(i128, String)>> {
+fn parse_named_values_meta(item: &syn::meta::ParseNestedMeta) -> syn::Result<Vec<(i128, String)>> {
     let mut pairs = Vec::new();
     let content;
     parenthesized!(content in item.input);

--- a/macros/macros_impl/src/config.rs
+++ b/macros/macros_impl/src/config.rs
@@ -11,6 +11,7 @@ pub struct Constraints {
     pub from: Option<Constraint<StringValue>>,
     pub size: Option<Constraint<Value>>,
     pub value: Option<Constraint<Value>>,
+    pub named_values: Vec<(i128, String)>,
 }
 
 impl Constraints {
@@ -26,12 +27,24 @@ impl Constraints {
             let from = self.from_attr().map(add_comma);
             let extensible = self.extensible.then_some(quote!(#[non_exhaustive]));
             let value = self.value_attr().map(add_comma);
+            let named_values = self.named_values_attr().map(add_comma);
 
             quote! {
-                #[rasn(#size #from #value)]
+                #[rasn(#size #from #value #named_values)]
                 #extensible
             }
         })
+    }
+
+    fn named_values_attr(&self) -> Option<proc_macro2::TokenStream> {
+        if self.named_values.is_empty() {
+            return None;
+        }
+        // Emit: named_values("pukAppl1" = 1, "pukAppl2" = 2, ...)
+        let pairs = self.named_values.iter().map(|(val, name)| {
+            quote!(#name = #val)
+        });
+        Some(quote!(named_values(#(#pairs),*)))
     }
 
     pub fn const_expr(&self, crate_root: &syn::Path) -> Option<proc_macro2::TokenStream> {
@@ -41,6 +54,7 @@ impl Constraints {
             let from = self.from_def(crate_root).map(add_comma);
             let extensible = self.extensible_def(crate_root).map(add_comma);
             let value = self.value_def(crate_root).map(add_comma);
+            let named_values_chain = self.named_values_def();
 
             quote! {
                 #crate_root::types::Constraints::new(&[
@@ -49,8 +63,19 @@ impl Constraints {
                     #extensible
                     #from
                 ])
+                #named_values_chain
             }
         })
+    }
+
+    fn named_values_def(&self) -> Option<proc_macro2::TokenStream> {
+        if self.named_values.is_empty() {
+            return None;
+        }
+        let pairs = self.named_values.iter().map(|(val, name)| {
+            quote!((#val as i128, #name))
+        });
+        Some(quote!(.with_named_values(&[#(#pairs),*])))
     }
 
     fn size_def(&self, crate_root: &syn::Path) -> Option<proc_macro2::TokenStream> {
@@ -221,7 +246,11 @@ impl Constraints {
     }
 
     fn has_constraints(&self) -> bool {
-        self.extensible || self.from.is_some() || self.size.is_some() || self.value.is_some()
+        self.extensible
+            || self.from.is_some()
+            || self.size.is_some()
+            || self.value.is_some()
+            || !self.named_values.is_empty()
     }
 }
 
@@ -252,6 +281,7 @@ impl Config {
         let mut value = None;
         let mut delegate = false;
         let mut extensible = false;
+        let mut named_values: Vec<(i128, String)> = Vec::new();
 
         for attr in &input.attrs {
             if attr.path().is_ident("non_exhaustive") {
@@ -288,6 +318,8 @@ impl Config {
                         size = Some(Value::from_meta(&meta)?);
                     } else if path.is_ident("value") {
                         value = Some(Value::from_meta(&meta)?);
+                    } else if path.is_ident("named_values") {
+                        named_values = parse_named_values_meta(&meta)?;
                     } else {
                         return Err(meta.error(format!(
                             "unknown input provided: {}",
@@ -369,6 +401,7 @@ impl Config {
                 from,
                 size,
                 value,
+                named_values,
             },
             crate_root: crate_root.unwrap_or_else(|| {
                 syn::LitStr::new(crate::CRATE_NAME, proc_macro2::Span::call_site())
@@ -472,6 +505,7 @@ impl<'config> VariantConfig<'config> {
         let mut size = None;
         let mut tag = None;
         let mut value = None;
+        let mut named_values: Vec<(i128, String)> = Vec::new();
 
         for attr in &variant.attrs {
             if !attr.path().is_ident(crate::CRATE_NAME) {
@@ -494,6 +528,8 @@ impl<'config> VariantConfig<'config> {
                     extensible = true;
                 } else if path.is_ident("extension_addition") {
                     extension_addition = true;
+                } else if path.is_ident("named_values") {
+                    named_values = parse_named_values_meta(&meta)?;
                 }
 
                 Ok(())
@@ -521,6 +557,7 @@ impl<'config> VariantConfig<'config> {
                 from,
                 size,
                 value,
+                named_values,
             },
             context,
         })
@@ -760,6 +797,7 @@ impl<'a> FieldConfig<'a> {
         let mut extensible = false;
         let mut extension_addition = false;
         let mut extension_addition_group = false;
+        let mut named_values: Vec<(i128, String)> = Vec::new();
         /*if !field.attrs.is_empty() {
             panic!("{:?}", field)
         }*/
@@ -800,6 +838,8 @@ impl<'a> FieldConfig<'a> {
                     extension_addition = true;
                 } else if path.is_ident("extension_addition_group") {
                     extension_addition_group = true;
+                } else if path.is_ident("named_values") {
+                    named_values = parse_named_values_meta(&meta)?;
                 } else {
                     return Err(meta.error(format!(
                         "unknown field tag {:?}",
@@ -830,6 +870,7 @@ impl<'a> FieldConfig<'a> {
                 from,
                 size,
                 value,
+                named_values,
             },
             context,
         })
@@ -1575,4 +1616,35 @@ fn skip_comma(content: &syn::parse::ParseBuffer) {
     if content.peek(Token![,]) {
         let _: Token![,] = content.parse().unwrap();
     }
+}
+
+/// Parse `named_values("name1" = integer1, "name2" = integer2, ...)` from a
+/// `#[rasn(named_values(...))]` attribute and return the list of `(i128, String)` pairs.
+fn parse_named_values_meta(
+    item: &syn::meta::ParseNestedMeta,
+) -> syn::Result<Vec<(i128, String)>> {
+    let mut pairs = Vec::new();
+    let content;
+    parenthesized!(content in item.input);
+
+    while !content.is_empty() {
+        // Expect a string literal for the name
+        let name: syn::LitStr = content.parse()?;
+        // Expect `=`
+        let _: Token![=] = content.parse()?;
+        // Expect an integer literal for the value; handle optional negative sign
+        let negative = if content.peek(Token![-]) {
+            let _: Token![-] = content.parse()?;
+            true
+        } else {
+            false
+        };
+        let int: syn::LitInt = content.parse()?;
+        let val: i128 = int.base10_parse()?;
+        let val = if negative { -val } else { val };
+        pairs.push((val, name.value()));
+        skip_comma(&content);
+    }
+
+    Ok(pairs)
 }

--- a/macros/macros_impl/src/enum.rs
+++ b/macros/macros_impl/src/enum.rs
@@ -116,6 +116,7 @@ impl Enum<'_> {
                 Some(0),
                 Some(variant_count as i128),
             ))),
+            named_values: Vec::new(),
         }
         .const_expr(crate_root);
 

--- a/src/avn.rs
+++ b/src/avn.rs
@@ -242,6 +242,45 @@ mod tests {
         );
     }
 
+    // Named-number INTEGER round-trip test
+    #[derive(Debug, Clone, PartialEq, Decode, Encode)]
+    #[rasn(delegate)]
+    #[rasn(crate_root = "crate")]
+    struct PUKKeyRef(pub u8);
+
+    impl crate::AsnType for PUKKeyRef {
+        const TAG: Tag = Tag::INTEGER;
+        const CONSTRAINTS: Constraints =
+            Constraints::new(&[crate::types::constraints::Constraint::Value(
+                crate::types::constraints::Extensible::new(crate::types::constraints::Value::new(
+                    crate::types::constraints::Bounded::Range {
+                        start: Some(0),
+                        end: Some(255),
+                    },
+                )),
+            )])
+            .with_named_values(&[
+                (1, "pukAppl1"),
+                (2, "pukAppl2"),
+                (129, "secondPUKAppl1"),
+                (130, "secondPUKAppl2"),
+            ]);
+    }
+
+    #[test]
+    fn named_integer_round_trip() {
+        // Named value should encode as identifier and decode back
+        round_trip_avn!(PUKKeyRef, PUKKeyRef(1), "pukAppl1");
+        round_trip_avn!(PUKKeyRef, PUKKeyRef(2), "pukAppl2");
+        round_trip_avn!(PUKKeyRef, PUKKeyRef(129), "secondPUKAppl1");
+    }
+
+    #[test]
+    fn named_integer_unlisted_value_uses_number() {
+        // Values not in the NamedNumberList fall back to bare numbers
+        round_trip_avn!(PUKKeyRef, PUKKeyRef(99), "99");
+    }
+
     #[test]
     fn with_identifier_annotation() {
         round_trip_avn!(

--- a/src/avn.rs
+++ b/src/avn.rs
@@ -243,29 +243,10 @@ mod tests {
     }
 
     // Named-number INTEGER round-trip test
-    #[derive(Debug, Clone, PartialEq, Decode, Encode)]
-    #[rasn(delegate)]
-    #[rasn(crate_root = "crate")]
+    #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
+    #[rasn(delegate, crate_root = "crate")]
+    #[rasn(value("0..=255"), named_values("pukAppl1" = 1, "pukAppl2" = 2, "secondPUKAppl1" = 129, "secondPUKAppl2" = 130))]
     struct PUKKeyRef(pub u8);
-
-    impl crate::AsnType for PUKKeyRef {
-        const TAG: Tag = Tag::INTEGER;
-        const CONSTRAINTS: Constraints =
-            Constraints::new(&[crate::types::constraints::Constraint::Value(
-                crate::types::constraints::Extensible::new(crate::types::constraints::Value::new(
-                    crate::types::constraints::Bounded::Range {
-                        start: Some(0),
-                        end: Some(255),
-                    },
-                )),
-            )])
-            .with_named_values(&[
-                (1, "pukAppl1"),
-                (2, "pukAppl2"),
-                (129, "secondPUKAppl1"),
-                (130, "secondPUKAppl2"),
-            ]);
-    }
 
     #[test]
     fn named_integer_round_trip() {

--- a/src/avn/de.rs
+++ b/src/avn/de.rs
@@ -419,9 +419,9 @@ impl crate::Decoder for Decoder {
     fn decode_integer<I: crate::types::IntegerType>(
         &mut self,
         _t: Tag,
-        _c: Constraints,
+        c: Constraints,
     ) -> Result<I, Self::Error> {
-        decode_avn_value!(Self::integer_from_value::<I>, self.stack)
+        decode_avn_value!(|v| Self::integer_from_value::<I>(v, c), self.stack)
     }
 
     fn decode_real<R: crate::types::RealType>(
@@ -803,9 +803,26 @@ impl Decoder {
         })
     }
 
-    fn integer_from_value<I: crate::types::IntegerType>(value: AvnValue) -> Result<I, DecodeError> {
+    fn integer_from_value<I: crate::types::IntegerType>(
+        value: AvnValue,
+        constraints: Constraints,
+    ) -> Result<I, DecodeError> {
         let s = match value {
             AvnValue::Integer(s) => s,
+            // Named value identifiers are parsed as Enumerated by the parser.
+            // Look up the identifier in the NamedNumberList to resolve the integer.
+            AvnValue::Enumerated(ref id) => {
+                if let Some(named_values) = constraints.named_values()
+                    && let Some(&(val, _)) = named_values.iter().find(|(_, n)| *n == id)
+                {
+                    return I::try_from(BigInt::from(val))
+                        .map_err(|_| DecodeError::integer_overflow(I::WIDTH, crate::Codec::Avn));
+                }
+                return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
+                    needed: "integer",
+                    found: alloc::format!("{:?}", value),
+                }));
+            }
             other => {
                 return Err(DecodeError::from(AvnDecodeErrorKind::AvnTypeMismatch {
                     needed: "integer",
@@ -1042,5 +1059,48 @@ impl Decoder {
 
     fn date_from_value(value: AvnValue) -> Result<Date, DecodeError> {
         crate::ber::de::Decoder::parse_date_string(&Self::char_string_from_value(value)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::de::Decoder as DecoderTrait;
+
+    #[test]
+    fn decode_integer_named_value() {
+        const NAMED: &[(i128, &str)] = &[(1, "pukAppl1"), (2, "pukAppl2")];
+        let c = Constraints::default().with_named_values(NAMED);
+
+        let mut dec = Decoder::new("pukAppl1").unwrap();
+        let val: i64 = dec.decode_integer(Tag::INTEGER, c).unwrap();
+        assert_eq!(val, 1);
+    }
+
+    #[test]
+    fn decode_integer_bare_number_with_named_values() {
+        const NAMED: &[(i128, &str)] = &[(1, "pukAppl1"), (2, "pukAppl2")];
+        let c = Constraints::default().with_named_values(NAMED);
+
+        let mut dec = Decoder::new("99").unwrap();
+        let val: i64 = dec.decode_integer(Tag::INTEGER, c).unwrap();
+        assert_eq!(val, 99);
+    }
+
+    #[test]
+    fn decode_integer_unknown_identifier_fails() {
+        const NAMED: &[(i128, &str)] = &[(1, "pukAppl1")];
+        let c = Constraints::default().with_named_values(NAMED);
+
+        let mut dec = Decoder::new("unknownId").unwrap();
+        let result: Result<i64, _> = dec.decode_integer(Tag::INTEGER, c);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_integer_identifier_without_named_values_fails() {
+        let mut dec = Decoder::new("pukAppl1").unwrap();
+        let result: Result<i64, _> = dec.decode_integer(Tag::INTEGER, Constraints::default());
+        assert!(result.is_err());
     }
 }

--- a/src/avn/enc.rs
+++ b/src/avn/enc.rs
@@ -132,11 +132,18 @@ impl crate::Encoder<'_> for Encoder {
     fn encode_integer<I: IntegerType>(
         &mut self,
         _t: Tag,
-        _c: Constraints,
+        c: Constraints,
         value: &I,
         _: Identifier,
     ) -> Result<Self::Ok, Self::Error> {
-        // BigInt always works — no i64 limitation unlike JER.
+        // When the INTEGER type defines a NamedNumberList, emit the symbolic
+        // identifier instead of the bare decimal (ITU-T X.680 §19.9).
+        if let Some(named_values) = c.named_values()
+            && let Some(i128_val) = num_traits::ToPrimitive::to_i128(value)
+            && let Some(&(_, name)) = named_values.iter().find(|(v, _)| *v == i128_val)
+        {
+            return self.update_root_or_constructed(AvnValue::Enumerated(name.into()));
+        }
         let s = value.to_bigint().unwrap_or_default().to_string();
         self.update_root_or_constructed(AvnValue::Integer(s))
     }
@@ -598,6 +605,28 @@ mod tests {
         )
         .unwrap();
         assert_eq!(enc.to_string(), "42");
+    }
+
+    #[test]
+    fn integer_with_named_values_encodes_name() {
+        const NAMED: &[(i128, &str)] = &[(1, "pukAppl1"), (2, "pukAppl2"), (129, "secondPUKAppl1")];
+        let c = Constraints::default().with_named_values(NAMED);
+
+        let mut enc = AvnEncoder::new();
+        enc.encode_integer(Tag::INTEGER, c, &1_i64, Identifier::EMPTY)
+            .unwrap();
+        assert_eq!(enc.to_string(), "pukAppl1");
+    }
+
+    #[test]
+    fn integer_with_named_values_falls_back_to_number() {
+        const NAMED: &[(i128, &str)] = &[(1, "pukAppl1"), (2, "pukAppl2")];
+        let c = Constraints::default().with_named_values(NAMED);
+
+        let mut enc = AvnEncoder::new();
+        enc.encode_integer(Tag::INTEGER, c, &99_i64, Identifier::EMPTY)
+            .unwrap();
+        assert_eq!(enc.to_string(), "99");
     }
 
     #[test]

--- a/src/types/constraints.rs
+++ b/src/types/constraints.rs
@@ -40,6 +40,7 @@ pub struct Constraints {
     size: Option<Extensible<Size>>,
     permitted_alphabet: Option<Extensible<PermittedAlphabet>>,
     extensible: bool,
+    named_values: Option<&'static [(i128, &'static str)]>,
 }
 
 impl Constraints {
@@ -49,6 +50,7 @@ impl Constraints {
         size: None,
         permitted_alphabet: None,
         extensible: false,
+        named_values: None,
     };
 
     /// Creates a new set of constraints from a given slice.
@@ -92,7 +94,22 @@ impl Constraints {
             size,
             permitted_alphabet,
             extensible,
+            named_values: None,
         }
+    }
+
+    /// Returns a new `Constraints` with the given named value mapping for
+    /// INTEGER types that define a `NamedNumberList` (ITU-T X.680 §19.9).
+    ///
+    /// Each entry maps a numeric value to its ASN.1 identifier name.
+    /// Text-based codecs (AVN) use this to emit/parse symbolic names.
+    #[must_use]
+    pub const fn with_named_values(
+        mut self,
+        named_values: &'static [(i128, &'static str)],
+    ) -> Self {
+        self.named_values = Some(named_values);
+        self
     }
 
     /// A const variant of the default function.
@@ -123,12 +140,18 @@ impl Constraints {
             (None, None) => None,
         };
         let extensible = self.extensible || rhs.extensible;
+        let named_values = match (self.named_values, rhs.named_values) {
+            (_, Some(rhs_nv)) => Some(rhs_nv),
+            (Some(nv), None) => Some(nv),
+            (None, None) => None,
+        };
 
         Self {
             value,
             size,
             permitted_alphabet,
             extensible,
+            named_values,
         }
     }
 
@@ -172,6 +195,13 @@ impl Constraints {
     #[must_use]
     pub const fn value(&self) -> Option<&Extensible<Value>> {
         self.value.as_ref()
+    }
+
+    /// Returns the named values mapping for INTEGER types with a
+    /// `NamedNumberList`, if available.
+    #[must_use]
+    pub const fn named_values(&self) -> Option<&'static [(i128, &'static str)]> {
+        self.named_values
     }
 }
 


### PR DESCRIPTION
  ## Summary
  - Add `named_values` support to `Constraints` so the AVN encoder outputs symbolic identifiers (e.g. `pukAppl1`) instead of bare decimals for INTEGER types
   with a NamedNumberList, per ITU-T X.680 §19.9
  - Parse `#[rasn(named_values("name" = val, ...))]` in the AsnType derive macro so the rasn-compiler can emit this attribute and have it flow through to
  runtime constraints
  - AVN decoder accepts both named identifiers and bare integer values
  - JER and DER codecs are unaffected

  ## Test plan
  - [ ] AVN encode: INTEGER value with known name emits the identifier (e.g. `1` → `pukAppl1`)
  - [ ] AVN encode: INTEGER value without a name emits bare decimal
  - [ ] AVN decode: accepts named identifier and bare integer
  - [ ] Derive macro round-trip: `#[rasn(named_values(...))]` is parsed and produces correct `Constraints`
  - [ ] JER/DER codecs unchanged