### PR TITLE
COER: Fix validation of Integer with length determinant encoding

### DIFF
--- a/src/coer.rs
+++ b/src/coer.rs
@@ -231,6 +231,7 @@ mod tests {
             (i128::from(u64::MAX) + 1).try_into().unwrap(),
             &[0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         );
+        round_trip!(coer, E, E::new(0), &[0x01, 0x00]);
         round_trip!(coer, F, F::new(2), &[0x00, 0x02]);
         // Error expected, outside of range constraints
         encode_error!(coer, A, A::new(-1));
@@ -325,6 +326,31 @@ mod tests {
     fn test_integer_single_constraint() {
         const CONSTRAINTS: Constraints = constraints!(value_constraint!(5));
         round_trip_with_constraints!(coer, Integer, CONSTRAINTS, 5.into(), &[0x05]);
+    }
+    #[test]
+    fn invalid_integer() {
+        type A = ConstrainedInteger<0, { (u64::MAX as i128) + 1 }>;
+        type B = ConstrainedInteger<{ (i64::MIN as i128) - 1 }, { (i64::MAX as i128) + 1 }>;
+
+        // Unconstrained (signed) integer, leading 0x00
+        let data: [u8; _] = [0x02, 0x00, 0x00];
+        decode_error!(coer, Integer, &data);
+
+        // Unconstrained (signed) integer, leading 0xff
+        let data: [u8; _] = [0x02, 0xff, 0xff];
+        decode_error!(coer, Integer, &data);
+
+        // Integer with unsigned constraints, leading 0x00
+        let data: [u8; _] = [0x02, 0x00, 0xff];
+        decode_error!(coer, A, &data);
+
+        // Integer with signed constraints, leading 0x00
+        let data: [u8; _] = [0x02, 0x00, 0x7f];
+        decode_error!(coer, B, &data);
+
+        // Integer with signed constraints, leading 0xff
+        let data: [u8; _] = [0x02, 0xff, 0xff];
+        decode_error!(coer, B, &data);
     }
     #[test]
     fn test_enumerated() {

--- a/src/oer/de.rs
+++ b/src/oer/de.rs
@@ -225,12 +225,21 @@ impl<'input, const RFC: usize, const EFC: usize> Decoder<'input, RFC, EFC> {
         let codec = self.codec();
         let coer = self.options.encoding_rules.is_coer();
         let data = self.extract_data_by_length(final_length)?;
-        // // Constrained data can correctly include leading zeros, unconstrained not
-        if coer && !signed && data.first() == Some(&0) && length.is_none() {
-            return Err(CoerDecodeErrorKind::NotValidCanonicalEncoding {
-                msg: "Leading zeros are not allowed on unsigned Integer value in COER.".to_string(),
+        // Constrained data can correctly include leading zeros/sign bits, unconstrained not
+        if coer && length.is_none() && data.len() >= 2 {
+            if !signed && data.first() == Some(&0) {
+                return Err(CoerDecodeErrorKind::NotValidCanonicalEncoding {
+                    msg: "Leading zeros are not allowed on unsigned Integer value in COER."
+                        .to_string(),
+                }
+                .into());
+            } else if signed && data[0] == (((data[1] & 0x80) as i8 >> 7) as u8) {
+                return Err(CoerDecodeErrorKind::NotValidCanonicalEncoding {
+                    msg: "Leading sign bits are not allowed on signed Integer value in COER."
+                        .to_string(),
+                }
+                .into());
             }
-            .into());
         }
         if signed {
             Ok(I::try_from_signed_bytes(data, codec)?)

--- a/src/types/constraints.rs
+++ b/src/types/constraints.rs
@@ -571,14 +571,25 @@ pub enum Bounded<T> {
 }
 
 impl<T> Bounded<T> {
-    /// Calculates the the amount of bytes that are required to represent integer `value`.
+    /// Calculates the the amount of bytes that are required to represent unsigned integer `value`.
     /// Particularly useful for OER codec
-    const fn octet_size_by_range(value: i128) -> Option<u8> {
-        match value.unsigned_abs() {
+    const fn unsigned_octet_size_by_range(value: u128) -> Option<u8> {
+        match value {
             x if x <= u8::MAX as u128 => Some(1),
             x if x <= u16::MAX as u128 => Some(2),
             x if x <= u32::MAX as u128 => Some(4),
             x if x <= u64::MAX as u128 => Some(8),
+            _ => None,
+        }
+    }
+    /// Calculates the the amount of bytes that are required to represent signed integer `value`.
+    /// Particularly useful for OER codec
+    const fn signed_octet_size_by_range(value: i128) -> Option<u8> {
+        match value {
+            x if x >= i8::MIN as i128 && x <= i8::MAX as i128 => Some(1),
+            x if x >= i16::MIN as i128 && x <= i16::MAX as i128 => Some(2),
+            x if x >= i32::MIN as i128 && x <= i32::MAX as i128 => Some(4),
+            x if x >= i64::MIN as i128 && x <= i64::MAX as i128 => Some(8),
             _ => None,
         }
     }
@@ -821,16 +832,39 @@ impl Bounded<i128> {
     #[must_use]
     pub const fn range_in_bytes(&self) -> (bool, Option<u8>) {
         match self {
-            Self::Single(value) => (*value < 0, Self::octet_size_by_range(*value)),
+            Self::Single(value) => {
+                let is_signed = *value < 0;
+                let octet_size = if is_signed {
+                    Self::signed_octet_size_by_range(*value)
+                } else {
+                    Self::unsigned_octet_size_by_range(*value as u128)
+                };
+                (is_signed, octet_size)
+            }
             Self::Range {
                 start: Some(start),
                 end: Some(end),
             } => {
                 let is_signed = *start < 0;
-                let end_abs = end.unsigned_abs();
-                let start_abs = start.unsigned_abs();
-                let bound_max = max_unsigned(start_abs, end_abs);
-                let octets = Self::octet_size_by_range(bound_max as i128);
+                let (octets_start, octets_end) = if is_signed {
+                    (
+                        Self::signed_octet_size_by_range(*start),
+                        Self::signed_octet_size_by_range(*end),
+                    )
+                } else {
+                    (
+                        Self::unsigned_octet_size_by_range(*start as u128),
+                        Self::unsigned_octet_size_by_range(*end as u128),
+                    )
+                };
+
+                let octets = match (octets_start, octets_end) {
+                    (Some(start), Some(end)) => {
+                        Some(max_unsigned(start as u128, end as u128) as u8)
+                    }
+                    (_, None) | (None, _) => None,
+                };
+
                 (is_signed, octets)
             }
             Self::Range {
@@ -1292,5 +1326,185 @@ mod tests {
         );
 
         assert_eq!(u_range.intersect(u_single), Some(u_single));
+    }
+    #[test]
+    fn range_in_bytes_none() {
+        let bounded = Bounded::<i128>::None;
+        assert_eq!(bounded.range_in_bytes(), (true, None));
+    }
+    #[test]
+    fn range_in_bytes_range() {
+        let bounded = Bounded::<i128>::Range {
+            start: Some(0i128),
+            end: Some(0i128),
+        };
+        assert_eq!(bounded.range_in_bytes(), (false, Some(1u8)));
+
+        let bounded = Bounded::<i128>::Range {
+            start: Some(-1i128),
+            end: Some(-1i128),
+        };
+        assert_eq!(bounded.range_in_bytes(), (true, Some(1u8)));
+
+        let boundary_test_values = [
+            (
+                i8::MIN as i128,
+                i8::MAX as i128,
+                (true, Some(1u8)),
+                (true, Some(2u8)),
+                (true, Some(2u8)),
+                "i8 range",
+            ),
+            (
+                i16::MIN as i128,
+                i16::MAX as i128,
+                (true, Some(2u8)),
+                (true, Some(4u8)),
+                (true, Some(4u8)),
+                "i16 range",
+            ),
+            (
+                i32::MIN as i128,
+                i32::MAX as i128,
+                (true, Some(4u8)),
+                (true, Some(8u8)),
+                (true, Some(8u8)),
+                "i32 range",
+            ),
+            (
+                i64::MIN as i128,
+                i64::MAX as i128,
+                (true, Some(8u8)),
+                (true, None),
+                (true, None),
+                "i64 range",
+            ),
+            (
+                u8::MIN as i128,
+                u8::MAX as i128,
+                (false, Some(1u8)),
+                (true, Some(2u8)),
+                (false, Some(2u8)),
+                "u8 range",
+            ),
+            (
+                u16::MIN as i128,
+                u16::MAX as i128,
+                (false, Some(2u8)),
+                (true, Some(4u8)),
+                (false, Some(4u8)),
+                "u16 range",
+            ),
+            (
+                u32::MIN as i128,
+                u32::MAX as i128,
+                (false, Some(4u8)),
+                (true, Some(8u8)),
+                (false, Some(8u8)),
+                "u32 range",
+            ),
+            (
+                u64::MIN as i128,
+                u64::MAX as i128,
+                (false, Some(8u8)),
+                (true, None),
+                (false, None),
+                "u64 range",
+            ),
+        ];
+
+        for (lower, upper, expected, expected_one_down, expected_one_up, name) in
+            boundary_test_values.into_iter()
+        {
+            // test regular case
+            let bounded = Bounded::<i128>::Range {
+                start: Some(lower),
+                end: Some(upper),
+            };
+            assert_eq!(bounded.range_in_bytes(), expected, "testing {}", name);
+
+            // test with lower bound decreased by 1 ("one down")
+            let bounded = Bounded::<i128>::Range {
+                start: Some(lower - 1),
+                end: Some(upper),
+            };
+            assert_eq!(
+                bounded.range_in_bytes(),
+                expected_one_down,
+                "testing {}, one down",
+                name
+            );
+
+            // test with upper bound increased by 1 ("one up")
+            let bounded = Bounded::<i128>::Range {
+                start: Some(lower),
+                end: Some(upper + 1),
+            };
+            assert_eq!(
+                bounded.range_in_bytes(),
+                expected_one_up,
+                "testing {}, one up",
+                name
+            );
+        }
+    }
+    #[test]
+    fn range_in_bytes_range_with_none() {
+        let test_values = [
+            (None, None, true),
+            (Some(-1i128), None, true),
+            (Some(0i128), None, false),
+            (Some(1i128), None, false),
+            (None, Some(-1i128), true),
+            (None, Some(0i128), true),
+            (None, Some(1i128), true),
+        ];
+
+        for (lower, upper, expected_signedness) in test_values.into_iter() {
+            let bounded = Bounded::<i128>::Range {
+                start: lower,
+                end: upper,
+            };
+            assert_eq!(
+                bounded.range_in_bytes(),
+                (expected_signedness, None),
+                "testing lower={:?} upper={:?}",
+                lower,
+                upper
+            );
+        }
+    }
+    #[test]
+    fn range_in_bytes_single() {
+        let test_values = [
+            (-1i128, (true, Some(1u8))),
+            (0i128, (false, Some(1u8))),
+            (1i128, (false, Some(1u8))),
+            (i8::MIN as i128, (true, Some(1u8))),
+            (i8::MAX as i128, (false, Some(1u8))),
+            (u8::MAX as i128, (false, Some(1u8))),
+            ((i8::MIN as i128) - 1, (true, Some(2u8))),
+            ((u8::MAX as i128) + 1, (false, Some(2u8))),
+            (i16::MIN as i128, (true, Some(2u8))),
+            (i16::MAX as i128, (false, Some(2u8))),
+            (u16::MAX as i128, (false, Some(2u8))),
+            ((i16::MIN as i128) - 1, (true, Some(4u8))),
+            ((u16::MAX as i128) + 1, (false, Some(4u8))),
+            (i32::MIN as i128, (true, Some(4u8))),
+            (i32::MAX as i128, (false, Some(4u8))),
+            (u32::MAX as i128, (false, Some(4u8))),
+            ((i32::MIN as i128) - 1, (true, Some(8u8))),
+            ((u32::MAX as i128) + 1, (false, Some(8u8))),
+            (i64::MIN as i128, (true, Some(8u8))),
+            (i64::MAX as i128, (false, Some(8u8))),
+            (u64::MAX as i128, (false, Some(8u8))),
+            ((i64::MIN as i128) - 1, (true, None)),
+            ((u64::MAX as i128) + 1, (false, None)),
+        ];
+
+        for (value, expected) in test_values.into_iter() {
+            let bounded = Bounded::<i128>::Single(value);
+            assert_eq!(bounded.range_in_bytes(), expected, "testing {}", value);
+        }
     }
 }


### PR DESCRIPTION
The current version of the validation logic for Integer values with length determinant encoding in COER has at least two bugs:
* The unsigned number 0 is considered invalid
* Signed Integer values are not validated to be canonical

This PR fixes these bugs and adds a few more test vectors to avoid regressions.