### PR TITLE
fix(oid): reject OIDs whose second arc exceeds 39 under first arc 0/1

### DIFF
--- a/src/types/oid.rs
+++ b/src/types/oid.rs
@@ -5,7 +5,18 @@ pub(crate) const MAX_OID_FIRST_OCTET: u32 = 2;
 pub(crate) const MAX_OID_SECOND_OCTET: u32 = 39;
 
 const fn is_valid_oid(slice: &[u32]) -> bool {
-    !slice.is_empty() && slice[0] <= MAX_OID_FIRST_OCTET
+    if slice.is_empty() || slice[0] > MAX_OID_FIRST_OCTET {
+        return false;
+    }
+    // Per X.660/X.690, when the first arc is 0 or 1 the second arc must be
+    // <= 39: the encoding packs the first two arcs as `first * 40 + second`,
+    // so a larger second arc aliases onto a different OID on encode (e.g.
+    // `0.40` would encode and decode back as `1.0`). Reject such values at
+    // construction. The first arc `2` has no such upper bound on the second.
+    if slice[0] < MAX_OID_FIRST_OCTET && slice.len() >= 2 && slice[1] > MAX_OID_SECOND_OCTET {
+        return false;
+    }
+    true
 }
 
 /// A reference to a global unique identifier that identifies an concept, such
@@ -800,5 +811,17 @@ mod test {
             Oid::ISO_MEMBER_BODY,
             ObjectIdentifier::new(vec![1, 2]).unwrap()
         );
+    }
+
+    #[test]
+    fn second_arc_validation() {
+        // First arc 2 does not bound the second arc.
+        assert!(ObjectIdentifier::new(vec![2, 999]).is_some());
+        // First arc 0 or 1: second arc up to 39 is valid (boundary).
+        assert!(ObjectIdentifier::new(vec![0, 39]).is_some());
+        // First arc 0 or 1: second arc above 39 would alias onto another OID
+        // when encoded (e.g. 0.40 -> 1.0), so it must be rejected.
+        assert!(ObjectIdentifier::new(vec![0, 40]).is_none());
+        assert!(ObjectIdentifier::new(vec![1, 40]).is_none());
     }
 }

--- a/src/xer.rs
+++ b/src/xer.rs
@@ -288,9 +288,9 @@ mod tests {
     round_trip!(
         object_identifier,
         ObjectIdentifier,
-        ObjectIdentifier::from(Oid::const_new(&[1, 654, 2, 1])),
+        ObjectIdentifier::from(Oid::const_new(&[2, 654, 2, 1])),
         "OBJECT_IDENTIFIER",
-        "1.654.2.1"
+        "2.654.2.1"
     );
     round_trip!(
         sequence,
@@ -377,10 +377,10 @@ mod tests {
             inner: InnerTestA {
                 hidden: Some(false),
             },
-            oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1]))),
+            oid: Some(ObjectIdentifier::from(Oid::const_new(&[2, 8270, 4, 1]))),
         },
         "NestedTestA",
-        "<wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid>"
+        "<wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>2.8270.4.1</oid>"
     );
     round_trip!(
         sequence_with_defaults,
@@ -402,10 +402,10 @@ mod tests {
             wine: true,
             grappa: vec![0, 1, 2, 3].into(),
             inner: InnerTestA { hidden: None },
-            oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1])))
+            oid: Some(ObjectIdentifier::from(Oid::const_new(&[2, 8270, 4, 1])))
         },
         "NestedTestA",
-        "<wine><true /></wine><grappa>00010203</grappa><inner /><oid>1.8270.4.1</oid>"
+        "<wine><true /></wine><grappa>00010203</grappa><inner /><oid>2.8270.4.1</oid>"
     );
     round_trip!(
         extensible_sequence_without_extensions,
@@ -545,11 +545,11 @@ mod tests {
                 inner: InnerTestA {
                     hidden: Some(false),
                 },
-                oid: Some(ObjectIdentifier::from(Oid::const_new(&[1, 8270, 4, 1]))),
+                oid: Some(ObjectIdentifier::from(Oid::const_new(&[2, 8270, 4, 1]))),
             }
         },
         "SequenceWithChoice",
-        "<recursion><Leaf /></recursion><nested><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>1.8270.4.1</oid></nested>"
+        "<recursion><Leaf /></recursion><nested><wine><true /></wine><grappa>00010203</grappa><inner><hidden><false /></hidden></inner><oid>2.8270.4.1</oid></nested>"
     );
     round_trip!(
         sequence_with_element_after_sequence_of,


### PR DESCRIPTION
Fixes #565.

## Root cause
`is_valid_oid` (src/types/oid.rs) only checked `slice[0] <= MAX_OID_FIRST_OCTET` (first arc <= 2). It never enforced the X.660/X.690 rule that when the first arc is 0 or 1, the second arc must be <= 39. Because the BER/DER/OER/PER encoders pack the first two arcs as `first * 40 + second`, a larger second arc silently aliases onto a different OID: `ObjectIdentifier::new(vec![0, 40])` was accepted, encoded, and decoded back as `1.0` (and `0.999` -> `2.919`). That is an OID-confusion issue -- two distinct constructed values collapse to the same encoding.

`is_valid_oid` is the sole guard for `Oid::new` / `Oid::new_mut` / `ObjectIdentifier::new` / `Oid::const_new`, so the check belongs there.

## Fix
Reject the invalid second arc at construction, mirroring the existing first-arc guard (const-fn safe, no allocation). The constant `MAX_OID_SECOND_OCTET = 39` already existed and was used in the codec math; this reuses it in the validator. First arc 2 keeps its unbounded second arc; single-arc OIDs are still accepted; `new_unchecked` / `new_unchecked_mut` (documented as intentionally unchecked) are left untouched.

## Tests
Added `second_arc_validation` (matches the existing test style):
- `[2, 999]` accepted (first arc 2 unbounded)
- `[0, 39]` accepted (boundary)
- `[0, 40]` / `[1, 40]` rejected

Red-green verified: with the validator reverted the two rejection cases fail on `assert!(... .is_none())`; with the fix the suite is green (338 passed).

## Note on scope / alternative
Tightening construction revealed that four existing XER round-trip fixtures in src/xer.rs used OIDs that are themselves invalid under this rule (`1.654.2.1`, `1.8270.4.1`). XER stores arcs as literal dotted-decimal so they survived there, but they are not valid OIDs. I updated them to valid equivalents by switching the top-level arc to 2 (which has no second-arc bound), preserving the multi-byte-arc coverage.

There is a design choice here worth your call: reject at construction (this PR -- codec-agnostic, matches the existing first-arc guard) versus reject only at encode time in the integer-packed codecs (BER/DER/CER/OER/PER), which would leave XER/JER free to round-trip such arcs and would not require touching those fixtures. Happy to switch to the encode-time approach if you prefer that.

This change was written with AI assistance (Claude) and reviewed by me.