### PR TITLE
fix BER encoding of tagged ANY type

### DIFF
--- a/src/ber.rs
+++ b/src/ber.rs
@@ -573,9 +573,11 @@ mod tests {
             d: true,
         };
         // Sequence tag (0x30), length 7
-        // Any 'c' is implicitly tagged with [2]: tag (0x82), length 2, value [0x05, 0x00]
+        // Any 'c' is explicitly tagged with [2]: tag (0xA2), constructed, length 2, value [0x05, 0x00],
+        // since Any (open type) is explicitly tagged by automatic tagging (X.680 section 25.10 note 1
+        // and section 31.2.7) and explicitly tagged type shall be constructed (X.690 section 8.14.3)
         // Boolean 'd' is implicitly tagged with [3]: tag (0x83), length 1, value TRUE
-        let expected4 = &[0x30, 0x07, 0x82, 0x02, 0x05, 0x00, 0x83, 0x01, 0xFF];
+        let expected4 = &[0x30, 0x07, 0xA2, 0x02, 0x05, 0x00, 0x83, 0x01, 0xFF];
         assert_eq!(encode(&value4).unwrap(), expected4);
         assert_eq!(decode::<TestSequence>(expected4).unwrap(), value4);
 
@@ -590,10 +592,10 @@ mod tests {
         // 'a' (u32, 255): implicitly tagged with [0] -> 80 02 00 FF
         // 'b' (TestChoice::Boolean(false)): explicitly tagged with [1] -> A1 03 (content)
         //   'Boolean' variant implicitly tagged with [1] -> 81 01 00
-        // 'c' (Any): implicitly tagged with [2] -> 82 02 05 00
+        // 'c' (Any): explicitly tagged with [2] -> A2 02 05 00
         // 'd' (bool, false): implicitly tagged with [3] -> 83 01 00
         let expected5 = &[
-            0x30, 0x10, 0x80, 0x02, 0x00, 0xFF, 0xA1, 0x03, 0x81, 0x01, 0x00, 0x82, 0x02, 0x05,
+            0x30, 0x10, 0x80, 0x02, 0x00, 0xFF, 0xA1, 0x03, 0x81, 0x01, 0x00, 0xA2, 0x02, 0x05,
             0x00, 0x83, 0x01, 0x00,
         ];
         assert_eq!(encode(&value5).unwrap(), expected5);
@@ -608,10 +610,10 @@ mod tests {
         };
         // Sequence tag (0x30), length 10
         // 'a' (u32, 1): implicitly tagged with [0] -> 80 01 01
-        // 'c' (Any): implicitly tagged with [2] -> 82 02 05 00
+        // 'c' (Any): explicitly tagged with [2] -> A2 02 05 00
         // 'd' (bool, true): implicitly tagged with [3] -> 83 01 FF
         let expected6 = &[
-            0x30, 0x0A, 0x80, 0x01, 0x01, 0x82, 0x02, 0x05, 0x00, 0x83, 0x01, 0xFF,
+            0x30, 0x0A, 0x80, 0x01, 0x01, 0xA2, 0x02, 0x05, 0x00, 0x83, 0x01, 0xFF,
         ];
         assert_eq!(encode(&value6).unwrap(), expected6);
         assert_eq!(decode::<TestSequence>(expected6).unwrap(), value6);
@@ -643,8 +645,8 @@ mod tests {
             b: Some(Any::new(any_payload.to_vec())),
         };
         // Sequence tag (0x30), length 4
-        // 'b' (Any, NULL): implicitly tagged with [1] -> 81 02 05 00
-        let expected3 = &[0x30, 0x04, 0x81, 0x02, 0x05, 0x00];
+        // 'b' (Any, NULL): explicitly tagged with [1] -> A1 02 05 00
+        let expected3 = &[0x30, 0x04, 0xA1, 0x02, 0x05, 0x00];
         assert_eq!(encode(&value3).unwrap(), expected3);
     }
 

