### PR TITLE
fix(xer): Return XER error on integer overflow when decoding

### DIFF
--- a/src/xer/de.rs
+++ b/src/xer/de.rs
@@ -514,7 +514,7 @@ impl crate::Decoder for Decoder {
             Some(XmlEvent::Characters(value)) => {
                 if let Ok(int) = value.parse::<i128>() {
                     int.try_into()
-                        .map_err(|_| DecodeError::integer_overflow(I::WIDTH, crate::Codec::Jer))
+                        .map_err(|_| DecodeError::integer_overflow(I::WIDTH, crate::Codec::Xer))
                 } else {
                     Err(DecodeError::from(XerDecodeErrorKind::XmlTypeMismatch {
                         needed: "integer value",


### PR DESCRIPTION
Just a small copy-paste typo I stumbled over.

XER integer decoding shall give an error with `Codec::Xer` instead of `Codec::Jer` (like it's done in the other decoding methods)