### PR TITLE
feat: Add feature flags to enable specific codecs (to optimize application size)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,20 @@ chrono = { version = "0.4.38", default-features = false, features = ["alloc"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [features]
-default = ["f32", "f64", "bytes"]
+default = ["f32", "f64", "bytes", "codecs"]
 std = []
 f32 = []
 f64 = []
 backtraces = ["std", "snafu/backtrace"]
 compiler = ["rasn-compiler"]
+# shorthand to enable all supported codecs at once
+codecs = ["codec_ber", "codec_oer", "codec_per", "codec_jer", "codec_xer", "codec_avn"]
+codec_ber = []
+codec_oer = ["codec_ber"]
+codec_per = ["codec_ber"]
+codec_jer = ["codec_ber", "dep:serde_json"]
+codec_xer = ["codec_ber"]
+codec_avn = ["codec_ber"]
 
 [profile.bench-lto]
 inherits = "bench"
@@ -80,6 +88,12 @@ name = "ieee1609dot2cert"
 path = "benches/ieee1609dot2_bsm_cert.rs"
 harness = false
 test = true
+required-features = ["codec_oer"]
+
+[[example]]
+name = "size_compare"
+path = "examples/size_compare.rs"
+required-features = ["codec_ber", "codec_per"]
 
 [dependencies]
 arc-slice = { version = "0.1.0", optional = true }
@@ -103,7 +117,7 @@ rasn-derive = { version = "0.28", path = "macros" }
 snafu = { version = "0.8.5", default-features = false, features = [
   "rust_1_81",
 ] }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
+serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 xml-no-std = "0.8.26"
 cfg-if = "1.0.1"
 
@@ -120,6 +134,7 @@ pretty_assertions.workspace = true
 rasn-pkix = { path = "standards/pkix", default-features = false }
 rasn-its = { path = "standards/its", default-features = false }
 serde = {version="1.0.228", features=["derive"]}
+serde_json = "*"
 
 # Assume that we need these dependencies only when benching manually on specific targets
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dev-dependencies]

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,6 +1,9 @@
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 use chrono::{FixedOffset, TimeZone, Utc};
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 use rasn::prelude::*;
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 #[derive(AsnType, Decode, Encode)]
 pub struct Bench {
     a: bool,
@@ -31,9 +34,11 @@ pub struct Bench {
     z: isize,
 }
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 #[derive(AsnType, Decode, Encode)]
 pub struct EmptySequence {}
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 #[derive(AsnType, Clone, Copy, Decode, Debug, Encode, PartialEq)]
 #[rasn(enumerated)]
 pub enum BenchEnum {
@@ -41,12 +46,14 @@ pub enum BenchEnum {
     B,
 }
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 #[derive(AsnType, Decode, Encode)]
 #[rasn(choice)]
 pub enum BenchChoice {
     A,
 }
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 pub fn bench_default() -> Bench {
     Bench {
         a: true,

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,9 +1,11 @@
 mod common;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_main};
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 use common::*;
 
+#[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
 fn rasn(c: &mut Criterion) {
     let decoded = black_box(bench_default());
 
@@ -19,7 +21,12 @@ fn rasn(c: &mut Criterion) {
         }}
     }
 
-    bench_encoding_rules!(ber, der, cer, uper, oer);
+    #[cfg(feature = "codec_oer")]
+    bench_encoding_rules!(ber, der, cer);
+    #[cfg(feature = "codec_per")]
+    bench_encoding_rules!(uper);
+    #[cfg(feature = "codec_oer")]
+    bench_encoding_rules!(oer);
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -131,8 +138,20 @@ fn x509_rtt(c: &mut Criterion) {
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-criterion_group!(codec, x509_decode, x509_encode, x509_rtt, rasn);
+pub fn codec() {
+    let mut criterion: Criterion<_> = Criterion::default().configure_from_args();
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    x509_decode(&mut criterion);
+    x509_encode(&mut criterion);
+    x509_rtt(&mut criterion);
+
+    #[cfg(any(feature = "codec_per", feature = "codec_per", feature = "codec_oer"))]
+    rasn(&mut criterion);
+}
+
+#[cfg(all(
+    not(any(target_arch = "x86_64", target_arch = "aarch64")),
+    any(feature = "codec_per", feature = "codec_per", feature = "codec_oer")
+))]
 criterion_group!(codec, rasn);
 criterion_main!(codec);

--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -6,8 +6,15 @@
 // Use macros to generate the tests
 // Wrap with black_box to prevent the compiler from optimizing out the code
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use rasn::{ber, oer, uper, xer};
+use criterion::{Criterion, black_box, criterion_main};
+#[cfg(feature = "codec_ber")]
+use rasn::ber;
+#[cfg(feature = "codec_oer")]
+use rasn::oer;
+#[cfg(feature = "codec_per")]
+use rasn::uper;
+#[cfg(feature = "codec_xer")]
+use rasn::xer;
 
 #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused)]
 pub mod world3d {
@@ -151,25 +158,46 @@ macro_rules! rasn_dec_fn {
     };
 }
 
+#[cfg(feature = "codec_per")]
 rasn_enc_fn!(uper_rasn_enc, uper);
+#[cfg(feature = "codec_oer")]
 rasn_enc_fn!(oer_rasn_enc, oer);
+#[cfg(feature = "codec_ber")]
 rasn_enc_fn!(ber_rasn_enc, ber);
+#[cfg(feature = "codec_xer")]
 rasn_enc_fn!(xer_rasn_enc, xer);
 
+#[cfg(feature = "codec_per")]
 rasn_dec_fn!(uper_rasn_dec, uper);
+#[cfg(feature = "codec_oer")]
 rasn_dec_fn!(oer_rasn_dec, oer);
+#[cfg(feature = "codec_ber")]
 rasn_dec_fn!(ber_rasn_dec, ber);
+#[cfg(feature = "codec_xer")]
 rasn_dec_fn!(xer_rasn_dec, xer);
 
-criterion_group!(
-    benches,
-    uper_rasn_enc,
-    uper_rasn_dec,
-    oer_rasn_enc,
-    oer_rasn_dec,
-    ber_rasn_enc,
-    ber_rasn_dec,
-    xer_rasn_enc,
-    xer_rasn_dec
-);
+pub fn benches() {
+    let mut criterion: Criterion<_> = Criterion::default().configure_from_args();
+
+    #[cfg(feature = "codec_per")]
+    uper_rasn_enc(&mut criterion);
+    #[cfg(feature = "codec_per")]
+    uper_rasn_dec(&mut criterion);
+
+    #[cfg(feature = "codec_oer")]
+    oer_rasn_enc(&mut criterion);
+    #[cfg(feature = "codec_oer")]
+    oer_rasn_dec(&mut criterion);
+
+    #[cfg(feature = "codec_ber")]
+    ber_rasn_enc(&mut criterion);
+    #[cfg(feature = "codec_ber")]
+    ber_rasn_dec(&mut criterion);
+
+    #[cfg(feature = "codec_xer")]
+    xer_rasn_enc(&mut criterion);
+    #[cfg(feature = "codec_xer")]
+    xer_rasn_dec(&mut criterion);
+}
+
 criterion_main!(benches);

--- a/benches/strings.rs
+++ b/benches/strings.rs
@@ -1,7 +1,12 @@
 //! Benchmarking the decoding of constrained octet strings
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_main};
+#[cfg(feature = "codec_ber")]
+use rasn::ber;
+#[cfg(feature = "codec_oer")]
+use rasn::oer;
 use rasn::prelude::*;
-use rasn::{ber, oer, uper};
+#[cfg(feature = "codec_per")]
+use rasn::uper;
 
 #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
 #[rasn(automatic_tags)]
@@ -115,21 +120,37 @@ macro_rules! rasn_dec_fixed_octet_fn {
     };
 }
 
+#[cfg(feature = "codec_per")]
 rasn_dec_octet_fn!(uper_octet, uper);
+#[cfg(feature = "codec_oer")]
 rasn_dec_octet_fn!(oer_octet, oer);
+#[cfg(feature = "codec_ber")]
 rasn_dec_octet_fn!(ber_octet, ber);
 
+#[cfg(feature = "codec_per")]
 rasn_dec_fixed_octet_fn!(uper_fixed_octet, uper);
+#[cfg(feature = "codec_oer")]
 rasn_dec_fixed_octet_fn!(oer_fixed_octet, oer);
+#[cfg(feature = "codec_ber")]
 rasn_dec_fixed_octet_fn!(ber_fixed_octet, ber);
 
