### PR TITLE
fix(der): reject trailing data in der::decode

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -3,11 +3,25 @@
 pub use crate::ber::*;
 
 /// Attempts to decode `T` from `input` using DER.
+///
+/// `input` must contain exactly one complete DER value; any trailing bytes left
+/// after the top-level value are rejected, as required by X.690 §8.1.1.1. Use
+/// [`decode_with_remainder`] to decode a value from the front of a larger buffer.
+///
+/// # Errors
+/// Returns `DecodeError` if `input` is not valid DER encoding specific to the
+/// expected type, or if there is unexpected trailing data after the decoded value.
 pub fn decode<T: crate::Decode>(input: &[u8]) -> Result<T, crate::error::DecodeError> {
-    T::decode(&mut crate::ber::de::Decoder::new(
-        input,
-        crate::ber::de::DecoderOptions::der(),
-    ))
+    let decoder = &mut de::Decoder::new(input, de::DecoderOptions::der());
+    let decoded = T::decode(decoder)?;
+    let remaining = decoder.remaining();
+    if !remaining.is_empty() {
+        return Err(crate::error::DecodeError::unexpected_extra_data(
+            remaining.len(),
+            decoder.codec(),
+        ));
+    }
+    Ok(decoded)
 }
 /// Attempts to decode `T` from `input` using DER. Returns both `T` and reference to the remainder of the input.
 ///

