### PR TITLE
chore: fix clippy byte_char_slices on new stable

### DIFF
--- a/src/types/strings/numeric.rs
+++ b/src/types/strings/numeric.rs
@@ -31,9 +31,7 @@ impl NumericString {
 
 impl StaticPermittedAlphabet for NumericString {
     type T = u8;
-    const CHARACTER_SET: &'static [u32] = &bytes_to_chars([
-        b' ', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9',
-    ]);
+    const CHARACTER_SET: &'static [u32] = &bytes_to_chars(*b" 0123456789");
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::Numeric;
 

--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -37,13 +37,9 @@ impl StaticPermittedAlphabet for PrintableString {
     type T = u8;
     /// `PrintableString` contains only "printable" characters.
     /// Latin letters, digits, (space) '()+,-./:=?
-    const CHARACTER_SET: &'static [u32] = &bytes_to_chars([
-        b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O',
-        b'P', b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c', b'd',
-        b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's',
-        b't', b'u', b'v', b'w', b'x', b'y', b'z', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7',
-        b'8', b'9', b' ', b'\'', b'(', b')', b'+', b',', b'-', b'.', b'/', b':', b'=', b'?',
-    ]);
+    const CHARACTER_SET: &'static [u32] = &bytes_to_chars(
+        *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '()+,-./:=?",
+    );
     const CHARACTER_SET_NAME: constrained::CharacterSetName =
         constrained::CharacterSetName::Printable;
 


### PR DESCRIPTION
Current stable clippy added `byte_char_slices`, which fires on the two `bytes_to_chars([b'…', …])` charset arrays (`NumericString`, `PrintableString`) and turns every `just lint` CI job red — including on unrelated PRs (e.g. #562). This rewrites both charsets as byte strings, byte-for-byte identical; lib tests pass unchanged.