--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -403,8 +403,10 @@ impl crate::Encoder<'_> for Encoder {
         }
         // If we have Any type or Choice type directly, don't encode the tag
         if tag != Tag::EOC {
-            let inner_constructed = (inner[0] & 0x20) != 0;
-            let ident = Identifier::from_tag(tag, inner_constructed);
+            // BER encoding of tagged ANY is always constructed because
+            // X.680 section 31.2.9 and 31.2.7 c) forbids implicit tagging on ANY (open type) and CHOICE,
+            // and X.690 section 8.14.3 requires that encoding of an explicitly tagged type shall be constructed.
+            let ident = Identifier::from_tag(tag, true);
             let ident_bytes = self.encode_identifier(ident);
             self.append_byte_or_bytes(ident_bytes);
             self.encode_length(ident, inner);

--- a/tests/prefixed_type.rs
+++ b/tests/prefixed_type.rs
@@ -160,3 +160,86 @@ fn test_issue_520_implicit_tag_on_tagged_choice_round_trip() {
     assert_eq!(tc2, tc2_de);
     assert_eq!(ttc2, ttc2_de);
 }
+
+#[test]
+fn test_tagged_any_round_trip() {
+    use rasn::prelude::*;
+
+    /*
+    TestModuleA DEFINITIONS ::= BEGIN
+        --tagged ANY
+        OpaqueInfo ::= [34] ANY
+
+        --actual content of OpaqueInfo
+        Info ::= [34] SEQUENCE {
+          version [1] OCTET STRING(SIZE(3)), -- implicitly tagged
+          data    [2] OCTET STRING OPTIONAL,
+        }
+    END
+    */
+
+    /// make it opaque by replacing `Info` with ANY.
+    #[doc = "tagged ANY"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(context, 34))]
+    pub struct OpaqueInfo(pub Any);
+
+    /// a SEQUENCE where we don't need to know the details.
+    #[doc = "actual content of OpaqueInfo"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(tag(context, 34))]
+    pub struct Info {
+        #[rasn(size("3"), tag(context, 1))]
+        pub version: OctetString,
+        #[rasn(tag(context, 2))]
+        pub data: Option<OctetString>,
+    }
+
+    let version = [0x02_u8, 0x03, 0x00];
+
+    // round-trip test. encoding of `Info` and `OpaqueInfo` should be identical.
+    let value = Info {
+        version: OctetString::from(version),
+        data: None,
+    };
+    let encoded = rasn::der::encode(&value).unwrap();
+    assert_eq!(
+        [0xbf_u8, 0x22, 0x05, 0x81, 0x03, 0x02, 0x03, 0x00],
+        encoded.as_slice()
+    );
+
+    let opaque = rasn::der::decode::<OpaqueInfo>(&encoded).unwrap();
+    let encoded2 = rasn::der::encode(&opaque).unwrap();
+
+    assert_eq!(encoded, encoded2);
+}
+
+#[test]
+fn issue_488_tagged_any_round_trip() {
+    use rasn::prelude::*;
+
+    // This test is mostly identical to https://github.com/librasn/rasn/issues/488. (round-trip test is added)
+    // All fields in actual IncomingRequest are replaced with Option<Any> since user is not interested in them.
+
+    #[derive(Debug, AsnType, Decode, Encode, PartialEq, Eq)]
+    struct IncomingRequest {
+        #[rasn(tag(Context, 0))]
+        handshake: Option<Any>,
+        #[rasn(tag(Context, 1))]
+        user_data: Option<Any>,
+    }
+
+    let incoming = vec![0x30_u8, 0x06, 0xA1, 0x04, 0x01, 0x02, 0x03, 0x04];
+    let decoded: IncomingRequest = rasn::Codec::Der.decode_from_binary(&incoming).unwrap();
+    let expected = IncomingRequest {
+        handshake: None,
+        user_data: Some(Any::new(vec![0x01, 0x02, 0x03, 0x04])),
+    };
+    assert_eq!(decoded, expected);
+
+    // round-trip test.
+    let encoded = rasn::der::encode(&decoded).unwrap();
+    assert_eq!(incoming, encoded);
+    // encoding of an explicitly tagged type shall be constructed (X.690 section 8.14.3)
+    assert_eq!(encoded[2] & 0x20, 0x20);
+}


### PR DESCRIPTION
rasn 0.28.14 fails round-trip test for BER encoding of tagged ANY type since it does not correctly encode the constructed bit in the tag.

This bug breaks the use case outlined in #488, which involves replacing data types that is not interested in with `ANY`.

This PR adds a round-trip tests to reproduce the issue and one-line fix for it. 
Existing tests in src/ber.rs are also fixed since they did not meet the ITU-T X.680 standard.