-criterion_group!(
-    benches,
-    uper_octet,
-    uper_fixed_octet,
-    oer_octet,
-    oer_fixed_octet,
-    ber_octet,
-    ber_fixed_octet
-);
+pub fn benches() {
+    let mut criterion: Criterion<_> = Criterion::default().configure_from_args();
+
+    #[cfg(feature = "codec_per")]
+    uper_octet(&mut criterion);
+    #[cfg(feature = "codec_per")]
+    uper_fixed_octet(&mut criterion);
+
+    #[cfg(feature = "codec_oer")]
+    oer_octet(&mut criterion);
+    #[cfg(feature = "codec_oer")]
+    oer_fixed_octet(&mut criterion);
+
+    #[cfg(feature = "codec_ber")]
+    ber_octet(&mut criterion);
+    #[cfg(feature = "codec_ber")]
+    ber_fixed_octet(&mut criterion);
+}
+
 criterion_main!(benches);

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,5 +1,6 @@
 //! Module for different bit modification functions which are used in the library.
 
+#[cfg(feature = "codec_per")]
 pub(crate) fn range_from_len(bit_length: u32) -> i128 {
     2i128.pow(bit_length) - 1
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -5,24 +5,34 @@ use crate::prelude::*;
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[non_exhaustive]
 pub enum Codec {
+    #[cfg(feature = "codec_per")]
     /// X.691 — Packed Encoding Rules (Aligned)
     Aper,
+    #[cfg(feature = "codec_ber")]
     /// X.690 — Basic Encoding Rules
     Ber,
+    #[cfg(feature = "codec_ber")]
     /// X.690 — Canonical Encoding Rules
     Cer,
+    #[cfg(feature = "codec_ber")]
     /// X.690 — Distinguished Encoding Rules
     Der,
+    #[cfg(feature = "codec_per")]
     /// X.691 — Packed Encoding Rules (Unaligned)
     Uper,
+    #[cfg(feature = "codec_jer")]
     /// [JSON Encoding Rules](https://obj-sys.com/docs/JSONEncodingRules.pdf)
     Jer,
+    #[cfg(feature = "codec_oer")]
     /// X.696 — Octet Encoding Rules
     Oer,
+    #[cfg(feature = "codec_oer")]
     /// X.696 — Canonical Octet Encoding Rules
     Coer,
+    #[cfg(feature = "codec_xer")]
     /// X.693 — XML Encoding Rules
     Xer,
+    #[cfg(feature = "codec_avn")]
     /// ASN.1 Value Notation (X.680 text format)
     Avn,
 }
@@ -30,15 +40,25 @@ pub enum Codec {
 impl core::fmt::Display for Codec {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            #[cfg(feature = "codec_per")]
             Self::Aper => write!(f, "APER"),
+            #[cfg(feature = "codec_ber")]
             Self::Ber => write!(f, "BER"),
+            #[cfg(feature = "codec_ber")]
             Self::Cer => write!(f, "CER"),
+            #[cfg(feature = "codec_ber")]
             Self::Der => write!(f, "DER"),
+            #[cfg(feature = "codec_per")]
             Self::Uper => write!(f, "UPER"),
+            #[cfg(feature = "codec_jer")]
             Self::Jer => write!(f, "JER"),
+            #[cfg(feature = "codec_oer")]
             Self::Oer => write!(f, "OER"),
+            #[cfg(feature = "codec_oer")]
             Self::Coer => write!(f, "COER"),
+            #[cfg(feature = "codec_xer")]
             Self::Xer => write!(f, "XER"),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => write!(f, "AVN"),
         }
     }
@@ -55,15 +75,25 @@ impl Codec {
         value: &T,
     ) -> Result<alloc::vec::Vec<u8>, crate::error::EncodeError> {
         match self {
+            #[cfg(feature = "codec_per")]
             Self::Aper => crate::aper::encode(value),
+            #[cfg(feature = "codec_ber")]
             Self::Ber => crate::ber::encode(value),
+            #[cfg(feature = "codec_ber")]
             Self::Cer => crate::cer::encode(value),
+            #[cfg(feature = "codec_ber")]
             Self::Der => crate::der::encode(value),
+            #[cfg(feature = "codec_per")]
             Self::Uper => crate::uper::encode(value),
+            #[cfg(feature = "codec_jer")]
             Self::Jer => crate::jer::encode(value).map(alloc::string::String::into_bytes),
+            #[cfg(feature = "codec_oer")]
             Self::Oer => crate::oer::encode(value),
+            #[cfg(feature = "codec_oer")]
             Self::Coer => crate::coer::encode(value),
+            #[cfg(feature = "codec_xer")]
             Self::Xer => crate::xer::encode(value),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => crate::avn::encode(value).map(alloc::string::String::into_bytes),
         }
     }
@@ -78,14 +108,23 @@ impl Codec {
         input: &[u8],
     ) -> Result<D, crate::error::DecodeError> {
         match self {
+            #[cfg(feature = "codec_per")]
             Self::Aper => crate::aper::decode(input),
+            #[cfg(feature = "codec_ber")]
             Self::Ber => crate::ber::decode(input),
+            #[cfg(feature = "codec_ber")]
             Self::Cer => crate::cer::decode(input),
+            #[cfg(feature = "codec_ber")]
             Self::Der => crate::der::decode(input),
+            #[cfg(feature = "codec_per")]
             Self::Uper => crate::uper::decode(input),
+            #[cfg(feature = "codec_oer")]
             Self::Oer => crate::oer::decode(input),
+            #[cfg(feature = "codec_oer")]
             Self::Coer => crate::coer::decode(input),
+            #[cfg(feature = "codec_xer")]
             Self::Xer => crate::xer::decode(input),
+            #[cfg(feature = "codec_jer")]
             Self::Jer => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
                 |e| {
                     Err(crate::error::DecodeError::from_kind(
@@ -97,6 +136,7 @@ impl Codec {
                 },
                 |s| crate::jer::decode(&s),
             ),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => alloc::string::String::from_utf8(input.to_vec()).map_or_else(
                 |e| {
                     Err(crate::error::DecodeError::from_kind(
@@ -116,25 +156,35 @@ impl Codec {
         input: &'input [u8],
     ) -> Result<(D, &'input [u8]), crate::error::DecodeError> {
         match self {
+            #[cfg(feature = "codec_per")]
             Self::Aper => crate::aper::decode_with_remainder(input),
+            #[cfg(feature = "codec_ber")]
             Self::Ber => crate::ber::decode_with_remainder(input),
+            #[cfg(feature = "codec_ber")]
             Self::Cer => crate::cer::decode_with_remainder(input),
+            #[cfg(feature = "codec_ber")]
             Self::Der => crate::der::decode_with_remainder(input),
+            #[cfg(feature = "codec_per")]
             Self::Uper => crate::uper::decode_with_remainder(input),
+            #[cfg(feature = "codec_oer")]
             Self::Oer => crate::oer::decode_with_remainder(input),
+            #[cfg(feature = "codec_oer")]
             Self::Coer => crate::coer::decode_with_remainder(input),
+            #[cfg(feature = "codec_xer")]
             Self::Xer => Err(crate::error::DecodeError::from_kind(
                 crate::error::DecodeErrorKind::Custom {
                     msg: "XER does not support decoding with remainder. ".into(),
                 },
                 *self,
             )),
+            #[cfg(feature = "codec_jer")]
             Self::Jer => Err(crate::error::DecodeError::from_kind(
                 crate::error::DecodeErrorKind::Custom {
                     msg: "JER does not support decoding with remainder. ".into(),
                 },
                 *self,
             )),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => Err(crate::error::DecodeError::from_kind(
                 crate::error::DecodeErrorKind::Custom {
                     msg: "AVN does not support decoding with remainder. ".into(),
@@ -144,6 +194,7 @@ impl Codec {
         }
     }
 
+    #[cfg(any(feature = "codec_jer", feature = "codec_avn"))]
     /// Encodes a given value based on the value of `Codec`.
     /// This method shall be used when using text-based encoding rules.
     ///
@@ -155,7 +206,9 @@ impl Codec {
         value: &T,
     ) -> Result<alloc::string::String, crate::error::EncodeError> {
         match self {
+            #[cfg(feature = "codec_jer")]
             Self::Jer => crate::jer::encode(value),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => crate::avn::encode(value),
             codec => Err(crate::error::EncodeError::from_kind(
                 crate::error::EncodeErrorKind::Custom {
@@ -174,9 +227,15 @@ impl Codec {
     /// # Errors
     /// - If `D` cannot be decoded from `input`, or if trying to decode using
     ///   binary-based encoding rules, returns `DecodeError` struct.
+    #[cfg_attr(
+        not(any(feature = "codec_jer", feature = "codec_avn")),
+        allow(unused_variables)
+    )]
     pub fn decode_from_str<D: Decode>(&self, input: &str) -> Result<D, crate::error::DecodeError> {
         match self {
+            #[cfg(feature = "codec_jer")]
             Self::Jer => crate::jer::decode(input),
+            #[cfg(feature = "codec_avn")]
             Self::Avn => crate::avn::decode(input),
             codec => Err(crate::error::DecodeError::from_kind(
                 crate::error::DecodeErrorKind::Custom {

--- a/src/coer.rs
+++ b/src/coer.rs
@@ -1499,6 +1499,7 @@ mod tests {
             ]
         );
     }
+
     #[test]
     fn test_decode_with_remainder() {
         let bytes = vec![0x04, 0x01, 0x02, 0x03, 0x04, 0x05];

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,16 +18,40 @@ pub mod strings {
     };
 }
 
+pub use decode::CodecDecodeError;
+pub use decode::DecodeError;
 pub use decode::DecodeErrorKind;
-pub use decode::{
-    AvnDecodeErrorKind, BerDecodeErrorKind, CodecDecodeError, CoerDecodeErrorKind, DecodeError,
-    DerDecodeErrorKind, JerDecodeErrorKind, OerDecodeErrorKind, XerDecodeErrorKind,
-};
+
+#[cfg(feature = "codec_avn")]
+pub use decode::AvnDecodeErrorKind;
+#[cfg(feature = "codec_ber")]
+pub use decode::BerDecodeErrorKind;
+#[cfg(feature = "codec_oer")]
+pub use decode::CoerDecodeErrorKind;
+#[cfg(feature = "codec_ber")]
+pub use decode::DerDecodeErrorKind;
+#[cfg(feature = "codec_jer")]
+pub use decode::JerDecodeErrorKind;
+#[cfg(feature = "codec_oer")]
+pub use decode::OerDecodeErrorKind;
+#[cfg(feature = "codec_xer")]
+pub use decode::XerDecodeErrorKind;
+
+pub use encode::CodecEncodeError;
+pub use encode::EncodeError;
 pub use encode::EncodeErrorKind;
+
+#[cfg(feature = "codec_avn")]
+pub use encode::AvnEncodeErrorKind;
+#[cfg(feature = "codec_ber")]
+pub use encode::BerEncodeErrorKind;
+#[cfg(feature = "codec_oer")]
+pub use encode::CoerEncodeErrorKind;
+#[cfg(feature = "codec_ber")]
+pub use encode::DerEncodeErrorKind;
+#[cfg(feature = "codec_jer")]
 pub use encode::JerEncodeErrorKind;
-pub use encode::{
-    AvnEncodeErrorKind, BerEncodeErrorKind, CodecEncodeError, CoerEncodeErrorKind, EncodeError,
-    XerEncodeErrorKind,
-};
+#[cfg(feature = "codec_xer")]
+pub use encode::XerEncodeErrorKind;
 
 pub use components::InnerSubtypeConstraintError;

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -1,5 +1,6 @@
 //! Error types associated with decoding from ASN.1 codecs.
 
+#[cfg(any(feature = "codec_jer", feature = "codec_xer"))]
 use core::num::ParseIntError;
 
 use super::strings::PermittedAlphabetError;
@@ -19,30 +20,50 @@ use num_bigint::BigInt;
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum CodecDecodeError {
+    #[cfg(feature = "codec_ber")]
     Ber(BerDecodeErrorKind),
+    #[cfg(feature = "codec_ber")]
     Cer(CerDecodeErrorKind),
+    #[cfg(feature = "codec_ber")]
     Der(DerDecodeErrorKind),
+    #[cfg(feature = "codec_per")]
     Uper(UperDecodeErrorKind),
+    #[cfg(feature = "codec_per")]
     Aper(AperDecodeErrorKind),
+    #[cfg(feature = "codec_jer")]
     Jer(JerDecodeErrorKind),
+    #[cfg(feature = "codec_oer")]
     Oer(OerDecodeErrorKind),
+    #[cfg(feature = "codec_oer")]
     Coer(CoerDecodeErrorKind),
+    #[cfg(feature = "codec_xer")]
     Xer(XerDecodeErrorKind),
+    #[cfg(feature = "codec_avn")]
     Avn(AvnDecodeErrorKind),
 }
 
 impl core::fmt::Display for CodecDecodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            #[cfg(feature = "codec_ber")]
             CodecDecodeError::Ber(kind) => write!(f, "BER decoding error: {kind}"),
+            #[cfg(feature = "codec_ber")]
             CodecDecodeError::Cer(kind) => write!(f, "CER decoding error: {kind}"),
+            #[cfg(feature = "codec_ber")]
             CodecDecodeError::Der(kind) => write!(f, "DER decoding error: {kind}"),
+            #[cfg(feature = "codec_per")]
             CodecDecodeError::Uper(kind) => write!(f, "UPER decoding error: {kind}"),
+            #[cfg(feature = "codec_per")]
             CodecDecodeError::Aper(kind) => write!(f, "APER decoding error: {kind}"),
+            #[cfg(feature = "codec_jer")]
             CodecDecodeError::Jer(kind) => write!(f, "JER decoding error: {kind}"),
+            #[cfg(feature = "codec_oer")]
             CodecDecodeError::Oer(kind) => write!(f, "OER decoding error: {kind}"),
+            #[cfg(feature = "codec_oer")]
             CodecDecodeError::Coer(kind) => write!(f, "COER decoding error: {kind}"),
+            #[cfg(feature = "codec_xer")]
             CodecDecodeError::Xer(kind) => write!(f, "XER decoding error: {kind}"),
+            #[cfg(feature = "codec_avn")]
             CodecDecodeError::Avn(kind) => write!(f, "AVN decoding error: {kind}"),
         }
     }
@@ -59,15 +80,25 @@ macro_rules! impl_from {
 }
 
 // implement From for each variant of CodecDecodeError into DecodeError
+#[cfg(feature = "codec_ber")]
 impl_from!(Ber, BerDecodeErrorKind);
+#[cfg(feature = "codec_ber")]
 impl_from!(Cer, CerDecodeErrorKind);
+#[cfg(feature = "codec_ber")]
 impl_from!(Der, DerDecodeErrorKind);
+#[cfg(feature = "codec_per")]
 impl_from!(Uper, UperDecodeErrorKind);
+#[cfg(feature = "codec_per")]
 impl_from!(Aper, AperDecodeErrorKind);
+#[cfg(feature = "codec_jer")]
 impl_from!(Jer, JerDecodeErrorKind);
+#[cfg(feature = "codec_oer")]
 impl_from!(Oer, OerDecodeErrorKind);
+#[cfg(feature = "codec_oer")]
 impl_from!(Coer, CoerDecodeErrorKind);
+#[cfg(feature = "codec_xer")]
 impl_from!(Xer, XerDecodeErrorKind);
+#[cfg(feature = "codec_avn")]
 impl_from!(Avn, AvnDecodeErrorKind);
 
 impl From<CodecDecodeError> for DecodeError {
@@ -427,18 +458,28 @@ impl DecodeError {
     #[must_use]
     fn from_codec_kind(inner: CodecDecodeError) -> Self {
         let codec = match inner {
+            #[cfg(feature = "codec_ber")]
             CodecDecodeError::Ber(_) => crate::Codec::Ber,
+            #[cfg(feature = "codec_ber")]
             #[allow(unreachable_patterns)]
             CodecDecodeError::Cer(_) => crate::Codec::Cer,
+            #[cfg(feature = "codec_ber")]
             CodecDecodeError::Der(_) => crate::Codec::Der,
+            #[cfg(feature = "codec_per")]
             #[allow(unreachable_patterns)]
             CodecDecodeError::Uper(_) => crate::Codec::Uper,
+            #[cfg(feature = "codec_per")]
             #[allow(unreachable_patterns)]
             CodecDecodeError::Aper(_) => crate::Codec::Aper,
+            #[cfg(feature = "codec_jer")]
             CodecDecodeError::Jer(_) => crate::Codec::Jer,
+            #[cfg(feature = "codec_oer")]
             CodecDecodeError::Oer(_) => crate::Codec::Oer,
+            #[cfg(feature = "codec_oer")]
             CodecDecodeError::Coer(_) => crate::Codec::Coer,
+            #[cfg(feature = "codec_xer")]
             CodecDecodeError::Xer(_) => crate::Codec::Xer,
+            #[cfg(feature = "codec_avn")]
             CodecDecodeError::Avn(_) => crate::Codec::Avn,
         };
         Self {
@@ -765,6 +806,7 @@ pub enum DecodeErrorKind {
     ExceedsMaxParseDepth,
 }
 
+#[cfg(feature = "codec_ber")]
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for BER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -795,6 +837,7 @@ pub enum BerDecodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_ber")]
 impl BerDecodeErrorKind {
     /// A helper function to create an error [`BerDecodeErrorKind::InvalidDate`].
     #[must_use]
@@ -810,6 +853,7 @@ impl BerDecodeErrorKind {
         }
     }
 }
+#[cfg(feature = "codec_ber")]
 // TODO check if there are more codec-specific errors here
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for CER.
 #[derive(Snafu, Debug)]
@@ -817,6 +861,7 @@ impl BerDecodeErrorKind {
 #[non_exhaustive]
 pub enum CerDecodeErrorKind {}
 
+#[cfg(feature = "codec_ber")]
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for DER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -827,6 +872,7 @@ pub enum DerDecodeErrorKind {
     ConstructedEncodingNotAllowed,
 }
 
+#[cfg(feature = "codec_jer")]
 /// An error that occurred when decoding JER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -870,6 +916,7 @@ pub enum JerDecodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_jer")]
 impl JerDecodeErrorKind {
     /// Helper function to create an error [`JerDecodeErrorKind::EndOfInput`].
     #[must_use]
@@ -878,6 +925,7 @@ impl JerDecodeErrorKind {
     }
 }
 
+#[cfg(feature = "codec_per")]
 // TODO check if there codec-specific errors here
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for UPER.
 #[derive(Snafu, Debug)]
@@ -885,6 +933,7 @@ impl JerDecodeErrorKind {
 #[non_exhaustive]
 pub enum UperDecodeErrorKind {}
 
+#[cfg(feature = "codec_per")]
 // TODO check if there codec-specific errors here
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for APER.
 #[derive(Snafu, Debug)]
@@ -892,6 +941,7 @@ pub enum UperDecodeErrorKind {}
 #[non_exhaustive]
 pub enum AperDecodeErrorKind {}
 
+#[cfg(feature = "codec_xer")]
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for XER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -952,6 +1002,7 @@ pub enum XerDecodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_oer")]
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for OER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -999,6 +1050,7 @@ pub enum OerDecodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_oer")]
 impl OerDecodeErrorKind {
     #[must_use]
     /// Helper function to create an error [`OerDecodeErrorKind::InvalidTagNumberOnChoice`].
@@ -1031,6 +1083,7 @@ impl OerDecodeErrorKind {
         CodecDecodeError::Oer(Self::InvalidPreamble { msg }).into()
     }
 }
+#[cfg(feature = "codec_avn")]
 
 /// An error that occurred when decoding AVN.
 #[derive(Snafu, Debug)]
@@ -1083,6 +1136,7 @@ pub enum AvnDecodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_avn")]
 impl AvnDecodeErrorKind {
     /// Helper to create an end-of-input [`CodecDecodeError`].
     #[must_use]
@@ -1091,6 +1145,7 @@ impl AvnDecodeErrorKind {
     }
 }
 
+#[cfg(feature = "codec_oer")]
 /// `DecodeError` kinds of `Kind::CodecSpecific` which are specific for COER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -1179,6 +1234,8 @@ mod tests {
             Ok(_) => panic!("Expected error"),
         }
     }
+
+    #[cfg(feature = "codec_per")]
     #[test]
     fn test_uper_missing_choice_index() {
         use crate as rasn;

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -12,28 +12,46 @@ use alloc::{boxed::Box, string::ToString};
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum CodecEncodeError {
+    #[cfg(feature = "codec_ber")]
     Ber(BerEncodeErrorKind),
+    #[cfg(feature = "codec_ber")]
     Cer(CerEncodeErrorKind),
+    #[cfg(feature = "codec_ber")]
     Der(DerEncodeErrorKind),
+    #[cfg(feature = "codec_per")]
     Uper(UperEncodeErrorKind),
+    #[cfg(feature = "codec_per")]
     Aper(AperEncodeErrorKind),
+    #[cfg(feature = "codec_jer")]
     Jer(JerEncodeErrorKind),
+    #[cfg(feature = "codec_oer")]
     Coer(CoerEncodeErrorKind),
+    #[cfg(feature = "codec_xer")]
     Xer(XerEncodeErrorKind),
+    #[cfg(feature = "codec_avn")]
     Avn(AvnEncodeErrorKind),
 }
 
 impl core::fmt::Display for CodecEncodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            #[cfg(feature = "codec_ber")]
             CodecEncodeError::Ber(kind) => write!(f, "BER encoding error: {kind}"),
+            #[cfg(feature = "codec_ber")]
             CodecEncodeError::Cer(kind) => write!(f, "CER encoding error: {kind}"),
+            #[cfg(feature = "codec_ber")]
             CodecEncodeError::Der(kind) => write!(f, "DER encoding error: {kind}"),
+            #[cfg(feature = "codec_per")]
             CodecEncodeError::Uper(kind) => write!(f, "UPER encoding error: {kind}"),
+            #[cfg(feature = "codec_per")]
             CodecEncodeError::Aper(kind) => write!(f, "APER encoding error: {kind}"),
+            #[cfg(feature = "codec_jer")]
             CodecEncodeError::Jer(kind) => write!(f, "JER encoding error: {kind}"),
+            #[cfg(feature = "codec_oer")]
             CodecEncodeError::Coer(kind) => write!(f, "COER encoding error: {kind}"),
+            #[cfg(feature = "codec_xer")]
             CodecEncodeError::Xer(kind) => write!(f, "XER encoding error: {kind}"),
+            #[cfg(feature = "codec_avn")]
             CodecEncodeError::Avn(kind) => write!(f, "AVN encoding error: {kind}"),
         }
     }
@@ -50,14 +68,23 @@ macro_rules! impl_from {
 }
 
 // implement From for each variant of CodecEncodeError into EncodeError
+#[cfg(feature = "codec_ber")]
 impl_from!(Ber, BerEncodeErrorKind);
+#[cfg(feature = "codec_ber")]
 impl_from!(Cer, CerEncodeErrorKind);
+#[cfg(feature = "codec_ber")]
 impl_from!(Der, DerEncodeErrorKind);
+#[cfg(feature = "codec_per")]
 impl_from!(Uper, UperEncodeErrorKind);
+#[cfg(feature = "codec_per")]
 impl_from!(Aper, AperEncodeErrorKind);
+#[cfg(feature = "codec_jer")]
 impl_from!(Jer, JerEncodeErrorKind);
+#[cfg(feature = "codec_oer")]
 impl_from!(Coer, CoerEncodeErrorKind);
+#[cfg(feature = "codec_xer")]
 impl_from!(Xer, XerEncodeErrorKind);
+#[cfg(feature = "codec_avn")]
 impl_from!(Avn, AvnEncodeErrorKind);
 
 impl From<CodecEncodeError> for EncodeError {
@@ -252,18 +279,27 @@ impl EncodeError {
     #[must_use]
     fn from_codec_kind(inner: CodecEncodeError) -> Self {
         let codec = match inner {
+            #[cfg(feature = "codec_ber")]
             CodecEncodeError::Ber(_) => crate::Codec::Ber,
+            #[cfg(feature = "codec_ber")]
             #[allow(unreachable_patterns)]
             CodecEncodeError::Cer(_) => crate::Codec::Cer,
+            #[cfg(feature = "codec_ber")]
             #[allow(unreachable_patterns)]
             CodecEncodeError::Der(_) => crate::Codec::Der,
+            #[cfg(feature = "codec_per")]
             #[allow(unreachable_patterns)]
             CodecEncodeError::Uper(_) => crate::Codec::Uper,
+            #[cfg(feature = "codec_per")]
             #[allow(unreachable_patterns)]
             CodecEncodeError::Aper(_) => crate::Codec::Aper,
+            #[cfg(feature = "codec_jer")]
             CodecEncodeError::Jer(_) => crate::Codec::Jer,
+            #[cfg(feature = "codec_oer")]
             CodecEncodeError::Coer(_) => crate::Codec::Coer,
+            #[cfg(feature = "codec_xer")]
             CodecEncodeError::Xer(_) => crate::Codec::Xer,
+            #[cfg(feature = "codec_avn")]
             CodecEncodeError::Avn(_) => crate::Codec::Avn,
         };
         Self {
@@ -361,6 +397,8 @@ pub enum EncodeErrorKind {
     #[snafu(display("Encoder doesn't support `REAL` type"))]
     RealNotSuppored,
 }
+
+#[cfg(feature = "codec_ber")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for BER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -379,6 +417,7 @@ pub enum BerEncodeErrorKind {
         oid: alloc::vec::Vec<u32>,
     },
 }
+#[cfg(feature = "codec_ber")]
 impl BerEncodeErrorKind {
     /// Create an error [`BerEncodeErrorKind::InvalidObjectIdentifier`}.
     #[must_use]
@@ -387,6 +426,7 @@ impl BerEncodeErrorKind {
     }
 }
 
+#[cfg(feature = "codec_ber")]
 // TODO are there CER/DER/APER/UPER specific errors?
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for CER.
 #[derive(Snafu, Debug)]
@@ -394,12 +434,14 @@ impl BerEncodeErrorKind {
 #[non_exhaustive]
 pub enum CerEncodeErrorKind {}
 
+#[cfg(feature = "codec_ber")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for DER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum DerEncodeErrorKind {}
 
+#[cfg(feature = "codec_jer")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for UPER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -436,18 +478,21 @@ pub enum JerEncodeErrorKind {
     },
 }
 
+#[cfg(feature = "codec_per")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for UPER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum UperEncodeErrorKind {}
 
+#[cfg(feature = "codec_per")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for APER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum AperEncodeErrorKind {}
 
+#[cfg(feature = "codec_xer")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for XER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -466,6 +511,7 @@ pub enum XerEncodeErrorKind {
     MissingIdentifier,
 }
 
+#[cfg(feature = "codec_oer")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for COER.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -482,6 +528,7 @@ pub enum CoerEncodeErrorKind {
     InvalidConstrainedIntegerOctetSize,
 }
 
+#[cfg(feature = "codec_avn")]
 /// `EncodeError` kinds of `Kind::CodecSpecific` which are specific for AVN.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -519,6 +566,7 @@ mod tests {
     use super::*;
     use crate::prelude::*;
 
+    #[cfg(feature = "codec_ber")]
     #[test]
     fn test_ber_error() {
         use crate::ber::enc;
@@ -565,6 +613,8 @@ mod tests {
         //     backtrace: Backtrace( .... ),
         // },
     }
+
+    #[cfg(feature = "codec_per")]
     #[test]
     fn test_uper_constrained_string_error() {
         use crate as rasn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,20 +19,31 @@ pub mod de;
 pub mod enc;
 pub mod error;
 mod num;
+#[cfg(feature = "codec_per")]
 mod per;
 pub mod types;
 
 // Data Formats
 
+#[cfg(feature = "codec_per")]
 pub mod aper;
+#[cfg(feature = "codec_avn")]
 pub mod avn;
+#[cfg(feature = "codec_ber")]
 pub mod ber;
+#[cfg(feature = "codec_ber")]
 pub mod cer;
+#[cfg(feature = "codec_oer")]
 pub mod coer;
+#[cfg(feature = "codec_ber")]
 pub mod der;
+#[cfg(feature = "codec_jer")]
 pub mod jer;
+#[cfg(feature = "codec_oer")]
 pub mod oer;
+#[cfg(feature = "codec_per")]
 pub mod uper;
+#[cfg(feature = "codec_xer")]
 pub mod xer;
 
 #[doc(inline)]
@@ -85,7 +96,12 @@ mod tests {
             }
         }
 
-        codecs!(uper, aper, oer, coer, ber);
+        #[cfg(feature = "codec_per")]
+        codecs!(uper, aper);
+        #[cfg(feature = "codec_oer")]
+        codecs!(oer, coer);
+        #[cfg(feature = "codec_ber")]
+        codecs!(ber);
     }
 
     #[test]
@@ -260,12 +276,19 @@ mod tests {
             };
         }
 
+        #[cfg(feature = "codec_oer")]
         test_codec_iter!(oer, crate::Codec::Oer);
+        #[cfg(feature = "codec_oer")]
         test_codec_iter!(coer, crate::Codec::Coer);
+        #[cfg(feature = "codec_per")]
         test_codec_iter!(uper, crate::Codec::Uper);
+        #[cfg(feature = "codec_per")]
         test_codec_iter!(aper, crate::Codec::Aper);
+        #[cfg(feature = "codec_ber")]
         test_codec_iter!(ber, crate::Codec::Ber);
+        #[cfg(feature = "codec_ber")]
         test_codec_iter!(cer, crate::Codec::Cer);
+        #[cfg(feature = "codec_ber")]
         test_codec_iter!(der, crate::Codec::Der);
     }
 }

--- a/src/macros/test.rs
+++ b/src/macros/test.rs
@@ -22,6 +22,7 @@ macro_rules! round_trip {
     }};
 }
 
+#[cfg(feature = "codec_oer")]
 /// unwrap_err but includes the encoding in the error message.
 macro_rules! encode_error {
     ($codec:ident, $typ:ty, $value:expr) => {{
@@ -41,6 +42,7 @@ macro_rules! encode_error {
     }};
 }
 
+#[cfg(feature = "codec_oer")]
 /// unwrap_err for decoding.
 macro_rules! decode_error {
     ($codec:ident, $typ:ty, $value:expr) => {{
@@ -55,6 +57,7 @@ macro_rules! decode_error {
     }};
 }
 
+#[cfg(feature = "codec_oer")]
 /// unwrap for decoding.
 macro_rules! decode_ok {
     ($codec:ident, $typ:ty, $value:expr, $expected:expr) => {{
@@ -69,6 +72,7 @@ macro_rules! decode_ok {
     }};
 }
 
+#[cfg(any(feature = "codec_per", feature = "codec_oer"))]
 /// Same functionality [round_trip] but with a constraints object for testing
 /// constrained types.
 macro_rules! round_trip_with_constraints {
@@ -86,6 +90,7 @@ macro_rules! round_trip_with_constraints {
     }};
 }
 
+#[cfg(feature = "codec_oer")]
 /// Same functionality [encode_error] but with a constraints object for testing
 /// constrained types.
 macro_rules! encode_error_with_constraints {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@
 mod any;
 mod identifier;
 mod instance;
+#[cfg(feature = "codec_jer")]
 mod json;
 mod open;
 mod prefix;

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -883,6 +883,7 @@ impl IntegerType for Integer {
     }
 }
 
+#[cfg(feature = "codec_oer")]
 #[cfg(test)]
 macro_rules! assert_integer_round_trip {
     ($t:ty, $value:expr, $expected_unsigned:expr, $expected_signed:expr) => {{
@@ -948,6 +949,7 @@ macro_rules! assert_integer_round_trip {
     }};
 }
 
+#[cfg(feature = "codec_oer")]
 macro_rules! test_integer_conversions_and_operations {
     ($($t:ident),*) => {
         #[cfg(test)]
@@ -1117,6 +1119,7 @@ macro_rules! test_integer_conversions_and_operations {
     };
 }
 
+#[cfg(feature = "codec_oer")]
 test_integer_conversions_and_operations!(
     i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
 );

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -552,50 +552,59 @@ mod tests {
             "number": 42,
         });
 
-        // DER canonical
-        let der_enc = crate::der::encode(&value).unwrap();
-        let der_enc2 = crate::der::encode(&value2).unwrap();
-        let der_enc3 = crate::der::encode(&value3).unwrap();
-        assert_eq!(der_enc, der_enc2);
-        assert_eq!(der_enc, der_enc3);
-        let der_dec: Value = crate::der::decode(&der_enc).expect("DER decode failed");
-        assert_eq!(value, der_dec);
+        #[cfg(feature = "codec_ber")]
+        {
+            // DER canonical
+            let der_enc = crate::der::encode(&value).unwrap();
+            let der_enc2 = crate::der::encode(&value2).unwrap();
+            let der_enc3 = crate::der::encode(&value3).unwrap();
+            assert_eq!(der_enc, der_enc2);
+            assert_eq!(der_enc, der_enc3);
+            let der_dec: Value = crate::der::decode(&der_enc).expect("DER decode failed");
+            assert_eq!(value, der_dec);
 
-        // BER non canonical
-        let ber_enc = crate::ber::encode(&value).unwrap();
-        let ber_dec: Value = crate::ber::decode(&ber_enc).expect("BER decode failed");
-        assert_eq!(value, ber_dec);
+            // BER non canonical
+            let ber_enc = crate::ber::encode(&value).unwrap();
+            let ber_dec: Value = crate::ber::decode(&ber_enc).expect("BER decode failed");
+            assert_eq!(value, ber_dec);
+        }
 
-        // OER
-        let oer_enc = crate::oer::encode(&value).unwrap();
-        let oer_enc2 = crate::oer::encode(&value2).unwrap();
-        let oer_enc3 = crate::oer::encode(&value3).unwrap();
-        assert_eq!(oer_enc, oer_enc2);
-        assert_eq!(oer_enc, oer_enc3);
-        let oer_dec: Value = crate::oer::decode(&oer_enc).expect("OER decode failed");
-        assert_eq!(value, oer_dec);
+        #[cfg(feature = "codec_oer")]
+        {
+            // OER
+            let oer_enc = crate::oer::encode(&value).unwrap();
+            let oer_enc2 = crate::oer::encode(&value2).unwrap();
+            let oer_enc3 = crate::oer::encode(&value3).unwrap();
+            assert_eq!(oer_enc, oer_enc2);
+            assert_eq!(oer_enc, oer_enc3);
+            let oer_dec: Value = crate::oer::decode(&oer_enc).expect("OER decode failed");
+            assert_eq!(value, oer_dec);
 
-        // COER
-        let coer_enc = crate::coer::encode(&value).unwrap();
-        let coer_enc2 = crate::coer::encode(&value2).unwrap();
-        let coer_enc3 = crate::coer::encode(&value3).unwrap();
-        assert_eq!(coer_enc, coer_enc2);
-        assert_eq!(coer_enc, coer_enc3);
-        let coer_dec: Value = crate::coer::decode(&coer_enc).expect("COER decode failed");
-        assert_eq!(value, coer_dec);
+            // COER
+            let coer_enc = crate::coer::encode(&value).unwrap();
+            let coer_enc2 = crate::coer::encode(&value2).unwrap();
+            let coer_enc3 = crate::coer::encode(&value3).unwrap();
+            assert_eq!(coer_enc, coer_enc2);
+            assert_eq!(coer_enc, coer_enc3);
+            let coer_dec: Value = crate::coer::decode(&coer_enc).expect("COER decode failed");
+            assert_eq!(value, coer_dec);
+        }
 
-        // UPER
-        let uper_enc = crate::uper::encode(&value).unwrap();
-        let uper_enc2 = crate::uper::encode(&value2).unwrap();
-        let uper_enc3 = crate::uper::encode(&value3).unwrap();
-        assert_eq!(uper_enc, uper_enc2);
-        assert_eq!(uper_enc, uper_enc3);
-        let uper_dec: Value = crate::uper::decode(&uper_enc).expect("UPER decode failed");
-        assert_eq!(value, uper_dec);
+        #[cfg(feature = "codec_per")]
+        {
+            // UPER
+            let uper_enc = crate::uper::encode(&value).unwrap();
+            let uper_enc2 = crate::uper::encode(&value2).unwrap();
+            let uper_enc3 = crate::uper::encode(&value3).unwrap();
+            assert_eq!(uper_enc, uper_enc2);
+            assert_eq!(uper_enc, uper_enc3);
+            let uper_dec: Value = crate::uper::decode(&uper_enc).expect("UPER decode failed");
+            assert_eq!(value, uper_dec);
 
-        // APER is not designed to be canonical
-        let aper_enc = crate::aper::encode(&value).unwrap();
-        let aper_dec: Value = crate::aper::decode(&aper_enc).expect("APER decode failed");
-        assert_eq!(value, aper_dec);
+            // APER is not designed to be canonical
+            let aper_enc = crate::aper::encode(&value).unwrap();
+            let aper_dec: Value = crate::aper::decode(&aper_enc).expect("APER decode failed");
+            assert_eq!(value, aper_dec);
+        }
     }
 }

--- a/src/types/strings.rs
+++ b/src/types/strings.rs
@@ -28,9 +28,9 @@ pub use {
     visible::VisibleString,
 };
 
-pub(crate) use constrained::{
-    DynConstrainedCharacterString, StaticPermittedAlphabet, should_be_indexed,
-};
+pub(crate) use constrained::StaticPermittedAlphabet;
+#[cfg(feature = "codec_per")]
+pub(crate) use constrained::{DynConstrainedCharacterString, should_be_indexed};
 
 const fn bytes_to_chars<const N: usize>(input: [u8; N]) -> [u32; N] {
     let mut chars: [u32; N] = [0; N];

--- a/src/types/strings/bmp.rs
+++ b/src/types/strings/bmp.rs
@@ -10,6 +10,7 @@ use once_cell::race::OnceBox;
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BmpString(pub(super) Vec<u16>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl BmpString {
@@ -36,10 +37,12 @@ impl StaticPermittedAlphabet for BmpString {
     fn push_char(&mut self, ch: u32) {
         self.0.push(ch as u16);
     }
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| u32::from(byte))
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -42,12 +42,14 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         + AsPrimitive<u16>
         + AsPrimitive<u32>;
     const CHARACTER_SET: &'static [u32];
+    #[cfg(feature = "codec_per")]
     /// Bits needed to represent a character in the character set so that every character can be represented
     /// Encoding specific requirement
     const CHARACTER_SET_WIDTH: usize = crate::num::log2(Self::CHARACTER_SET.len() as i128) as usize;
     const CHARACTER_SET_NAME: CharacterSetName;
 
     fn push_char(&mut self, ch: u32);
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_;
     fn contains_char(ch: u32) -> bool {
         Self::CHARACTER_SET.contains(&ch)
@@ -121,8 +123,10 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         }
         Ok(vec)
     }
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32>;
     fn character_map() -> &'static alloc::collections::BTreeMap<u32, u32>;
+    #[cfg(feature = "codec_per")]
     fn char_range_to_bit_range(mut range: core::ops::Range<usize>) -> core::ops::Range<usize> {
         let width = Self::CHARACTER_SET_WIDTH;
         range.start *= width;
@@ -130,6 +134,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         range
     }
 
+    #[cfg(feature = "codec_per")]
     fn to_index_or_value_bitstring(&self) -> types::BitString {
         if should_be_indexed(Self::CHARACTER_SET_WIDTH as u32, Self::CHARACTER_SET) {
             self.to_index_string()
@@ -138,6 +143,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         }
     }
 
+    #[cfg(feature = "codec_per")]
     fn to_index_string(&self) -> types::BitString {
         let index_map = Self::index_map();
         let mut index_string = types::BitString::new();
@@ -150,6 +156,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         index_string
     }
 
+    #[cfg(feature = "codec_per")]
     fn to_octet_aligned_index_string(&self) -> Vec<u8> {
         let index_map = Self::index_map();
         let mut index_string = types::BitString::new();
@@ -168,6 +175,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         index_string.as_raw_slice().to_vec()
     }
 
+    #[cfg(feature = "codec_per")]
     fn octet_aligned_char_width(&self) -> usize {
         if Self::CHARACTER_SET_WIDTH.is_power_of_two() {
             Self::CHARACTER_SET_WIDTH
@@ -176,6 +184,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         }
     }
 
+    #[cfg(feature = "codec_per")]
     fn to_bit_string(&self) -> types::BitString {
         let mut octet_string = types::BitString::new();
         let width = Self::CHARACTER_SET_WIDTH;
@@ -187,6 +196,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         octet_string
     }
 
+    #[cfg(feature = "codec_per")]
     fn to_octet_aligned_string(&self) -> Vec<u8> {
         let mut octet_string = types::BitString::new();
         let width = self.octet_aligned_char_width();
@@ -198,14 +208,17 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
         octet_string.as_raw_slice().to_vec()
     }
 
+    #[cfg(feature = "codec_per")]
     fn character_width() -> u32 {
         crate::num::log2(Self::CHARACTER_SET.len() as i128)
     }
 
+    #[cfg(feature = "codec_per")]
     fn len(&self) -> usize {
         self.chars().count()
     }
 
+    #[cfg(feature = "codec_per")]
     #[allow(clippy::box_collection)]
     fn build_index_map() -> Box<alloc::collections::BTreeMap<u32, u32>> {
         Box::new(
@@ -298,6 +311,7 @@ pub struct DynConstrainedCharacterString {
 }
 
 impl DynConstrainedCharacterString {
+    #[cfg(feature = "codec_per")]
     pub fn from_bits(
         data: impl Iterator<Item = u32>,
         character_set: &[u32],

--- a/src/types/strings/general.rs
+++ b/src/types/strings/general.rs
@@ -13,6 +13,7 @@ use once_cell::race::OnceBox;
 pub struct GeneralString(pub(super) Vec<u8>);
 
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl GeneralString {
@@ -57,12 +58,14 @@ impl StaticPermittedAlphabet for GeneralString {
     ];
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::General;
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
     fn push_char(&mut self, ch: u32) {
         self.0.push(ch as u8);
     }
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/graphic.rs
+++ b/src/types/strings/graphic.rs
@@ -9,6 +9,7 @@ use once_cell::race::OnceBox;
 pub struct GraphicString(pub(super) Vec<u8>);
 
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl GraphicString {
@@ -49,12 +50,14 @@ impl StaticPermittedAlphabet for GraphicString {
     ];
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::Graphic;
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
     fn push_char(&mut self, ch: u32) {
         self.0.push(ch as u8);
     }
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/ia5.rs
+++ b/src/types/strings/ia5.rs
@@ -10,6 +10,7 @@ use once_cell::race::OnceBox;
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Ia5String(pub(super) Vec<u8>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl Ia5String {
@@ -49,6 +50,7 @@ impl super::StaticPermittedAlphabet for Ia5String {
     ];
     const CHARACTER_SET_NAME: constrained::CharacterSetName = constrained::CharacterSetName::IA5;
 
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
@@ -57,6 +59,7 @@ impl super::StaticPermittedAlphabet for Ia5String {
         self.0.push(ch as u8);
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/numeric.rs
+++ b/src/types/strings/numeric.rs
@@ -11,6 +11,7 @@ use once_cell::race::OnceBox;
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NumericString(pub(super) Vec<u8>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl NumericString {
@@ -37,6 +38,7 @@ impl StaticPermittedAlphabet for NumericString {
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::Numeric;
 
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
@@ -45,6 +47,7 @@ impl StaticPermittedAlphabet for NumericString {
         self.0.push(ch as u8);
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -14,6 +14,7 @@ use once_cell::race::OnceBox;
 #[allow(clippy::module_name_repetitions)]
 pub struct PrintableString(pub(super) Vec<u8>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl PrintableString {
@@ -51,10 +52,12 @@ impl StaticPermittedAlphabet for PrintableString {
         self.0.push(ch as u8);
     }
 
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/teletex.rs
+++ b/src/types/strings/teletex.rs
@@ -10,6 +10,7 @@ use once_cell::race::OnceBox;
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TeletexString(pub(super) Vec<u32>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl TeletexString {
@@ -41,10 +42,12 @@ impl StaticPermittedAlphabet for TeletexString {
     fn push_char(&mut self, ch: u32) {
         self.0.push(ch);
     }
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().copied()
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/src/types/strings/visible.rs
+++ b/src/types/strings/visible.rs
@@ -19,6 +19,7 @@ use once_cell::race::OnceBox;
 #[allow(clippy::module_name_repetitions)]
 pub struct VisibleString(pub(super) Vec<u8>);
 static CHARACTER_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
+#[cfg(feature = "codec_per")]
 static INDEX_MAP: OnceBox<alloc::collections::BTreeMap<u32, u32>> = OnceBox::new();
 
 impl VisibleString {
@@ -52,6 +53,7 @@ impl StaticPermittedAlphabet for VisibleString {
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::Visible;
 
+    #[cfg(feature = "codec_per")]
     fn chars(&self) -> impl Iterator<Item = u32> + '_ {
         self.0.iter().map(|&byte| byte as u32)
     }
@@ -61,6 +63,7 @@ impl StaticPermittedAlphabet for VisibleString {
         self.0.push(ch as u8);
     }
 
+    #[cfg(feature = "codec_per")]
     fn index_map() -> &'static alloc::collections::BTreeMap<u32, u32> {
         INDEX_MAP.get_or_init(Self::build_index_map)
     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -159,6 +159,7 @@ pub struct BasicConstraints {
     pub path_len_constraint: Option<Integer>,
 }
 
+#[cfg(feature = "codec_ber")]
 // This test makes sure that Newtype3(Newtype2(Newtype1(T))) results in serializing
 // as T when using the #[rasn(delegate)] attribute when T is a non-universal type.
 #[test]
@@ -258,6 +259,8 @@ fn explicit_identifiers() {
     );
     assert_eq!(MyDelegate::IDENTIFIER, Identifier(Some("my-delegate")));
 }
+
+#[cfg(all(feature = "codec_oer", feature = "codec_per"))]
 #[test]
 fn test_constraint_values() {
     #[derive(AsnType, Encode, Decode)]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -5,6 +5,7 @@ pub trait LeetTrait {
     fn leet(&self) -> Self::Leet;
 }
 
+#[cfg(feature = "codec_oer")]
 // https://github.com/librasn/rasn/issues/193
 #[test]
 fn test_sequence_with_generics_issue_193() {
@@ -74,6 +75,8 @@ fn test_sequence_with_generic_and_constraints() {
         Third(T),
     }
 }
+
+#[cfg(feature = "codec_oer")]
 #[test]
 fn test_multi_field_tuple_structs_with_phantom_data() {
     use core::marker::PhantomData;

--- a/tests/issue204.rs
+++ b/tests/issue204.rs
@@ -1,17 +1,22 @@
+#[cfg(feature = "codec_per")]
 use rasn::prelude::*;
 
+#[cfg(feature = "codec_per")]
 #[derive(Debug, AsnType, rasn::Encode, rasn::Decode, PartialEq)]
 #[rasn(delegate, size("1..=255"))]
 struct SimpleNumericString(pub NumericString);
 
+#[cfg(feature = "codec_per")]
 #[derive(Debug, AsnType, rasn::Encode, rasn::Decode, PartialEq)]
 #[rasn(delegate, from("0..=9"), size("1..=255"))]
 struct SimpleConstrainedNumericString(pub NumericString);
 
+#[cfg(feature = "codec_per")]
 #[derive(Debug, AsnType, rasn::Encode, rasn::Decode, PartialEq)]
 #[rasn(delegate, from("0..=2"), size("1..=255"))]
 struct Simple123NumericString(pub NumericString);
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_numeric_string_aper() {
     let string = SimpleNumericString(
@@ -24,6 +29,7 @@ fn round_trip_numeric_string_aper() {
     assert_eq!(decoded, string);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_numeric_string_uper() {
     let string = SimpleNumericString(
@@ -36,6 +42,7 @@ fn round_trip_numeric_string_uper() {
     assert_eq!(decoded, string);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_constrained_numeric_string_aper() {
     let string = SimpleConstrainedNumericString(
@@ -48,6 +55,7 @@ fn round_trip_constrained_numeric_string_aper() {
     assert_eq!(decoded, string);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_constrained_numeric_string_uper() {
     let string = SimpleConstrainedNumericString(
@@ -60,6 +68,7 @@ fn round_trip_constrained_numeric_string_uper() {
     assert_eq!(decoded, string);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_limited_charset_numeric_string_aper() {
     let string = Simple123NumericString(
@@ -71,6 +80,7 @@ fn round_trip_limited_charset_numeric_string_aper() {
     assert_eq!(decoded, string);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn round_trip_limited_charset_numeric_string_uper() {
     let string = Simple123NumericString(

--- a/tests/issue286.rs
+++ b/tests/issue286.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "codec_per")]
 use rasn::{error::EncodeErrorKind, prelude::*, uper};
 
+#[cfg(feature = "codec_per")]
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[rasn(delegate, value("-500..=504"))]
 pub struct Test(pub i16);
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn value_too_positive() {
     let x = Test(505);
@@ -21,6 +24,7 @@ fn value_too_positive() {
     ));
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn value_too_negative() {
     let x = Test(-505);

--- a/tests/issue492.rs
+++ b/tests/issue492.rs
@@ -15,6 +15,7 @@ pub struct AnonymousItemList(pub Integer);
 #[rasn(delegate, size("0..=65535"))]
 pub struct ItemList(pub SequenceOf<AnonymousItemList>);
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn test_minimal_64k_sequence_round_trip() {
     // Round-trip a small sequence to ensure decoder accepts 16-bit constrained length for span 65536

--- a/tests/issue505.rs
+++ b/tests/issue505.rs
@@ -22,6 +22,7 @@ pub struct S1 {
     pub ext_group_b3: Option<S1ExtGroupB3>,
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn uper_issue505_empty_extension_group_encoded_as_absent() {
     let value_with_empty_some = S1 {
@@ -51,6 +52,7 @@ fn uper_issue505_empty_extension_group_encoded_as_absent() {
     assert_eq!(decoded.ext_group_b3, Some(S1ExtGroupB3 { b3: Some(true) }));
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn uper_issue505_some_all_none_equals_none() {
     let with_empty_some = S1 {

--- a/tests/issue523.rs
+++ b/tests/issue523.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "codec_per")]
 use rasn::prelude::*;
 
+#[cfg(feature = "codec_per")]
 #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
 #[rasn(automatic_tags)]
 struct Seq64 {
@@ -134,6 +136,7 @@ struct Seq64 {
     pub e63: Option<Integer>,
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn uper_issue523_normally_small_length_64_extensions() {
     let original = Seq64 {

--- a/tests/personnel.rs
+++ b/tests/personnel.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "codec_oer")]
 use pretty_assertions::assert_eq;
 use rasn::prelude::*;
 
@@ -387,6 +388,7 @@ pub struct InitialString {
     pub initial: NameString,
 }
 
+#[cfg(feature = "codec_per")]
 #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
 #[non_exhaustive]
 struct Ax {
@@ -400,6 +402,7 @@ struct Ax {
     j: Option<PrintableString>,
 }
 
+#[cfg(feature = "codec_per")]
 #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
 #[rasn(choice)]
 #[non_exhaustive]
@@ -411,6 +414,7 @@ enum AxChoice {
     F(Ia5String),
 }
 
+#[cfg(feature = "codec_per")]
 #[derive(AsnType, Decode, Encode, Debug, PartialEq)]
 struct AxExtension {
     #[rasn(size(3))]
@@ -418,6 +422,7 @@ struct AxExtension {
     h: Option<bool>,
 }
 
+#[cfg(feature = "codec_per")]
 impl Default for Ax {
     fn default() -> Self {
         Self {
@@ -434,6 +439,7 @@ impl Default for Ax {
     }
 }
 
+#[cfg(any(feature = "codec_oer", feature = "codec_per"))]
 macro_rules! test {
     ($( $(#[$attrs:ident])* $name:ident ( $codec:ident ) : $typ:ty = $value:expr => $expected:expr;)+) => {
         $(
@@ -456,6 +462,7 @@ macro_rules! test {
     }
 }
 
+#[cfg(feature = "codec_oer")]
 test! {
     unconstrained_ber(ber): PersonnelRecord = <_>::default() => &[
         0x60, 0x81, 0x85,
@@ -495,7 +502,10 @@ test! {
                     0xA0, 0x0A,
                         0x43, 0x8, 0x31, 0x39, 0x35, 0x39, 0x30, 0x37, 0x31, 0x37,
     ];
+}
 
+#[cfg(feature = "codec_per")]
+test! {
     unconstrained_aper(aper): PersonnelRecord = <_>::default() => &[
         0x80, 0x04, 0x4A, 0x6F, 0x68, 0x6E, 0x01, 0x50, 0x05, 0x53, 0x6D, 0x69,
         0x74, 0x68, 0x01, 0x33, 0x08, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6F,
@@ -572,6 +582,10 @@ test! {
         0x6E, 0x65, 0x73, 0x00, 0x19, 0x59, 0x07, 0x17,
         0x01, 0x01, 0x40
     ];
+}
+
+#[cfg(feature = "codec_oer")]
+test! {
     unconstrained_coer(coer): PersonnelRecord = <_>::default() => &[
         0x80,0x04,0x4A,0x6F,0x68,0x6E,0x01,0x50,0x05,0x53,0x6D,0x69,0x74,0x68,0x01,
         0x33,0x08,0x44,0x69,0x72,0x65,0x63,0x74,0x6F,0x72,0x08,0x31,0x39,0x37,0x31,

--- a/tests/recursiveDepth.rs
+++ b/tests/recursiveDepth.rs
@@ -6,7 +6,15 @@
 
 use crate::recursive_module::RecursiveChoice;
 use rasn::error::DecodeErrorKind;
-use rasn::{aper, ber, cer, coer, der, jer, oer, uper};
+
+#[cfg(feature = "codec_jer")]
+use rasn::jer;
+#[cfg(feature = "codec_per")]
+use rasn::{aper, uper};
+#[cfg(feature = "codec_ber")]
+use rasn::{ber, cer, der};
+#[cfg(feature = "codec_oer")]
+use rasn::{coer, oer};
 
 #[allow(
     non_camel_case_types,
@@ -72,6 +80,7 @@ fn nested_exceeds_max_parse_depth_level(mut kind: &DecodeErrorKind) -> Option<us
     }
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn recursive_depth_150_aper() {
     let bytes = &*include_bytes!("data/recursive_depth_150.aper");
@@ -81,6 +90,7 @@ fn recursive_depth_150_aper() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_ber")]
 #[test]
 fn recursive_depth_150_ber() {
     let bytes = &*include_bytes!("data/recursive_depth_150.ber");
@@ -90,6 +100,7 @@ fn recursive_depth_150_ber() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_ber")]
 #[test]
 fn recursive_depth_150_cer() {
     let bytes = &*include_bytes!("data/recursive_depth_150.cer");
@@ -99,6 +110,7 @@ fn recursive_depth_150_cer() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_oer")]
 #[test]
 fn recursive_depth_150_coer() {
     let bytes = &*include_bytes!("data/recursive_depth_150.coer");
@@ -108,6 +120,7 @@ fn recursive_depth_150_coer() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_ber")]
 #[test]
 fn recursive_depth_150_der() {
     let bytes = &*include_bytes!("data/recursive_depth_150.der");
@@ -117,6 +130,7 @@ fn recursive_depth_150_der() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_jer")]
 #[test]
 fn recursive_depth_150_jer() {
     // serde_json has a limit of 128
@@ -128,6 +142,7 @@ fn recursive_depth_150_jer() {
     );
 }
 
+#[cfg(feature = "codec_oer")]
 #[test]
 fn recursive_depth_150_oer() {
     let bytes = &*include_bytes!("data/recursive_depth_150.oer");
@@ -137,6 +152,7 @@ fn recursive_depth_150_oer() {
     assert_eq!(level, 16);
 }
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn recursive_depth_150_uper() {
     let bytes = &*include_bytes!("data/recursive_depth_150.uper");

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -1,6 +1,13 @@
 use bitvec::prelude::*;
+#[cfg(feature = "codec_ber")]
+use rasn::ber;
+#[cfg(feature = "codec_jer")]
+use rasn::jer;
+#[cfg(feature = "codec_oer")]
+use rasn::oer;
 use rasn::prelude::*;
-use rasn::{aper, ber, jer, oer, uper};
+#[cfg(feature = "codec_per")]
+use rasn::{aper, uper};
 
 #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
 #[rasn(automatic_tags)]
@@ -128,9 +135,13 @@ macro_rules! test_decode_eq {
         }
     };
 }
+#[cfg(feature = "codec_per")]
 test_decode_eq!(test_uper_octet_eq, uper);
+#[cfg(feature = "codec_oer")]
 test_decode_eq!(test_oer_octet_eq, oer);
+#[cfg(feature = "codec_ber")]
 test_decode_eq!(test_ber_octet_eq, ber);
+#[cfg(feature = "codec_jer")]
 test_decode_eq!(test_jer_octet_eq, jer);
 
 #[derive(AsnType, Decode, Encode, Debug, Clone, PartialEq)]
@@ -140,6 +151,7 @@ pub struct ABitString {
     pub the_string: BitString,
 }
 
+#[cfg(feature = "codec_jer")]
 /// Tests that valid strings are parsed and invalid strings are rejected.
 #[test]
 fn test_jer_bitstring_dec() {
@@ -231,6 +243,7 @@ pub struct AnOctetString {
     pub the_string: OctetString,
 }
 
+#[cfg(feature = "codec_jer")]
 /// Tests that valid strings are parsed and invalid strings are rejected.
 #[test]
 fn test_jer_octetstring_dec() {
@@ -328,6 +341,7 @@ fn test_jer_octetstring_dec() {
     }
 }
 
+#[cfg(feature = "codec_per")]
 // Tests that OctetStrings are encoded and decoded correctly (APER, UPER).
 const BYTE_ARRAYS: &[&[u8]] = &[
     &[],
@@ -355,6 +369,7 @@ const BYTE_ARRAYS: &[&[u8]] = &[
     &[0xFF; 16383],
 ];
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn test_per_encode_octet_string() {
     for case in BYTE_ARRAYS {
@@ -383,6 +398,7 @@ fn test_per_encode_octet_string() {
     }
 }
 
+#[cfg(feature = "codec_per")]
 // Tests that UTF8Strings are encoded and decoded correctly (APER, UPER).
 const UTF8_STRINGS: &[&str] = &[
     "",
@@ -424,6 +440,7 @@ const UTF8_STRINGS: &[&str] = &[
     "👭👩🏻‍🤝‍👨🏾🧑🏿‍🤝‍🧑🏼",
 ];
 
+#[cfg(feature = "codec_per")]
 #[test]
 fn test_per_encode_utf8_string() {
     for case in UTF8_STRINGS {


### PR DESCRIPTION
The size of an ASN.1 parser library can get quite big when `rasn` is generating code for all supported codecs. This can be an issue on embedded targets where XER and JER encoding may not be needed when you're only operating on the rust types.

This PR adds a set of feature flags to individually enable each codec "suite":
- `codec_ber`: BER, CER and PER
- `codec_oer`: OER and COER
- `codec_per`: UPER and APER
- `codec_xer`: XER
- `codec_jer`: JER
- `codec_avn`: AVN

Sadly, all codes depend on some BER and DER encoding/ decoding which means that full BER/ CER/ DER support is always carried even if e.g. only UPER is needed. But it wasn't easily achievable to only pull in the required BER and DER parts.