--- a/standards/cms/tests/test_cms.rs
+++ b/standards/cms/tests/test_cms.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use rasn::der::{decode, encode};
+use rasn::der::{decode, decode_with_remainder, encode};
 
 use rasn_cms::authenticode::{
     SPC_CLASS_UUID, SPC_INDIRECT_DATA_OBJID, SpcIndirectDataContent, SpcLink, SpcPeImageData,
@@ -39,7 +39,12 @@ fn test_cms_encrypted() {
 
 #[test]
 fn test_authenticode() {
-    let info = decode::<ContentInfo>(PE_SIG_DATA).unwrap();
+    // Authenticode stores the PKCS#7 blob in a WIN_CERTIFICATE structure padded
+    // to an 8-byte boundary, so `PE_SIG_DATA` carries two trailing padding bytes
+    // after the DER value. `der::decode` is now strict and rejects trailing bytes
+    // (see #552), so use `decode_with_remainder` to parse the complete ContentInfo
+    // and ignore that container padding.
+    let (info, _padding) = decode_with_remainder::<ContentInfo>(PE_SIG_DATA).unwrap();
     assert_eq!(CONTENT_SIGNED_DATA, info.content_type);
 
     let signed_data = decode::<pkcs7_compat::SignedData>(info.content.as_bytes()).unwrap();

--- a/standards/pkix/tests/fuzz.rs
+++ b/standards/pkix/tests/fuzz.rs
@@ -35,7 +35,12 @@ fn splice() {
     let encoded = rasn::cer::encode(&value).unwrap();
     assert_eq!(value, rasn::cer::decode(&encoded).unwrap());
 
-    let value = rasn::der::decode::<rasn_pkix::AlgorithmIdentifier>(data).unwrap();
+    // `splice.bin` carries trailing bytes after the AlgorithmIdentifier. DER
+    // decoding is now strict and rejects trailing data (see #552), so parse the
+    // raw fixture with `decode_with_remainder`, mirroring the lenient BER/CER arms
+    // above; the canonical re-encoding has no trailing data.
+    let (value, _) =
+        rasn::der::decode_with_remainder::<rasn_pkix::AlgorithmIdentifier>(data).unwrap();
     let encoded = rasn::der::encode(&value).unwrap();
     assert_eq!(value, rasn::der::decode(&encoded).unwrap());
 }

--- a/tests/issue552.rs
+++ b/tests/issue552.rs
@@ -1,0 +1,63 @@
+//! Regression tests for <https://github.com/librasn/rasn/issues/552>.
+//!
+//! `der::decode` must reject input that carries trailing bytes after the
+//! top-level value: X.690 §8.1.1.1 requires a DER message to be exactly one
+//! complete TLV with no trailing data. Previously `der::decode` returned the
+//! decoded value and silently dropped any remaining bytes.
+
+use rasn::error::DecodeErrorKind;
+use rasn::prelude::*;
+
+#[test]
+fn der_decode_rejects_trailing_bytes() {
+    // NULL (`05 00`) followed by four garbage bytes, the exact example from the
+    // issue (ASN.1 NULL decodes to the unit type). Before the fix this decoded to
+    // `()` and dropped `DE AD BE EF`.
+    let input = &[0x05, 0x00, 0xDE, 0xAD, 0xBE, 0xEF];
+    let err = rasn::der::decode::<()>(input).expect_err("trailing data must be rejected");
+    assert!(
+        matches!(
+            &*err.kind,
+            DecodeErrorKind::UnexpectedExtraData { length: 4 }
+        ),
+        "issue #552: expected UnexpectedExtraData {{ length: 4 }}, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn der_decode_rejects_trailing_bytes_on_integer() {
+    // Same property for a primitive with content: INTEGER 1 (`02 01 01`) plus a
+    // single trailing byte.
+    let input = &[0x02, 0x01, 0x01, 0xFF];
+    let err = rasn::der::decode::<Integer>(input).expect_err("trailing data must be rejected");
+    assert!(
+        matches!(
+            &*err.kind,
+            DecodeErrorKind::UnexpectedExtraData { length: 1 }
+        ),
+        "issue #552: expected UnexpectedExtraData {{ length: 1 }}, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn der_decode_accepts_exact_input() {
+    // The exact encoding with no trailing bytes still decodes successfully.
+    rasn::der::decode::<()>(&[0x05, 0x00]).expect("exact NULL must still decode");
+    assert_eq!(
+        rasn::der::decode::<Integer>(&[0x02, 0x01, 0x2A]).expect("exact INTEGER must still decode"),
+        Integer::from(42)
+    );
+}
+
+#[test]
+fn der_decode_round_trip_holds_for_exact_input() {
+    // `encode(decode(bytes))` reproduces the exact input when there is no
+    // trailing data. The round-trip divergence reported in the issue only arose
+    // because trailing bytes were silently absorbed on decode.
+    let input = &[0x02, 0x01, 0x2A]; // INTEGER 42
+    let value = rasn::der::decode::<Integer>(input).expect("decode");
+    let reencoded = rasn::der::encode(&value).expect("encode");
+    assert_eq!(reencoded, input);
+}


### PR DESCRIPTION
## Summary

Fixes #552.

`der::decode` decoded the root value and returned without checking that the whole input
was consumed, so `der::decode::<()>(&[0x05, 0x00, 0xDE, 0xAD, 0xBE, 0xEF])` (a `NULL`
followed by four garbage bytes) decoded to `()` and silently dropped the trailing bytes.
X.690 §8.1.1.1 requires a DER message to be exactly one complete value with no trailing
data. The same leniency is what produced the round-trip divergence @tynus2 flagged, where
`encode(decode(bytes))` can be shorter than `bytes`. I've kept out of the
security-classification discussion and scoped this purely to the exact-consumption / API
contract of `decode<T>`.

## What the fix does

`src/der.rs`: after decoding the root value, `der::decode` now checks the decoder's
remaining input and returns `DecodeErrorKind::UnexpectedExtraData { length }` when any
bytes are left. It reuses the extra-data error rasn already emits for trailing bytes inside
a constructed value (`src/ber/de.rs`), so the behaviour and error type stay consistent with
the rest of the codec. `decode_with_remainder` is unchanged, for callers that intentionally
decode a value from the front of a larger buffer, and the `decode` doc comment now states
the strictness.

## Scope: DER only, and the codec-wide question

I scoped this to `der::decode`, matching the issue. @Nicceboy's point that the same pattern
applies to several `decode` entry points is right: each codec has its own thin top-level
`decode` wrapper (`ber`, `cer`, `oer`, `uper`, ...), and the strictness lives in that
wrapper rather than in shared machinery, so extending it is mechanical. I deliberately did
not touch the others here:

- BER has historically dropped trailing bytes (as you noted, established practice given its
  streaming heritage), so making it strict is a semantics decision I didn't want to take
  unilaterally.
- CER is a distinguished form like DER and is a natural next candidate; OER/PER are the
  same shape of question.

If you'd like the same check applied uniformly across the strict `decode` entry points
(with the `decode` docs updated to state the strictness, per your suggestion), I'm happy to
do that as a follow-up — just say which codecs you want it on.

## Real-world impact surfaced by the change

Two fixtures already in the tree carried trailing bytes that the lenient decoder silently
accepted, and both are legitimate:

- `standards/cms/tests/data/pesig.p7` (Authenticode): the PKCS#7 blob lives inside a
  WIN_CERTIFICATE structure padded to an 8-byte boundary, so it has two `00` padding bytes
  after the DER value. `test_authenticode` now parses it with `decode_with_remainder`.
- `standards/pkix/tests/data/splice.bin` (a fuzz-regression fixture): a valid
  `AlgorithmIdentifier` followed by three trailing bytes. The `splice` test's DER arm now
  uses `decode_with_remainder`, matching its existing BER/CER arms.

Both are small, mechanical migrations to the "decode one value, ignore the rest" API, and
are included here so CI stays green. They're also a useful signal for the codec-wide
decision: trailing bytes do turn up in real inputs (container padding), so the strict
default and the `decode_with_remainder` escape hatch matter together.

## Tests

`tests/issue552.rs`:

- `der_decode_rejects_trailing_bytes` — the issue's exact `NULL` + 4 trailing bytes now
  returns `UnexpectedExtraData { length: 4 }`.
- `der_decode_rejects_trailing_bytes_on_integer` — `INTEGER` + 1 trailing byte.
- `der_decode_accepts_exact_input` — exact encodings still decode.
- `der_decode_round_trip_holds_for_exact_input` — `encode(decode(bytes)) == bytes` for
  exact input.

I confirmed the two rejection tests fail on the unpatched tree and pass with the fix. The
full workspace suite is green (`cargo test --workspace`), as are `cargo fmt --all --
--check`, `cargo clippy --workspace --all-targets --features=f32,f64,bytes,std,backtraces
-- -D warnings`, and the doc build with `-D warnings`.

## Evidence note (independent reference)

As an independent cross-check on the property, not as a dependency: I maintain
`der-verified` (0.1.0, MIT/Apache-2.0, proofs re-runnable from a fresh clone), a DER/X.690
core in which exact whole-input consumption is one of the verified properties. Its
top-level strict decoders return a distinct `TrailingData` error on any trailing bytes, and
a Kani harness proves that whenever the TLV reader accepts an input it consumes exactly
`header + declared_length` bytes and never over-reads. That is bounded model checking (a
16-byte symbolic buffer, loop unwinding to depth 16) rather than an all-length statement,
but it covers the trailing-data property on that domain; the crate also carries round-trip
harnesses of the same shape. This PR simply brings `der::decode` in line with that
exact-consumption behaviour.
